### PR TITLE
Minor fixes for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,8 +14,8 @@ RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requ
    && rm -rf /tmp/pip-tmp
 
 # [Optional] Uncomment this section to install additional OS packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
 # [Optional] Uncomment this line to install global node packages.
 # RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && cd frontend && npm install" 2>&1

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ coverage/
 site/
 .mypy_cache/
 
-tests/e2e/videos/
-tests/e2e/screenshots/
+frontend/tests/e2e/videos/
+frontend/tests/e2e/screenshots/
 
 # local env files
 .env

--- a/vetur.config.js
+++ b/vetur.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  projects: [
+    {
+      root: "./frontend", //root of subproject
+      package: "./package.json", // It is relative to root property.
+      tsconfig: "./tsconfig.json", // It is relative to root property.
+    },
+  ],
+};


### PR DESCRIPTION
For some reason now, running `npm run serve` inside of the devcontainer is fast (as well as hot-reloading)??? Not sure exactly what I did differently compared to when I spent time on this in the past, but that's good news.