### PR TITLE
Backend tests cleanup

### DIFF
--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -103,20 +103,21 @@ def read_observable(type: str, value: str, db: Session) -> Union[Observable, Non
     )
 
 
-def read_user_by_username(username: str, db: Session) -> User:
+def read_user_by_username(username: str, db: Session, err_on_not_found: bool = True) -> User:
     """Returns the User with the given username if it exists. Designed to be called only
     by the API since it raises an HTTPException."""
 
     try:
         return db.execute(select(User).where(User.username == username)).scalars().one()
     except NoResultFound:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"The user {username} does not exist",
-        )
+        if err_on_not_found:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"The user {username} does not exist",
+            )
 
 
-def read_by_value(value: str, db_table: DeclarativeMeta, db: Session):
+def read_by_value(value: str, db_table: DeclarativeMeta, db: Session, err_on_not_found: bool = True):
     """Returns an object from the given database table with the given value.
     Designed to be called only by the API since it raises an HTTPException."""
 
@@ -129,10 +130,11 @@ def read_by_value(value: str, db_table: DeclarativeMeta, db: Session):
     # MultipleResultsFound exception is not caught since each database table that has a
     # value column should be configured to have that column be unique.
     except NoResultFound:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"The {value} {db_table} does not exist",
-        )
+        if err_on_not_found:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"The {value} {db_table} does not exist",
+            )
 
 
 def read_by_values(values: List[str], db_table: DeclarativeMeta, db: Session):

--- a/backend/app/db/migrations/versions/c20685e782b5_initial.py
+++ b/backend/app/db/migrations/versions/c20685e782b5_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: 5a9ce387d950
+Revision ID: c20685e782b5
 Revises: 
-Create Date: 2021-10-07 14:00:52.370542
+Create Date: 2021-10-31 22:34:44.922635
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = '5a9ce387d950'
+revision = 'c20685e782b5'
 down_revision = None
 branch_labels = None
 depends_on = None

--- a/backend/app/tests/api/alert/test_create.py
+++ b/backend/app/tests/api/alert/test_create.py
@@ -75,10 +75,10 @@ def test_create_invalid_node_fields(client_valid_access_token, key, value):
         ("uuid"),
     ],
 )
-def test_create_duplicate_unique_fields(client_valid_access_token, key):
+def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an object
     create1_json = {"uuid": str(uuid.uuid4()), "queue": "test_queue", "type": "test_type"}
@@ -91,10 +91,10 @@ def test_create_duplicate_unique_fields(client_valid_access_token, key):
     assert create2.status_code == status.HTTP_409_CONFLICT
 
 
-def test_create_nonexistent_owner(client_valid_access_token):
+def test_create_nonexistent_owner(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -104,9 +104,9 @@ def test_create_nonexistent_owner(client_valid_access_token):
     assert "user" in create.text
 
 
-def test_create_nonexistent_queue(client_valid_access_token):
+def test_create_nonexistent_queue(client_valid_access_token, db):
     # Create an alert type
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/alert/", json={"queue": "test_queue", "type": "test_type"})
@@ -114,10 +114,10 @@ def test_create_nonexistent_queue(client_valid_access_token):
     assert "alert_queue" in create.text
 
 
-def test_create_nonexistent_tool(client_valid_access_token):
+def test_create_nonexistent_tool(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -127,10 +127,10 @@ def test_create_nonexistent_tool(client_valid_access_token):
     assert "alert_tool" in create.text
 
 
-def test_create_nonexistent_tool_instance(client_valid_access_token):
+def test_create_nonexistent_tool_instance(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -140,9 +140,9 @@ def test_create_nonexistent_tool_instance(client_valid_access_token):
     assert "alert_tool_instance" in create.text
 
 
-def test_create_nonexistent_type(client_valid_access_token):
+def test_create_nonexistent_type(client_valid_access_token, db):
     # Create an alert type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
+    helpers.create_alert_queue(value="test_queue", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/alert/", json={"queue": "test_queue", "type": "test_type"})
@@ -154,10 +154,10 @@ def test_create_nonexistent_type(client_valid_access_token):
     "key,value",
     NONEXISTENT_FIELDS,
 )
-def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
+def test_create_nonexistent_node_fields(client_valid_access_token, db, key, value):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     create = client_valid_access_token.post(
         "/api/alert/", json={key: value, "queue": "test_queue", "type": "test_type"}
@@ -187,12 +187,12 @@ def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
         ("uuid", str(uuid.uuid4())),
     ],
 )
-def test_create_valid_optional_fields(client_valid_access_token, key, value):
+def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
-    # Create the object
+    # Create the alert
     create = client_valid_access_token.post(
         "/api/alert/", json={key: value, "queue": "test_queue", "type": "test_type"}
     )
@@ -208,24 +208,13 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
         assert get.json()[key] == value
 
 
-def test_create_valid_owner(client_valid_access_token):
+def test_create_valid_owner(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
-    # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create a user
-    create_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "John Doe",
-        "email": "john@test.com",
-        "password": "abcd1234",
-        "roles": ["test_role"],
-        "username": "johndoe",
-    }
-    client_valid_access_token.post("/api/user/", json=create_json)
+    helpers.create_user(username="johndoe", db=db)
 
     # Use the user to create a new alert
     create = client_valid_access_token.post(
@@ -238,13 +227,13 @@ def test_create_valid_owner(client_valid_access_token):
     assert get.json()["owner"]["username"] == "johndoe"
 
 
-def test_create_valid_tool(client_valid_access_token):
+def test_create_valid_tool(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an alert tool
-    client_valid_access_token.post("/api/alert/tool/", json={"value": "test_tool"})
+    helpers.create_alert_tool(value="test_tool", db=db)
 
     # Use the tool to create a new alert
     create = client_valid_access_token.post(
@@ -257,13 +246,13 @@ def test_create_valid_tool(client_valid_access_token):
     assert get.json()["tool"]["value"] == "test_tool"
 
 
-def test_create_valid_tool_instance(client_valid_access_token):
+def test_create_valid_tool_instance(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
     # Create an alert tool instance
-    client_valid_access_token.post("/api/alert/tool/instance/", json={"value": "test_tool_instance"})
+    helpers.create_alert_tool_instance(value="test_tool_instance", db=db)
 
     # Use the tool instance to create a new alert
     create = client_valid_access_token.post(
@@ -276,12 +265,12 @@ def test_create_valid_tool_instance(client_valid_access_token):
     assert get.json()["tool_instance"]["value"] == "test_tool_instance"
 
 
-def test_create_valid_required_fields(client_valid_access_token):
+def test_create_valid_required_fields(client_valid_access_token, db):
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
-    # Create the object
+    # Create the alert
     create = client_valid_access_token.post("/api/alert/", json={"queue": "test_queue", "type": "test_type"})
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -296,17 +285,16 @@ def test_create_valid_required_fields(client_valid_access_token):
     "values",
     VALID_DIRECTIVES,
 )
-def test_create_valid_node_directives(client_valid_access_token, values):
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
+def test_create_valid_node_directives(client_valid_access_token, db, values):
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
-    # Create the node
+    # Create the alert
     create = client_valid_access_token.post(
         "/api/alert/", json={"directives": values, "queue": "test_queue", "type": "test_type"}
     )
@@ -355,19 +343,18 @@ def test_create_valid_node_tags(client_valid_access_token, db, values):
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_create_valid_node_threat_actor(client_valid_access_token, value):
-    # Create the threat actor. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
+def test_create_valid_node_threat_actor(client_valid_access_token, db, value):
+    # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
-    # Create the node
+    # Create the alert
     create = client_valid_access_token.post(
-        "/api/analysis/", json={"threat_actor": value, "queue": "test_queue", "type": "test_type"}
+        "/api/alert/", json={"threat_actor": value, "queue": "test_queue", "type": "test_type"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -383,22 +370,18 @@ def test_create_valid_node_threat_actor(client_valid_access_token, value):
     "values",
     VALID_THREATS,
 )
-def test_create_valid_node_threats(client_valid_access_token, values):
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
+def test_create_valid_node_threats(client_valid_access_token, db, values):
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, db=db, types=["test_type"])
 
     # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+    helpers.create_alert_queue(value="test_queue", db=db)
+    helpers.create_alert_type(value="test_type", db=db)
 
-    # Create the node
+    # Create the alert
     create = client_valid_access_token.post(
-        "/api/analysis/", json={"threats": values, "queue": "test_queue", "type": "test_type"}
+        "/api/alert/", json={"threats": values, "queue": "test_queue", "type": "test_type"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 

--- a/backend/app/tests/api/alert/test_update.py
+++ b/backend/app/tests/api/alert/test_update.py
@@ -76,16 +76,12 @@ def test_update_invalid_uuid(client_valid_access_token):
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_update_invalid_version(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_invalid_version(client_valid_access_token, db):
     # Create an alert
-    create = client_valid_access_token.post("/api/alert/", json={"queue": "test_queue", "type": "test_type"})
+    alert = helpers.create_alert(db=db)
 
     # Make sure you cannot update it using an invalid version
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"version": str(uuid.uuid4())})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -101,19 +97,14 @@ def test_update_invalid_version(client_valid_access_token):
         ("type", "abc"),
     ],
 )
-def test_update_nonexistent_fields(client_valid_access_token, key, value):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_nonexistent_fields(client_valid_access_token, db, key, value):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
+    alert = helpers.create_alert(db=db)
 
     # Make sure you cannot update it to use a nonexistent field value
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: value, "version": version})
+    update = client_valid_access_token.patch(
+        f"/api/alert/{alert.uuid}", json={key: value, "version": str(alert.version)}
+    )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -121,19 +112,14 @@ def test_update_nonexistent_fields(client_valid_access_token, key, value):
     "key,value",
     NONEXISTENT_FIELDS,
 )
-def test_update_nonexistent_node_fields(client_valid_access_token, key, value):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_nonexistent_node_fields(client_valid_access_token, db, key, value):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
+    alert = helpers.create_alert(db=db)
 
     # Make sure you cannot update it to use a nonexistent node field value
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: value, "version": version})
+    update = client_valid_access_token.patch(
+        f"/api/alert/{alert.uuid}", json={key: value, "version": str(alert.version)}
+    )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -148,396 +134,258 @@ def test_update_nonexistent_uuid(client_valid_access_token):
 
 
 def test_update_disposition(client_valid_access_token, db):
+    # Create an alert
+    alert = helpers.create_alert(db=db)
+    initial_version = alert.version
+
+    # Create a user
     helpers.create_user(username="analyst", db=db)
 
-    # Create an alert type
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
-    # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["disposition"] is None
-
     # Create a disposition
-    client_valid_access_token.post("/api/alert/disposition/", json={"rank": 1, "value": "test"})
+    helpers.create_alert_disposition(value="test", rank=1, db=db)
 
     # Update the disposition
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"disposition": "test", "version": version}
+        f"/api/alert/{alert.uuid}", json={"disposition": "test", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["disposition"]["value"] == "test"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_version)
 
 
-def test_update_event_uuid(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_event_uuid(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["event_uuid"] is None
-
-    # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create an event
-    event_uuid = str(uuid.uuid4())
-    initial_event_version = str(uuid.uuid4())
-    event_create = client_valid_access_token.post(
-        "/api/event/",
-        json={
-            "version": initial_event_version,
-            "name": "test",
-            "status": "OPEN",
-            "uuid": event_uuid,
-        },
-    )
+    event = helpers.create_event(name="test", db=db)
+    initial_event_version = event.version
 
     # Update the alert to add it to the event
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"event_uuid": event_uuid, "version": version}
+        f"/api/alert/{alert.uuid}", json={"event_uuid": str(event.uuid), "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["event_uuid"] == event_uuid
-    assert get.json()["version"] != version
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
+    assert get.json()["event_uuid"] == str(event.uuid)
+    assert get.json()["version"] != str(initial_alert_version)
 
-    # Read the event back. By adding the alert to the event, you should be able to see the alert UUID in the event's
+    # By adding the alert to the event, you should be able to see the alert UUID in the event's
     # alert_uuids list even though it was not explicitly added.
-    get_event = client_valid_access_token.get(event_create.headers["Content-Location"])
-    assert get_event.json()["alert_uuids"] == [get.json()["uuid"]]
+    assert event.alert_uuids == [alert.uuid]
 
     # Additionally, adding the alert to the event should trigger the event to have a new version.
-    assert get_event.json()["version"] != initial_event_version
+    assert event.version != initial_event_version
 
 
-def test_update_owner(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_owner(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["owner"] is None
-
-    # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create a user
-    create_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "John Doe",
-        "email": "john@test.com",
-        "password": "abcd1234",
-        "roles": ["test_role"],
-        "username": "johndoe",
-    }
-    client_valid_access_token.post("/api/user/", json=create_json)
+    helpers.create_user(username="johndoe", db=db)
 
     # Update the owner
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"owner": "johndoe", "version": version}
+        f"/api/alert/{alert.uuid}", json={"owner": "johndoe", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["owner"]["username"] == "johndoe"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
-def test_update_queue(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_queue(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["queue"]["value"] == "test_queue"
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create a new alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue2"})
+    helpers.create_alert_queue(value="test_queue2", db=db)
 
-    # Update the disposition
+    # Update the queue
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"queue": "test_queue2", "version": version}
+        f"/api/alert/{alert.uuid}", json={"queue": "test_queue2", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["queue"]["value"] == "test_queue2"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
-def test_update_tool(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_tool(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["tool"] is None
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create an alert tool
-    client_valid_access_token.post("/api/alert/tool/", json={"value": "test"})
+    helpers.create_alert_tool(value="test", db=db)
 
     # Update the tool
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"tool": "test", "version": version}
+        f"/api/alert/{alert.uuid}", json={"tool": "test", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["tool"]["value"] == "test"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
-def test_update_tool_instance(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_tool_instance(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["tool_instance"] is None
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create an alert tool instance
-    client_valid_access_token.post("/api/alert/tool/instance/", json={"value": "test"})
+    helpers.create_alert_tool_instance(value="test", db=db)
 
     # Update the tool instance
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"tool_instance": "test", "version": version}
+        f"/api/alert/{alert.uuid}", json={"tool_instance": "test", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["tool_instance"]["value"] == "test"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
-def test_update_type(client_valid_access_token):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_type(client_valid_access_token, db):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["type"]["value"] == "test_type"
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create a new alert type
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type2"})
+    helpers.create_alert_type(value="test_type2", db=db)
 
     # Update the disposition
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"type": "test_type2", "version": version}
+        f"/api/alert/{alert.uuid}", json={"type": "test_type2", "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()["type"]["value"] == "test_type2"
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_DIRECTIVES,
 )
-def test_update_valid_node_directives(client_valid_access_token, values):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_valid_node_directives(client_valid_access_token, db, values):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["directives"] == []
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
-
-    # Update the node
+    # Update the alert
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"directives": values, "version": version}
+        f"/api/alert/{alert.uuid}", json={"directives": values, "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert len(get.json()["directives"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_TAGS,
 )
-def test_update_valid_node_tags(client_valid_access_token, values):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_valid_node_tags(client_valid_access_token, db, values):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["tags"] == []
+    # Create the tags
+    for value in values:
+        helpers.create_node_tag(value=value, db=db)
 
-    # Create the tags. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/tag/", json={"value": value})
-
-    # Update the node
+    # Update the alert
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"tags": values, "version": version}
+        f"/api/alert/{alert.uuid}", json={"tags": values, "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert len(get.json()["tags"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
 @pytest.mark.parametrize(
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_update_valid_node_threat_actor(client_valid_access_token, value):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["threat_actor"] is None
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
     # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
-    # Update the node
+    # Update the alert
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"threat_actor": value, "version": version}
+        f"/api/alert/{alert.uuid}", json={"threat_actor": value, "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     if value:
         assert get.json()["threat_actor"]["value"] == value
     else:
         assert get.json()["threat_actor"] is None
 
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_THREATS,
 )
-def test_update_valid_node_threats(client_valid_access_token, values):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
-
+def test_update_valid_node_threats(client_valid_access_token, db, values):
     # Create an alert
-    version = str(uuid.uuid4())
-    create = client_valid_access_token.post(
-        "/api/alert/", json={"version": version, "queue": "test_queue", "type": "test_type"}
-    )
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["directives"] == []
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
-
-    # Update the node
+    # Update the alert
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"threats": values, "version": version}
+        f"/api/alert/{alert.uuid}", json={"threats": values, "version": str(alert.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert len(get.json()["threats"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)
 
 
 @pytest.mark.parametrize(
@@ -559,30 +407,26 @@ def test_update_valid_node_threats(client_valid_access_token, values):
         ("name", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
-    # Create an alert queue and type
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
+    # Create an alert
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
 
-    # Create the object
-    version = str(uuid.uuid4())
-    create_json = {"version": version, "queue": "test_queue", "type": "test_type"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/alert/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    # Set the initial value on the alert
+    setattr(alert, key, initial_value)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
     assert get.json()[key] == initial_value
 
     # Update it
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"version": version, key: updated_value}
+        f"/api/alert/{alert.uuid}", json={"version": str(alert.version), key: updated_value}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
 
     # If the test is for event_time, make sure that the retrieved value matches the proper UTC timestamp
     if key == "event_time":
@@ -590,4 +434,4 @@ def test_update(client_valid_access_token, key, initial_value, updated_value):
     else:
         assert get.json()[key] == updated_value
 
-    assert get.json()["version"] != version
+    assert get.json()["version"] != str(initial_alert_version)

--- a/backend/app/tests/api/alert/test_update.py
+++ b/backend/app/tests/api/alert/test_update.py
@@ -11,7 +11,7 @@ from tests.api.node import (
     VALID_THREAT_ACTOR,
     VALID_THREATS,
 )
-from tests.helpers import create_test_user
+from tests import helpers
 
 
 #
@@ -148,8 +148,7 @@ def test_update_nonexistent_uuid(client_valid_access_token):
 
 
 def test_update_disposition(client_valid_access_token, db):
-    # Create an analyst user
-    create_test_user(db=db, username="analyst", password="asdfasdf")
+    helpers.create_user(username="analyst", db=db)
 
     # Create an alert type
     client_valid_access_token.post("/api/alert/type/", json={"value": "test_type"})

--- a/backend/app/tests/api/alert_disposition/test_delete.py
+++ b/backend/app/tests/api/alert_disposition/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,14 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/alert/disposition/", json={"rank": 1, "value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.status_code == status.HTTP_200_OK
+    obj = helpers.create_alert_disposition(value="test", rank=1, db=db)
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/alert/disposition/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/disposition/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/alert_disposition/test_read.py
+++ b/backend/app/tests/api/alert_disposition/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/alert/disposition/", json={"rank": 1, "value": "test"})
-    client_valid_access_token.post("/api/alert/disposition/", json={"rank": 2, "value": "test2"})
+    helpers.create_alert_disposition(value="test", rank=1, db=db)
+    helpers.create_alert_disposition(value="test2", rank=2, db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/alert/disposition/")

--- a/backend/app/tests/api/alert_disposition/test_update.py
+++ b/backend/app/tests/api/alert_disposition/test_update.py
@@ -82,7 +82,4 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
     # Update it
     update = client_valid_access_token.patch(f"/api/alert/disposition/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(f"/api/alert/disposition/{obj.uuid}")
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/alert_disposition/test_update.py
+++ b/backend/app/tests/api/alert_disposition/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -39,16 +41,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"rank": 1, "value": "test"}
-    client_valid_access_token.post("/api/alert/disposition/", json=create1_json)
-
-    create2_json = {"rank": 2, "value": "test2"}
-    create2 = client_valid_access_token.post("/api/alert/disposition/", json=create2_json)
+    obj1 = helpers.create_alert_disposition(value="test", rank=1, db=db)
+    obj2 = helpers.create_alert_disposition(value="test2", rank=2, db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/alert/disposition/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -73,21 +72,17 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"rank": 1, "value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/alert/disposition/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_alert_disposition(value="test", rank=1, db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/alert/disposition/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/disposition/{obj.uuid}")
     assert get.json()[key] == updated_value

--- a/backend/app/tests/api/alert_queue/test_delete.py
+++ b/backend/app/tests/api/alert_queue/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,14 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/alert/queue/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.status_code == status.HTTP_200_OK
+    obj = helpers.create_alert_queue(value="test", db=db)
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/alert/queue/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/queue/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/alert_queue/test_read.py
+++ b/backend/app/tests/api/alert_queue/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test"})
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test2"})
+    helpers.create_alert_queue(value="test", db=db)
+    helpers.create_alert_queue(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/alert/queue/")

--- a/backend/app/tests/api/alert_queue/test_update.py
+++ b/backend/app/tests/api/alert_queue/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/alert/queue/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/alert/queue/", json=create2_json)
+    obj1 = helpers.create_alert_queue(value="test", db=db)
+    obj2 = helpers.create_alert_queue(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/alert/queue/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/alert/queue/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_alert_queue(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/alert/queue/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/alert_tool/test_delete.py
+++ b/backend/app/tests/api/alert_tool/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,14 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/alert/tool/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.status_code == status.HTTP_200_OK
+    obj = helpers.create_alert_tool(value="test", db=db)
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/alert/tool/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/tool/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/alert_tool/test_read.py
+++ b/backend/app/tests/api/alert_tool/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/alert/tool/", json={"value": "test"})
-    client_valid_access_token.post("/api/alert/tool/", json={"value": "test2"})
+    helpers.create_alert_tool(value="test", db=db)
+    helpers.create_alert_tool(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/alert/tool/")

--- a/backend/app/tests/api/alert_tool_instance/test_delete.py
+++ b/backend/app/tests/api/alert_tool_instance/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,14 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/alert/tool/instance/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.status_code == status.HTTP_200_OK
+    obj = helpers.create_alert_tool_instance(value="test", db=db)
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/alert/tool/instance/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/tool/instance/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/alert_tool_instance/test_read.py
+++ b/backend/app/tests/api/alert_tool_instance/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/alert/tool/instance/", json={"value": "test"})
-    client_valid_access_token.post("/api/alert/tool/instance/", json={"value": "test2"})
+    helpers.create_alert_tool_instance(value="test", db=db)
+    helpers.create_alert_tool_instance(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/alert/tool/instance/")

--- a/backend/app/tests/api/alert_tool_instance/test_update.py
+++ b/backend/app/tests/api/alert_tool_instance/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/alert/tool/instance/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/alert/tool/instance/", json=create2_json)
+    obj1 = helpers.create_alert_tool_instance(value="test", db=db)
+    obj2 = helpers.create_alert_tool_instance(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/alert/tool/instance/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/alert/tool/instance/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_alert_tool_instance(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/alert/tool/instance/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/alert_type/test_delete.py
+++ b/backend/app/tests/api/alert_type/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,14 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/alert/type/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.status_code == status.HTTP_200_OK
+    obj = helpers.create_alert_type(value="test", db=db)
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/alert/type/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/type/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/alert_type/test_read.py
+++ b/backend/app/tests/api/alert_type/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test"})
-    client_valid_access_token.post("/api/alert/type/", json={"value": "test2"})
+    helpers.create_alert_type(value="test", db=db)
+    helpers.create_alert_type(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/alert/type/")

--- a/backend/app/tests/api/alert_type/test_update.py
+++ b/backend/app/tests/api/alert_type/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/alert/type/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/alert/type/", json=create2_json)
+    obj1 = helpers.create_alert_type(value="test", db=db)
+    obj2 = helpers.create_alert_type(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/alert/type/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/alert/type/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_alert_type(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/alert/type/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/analysis/test_create.py
+++ b/backend/app/tests/api/analysis/test_create.py
@@ -12,7 +12,7 @@ from tests.api.node import (
     VALID_THREAT_ACTOR,
     VALID_THREATS,
 )
-from tests.helpers import create_alert
+from tests import helpers
 
 
 #
@@ -144,9 +144,9 @@ def test_create_valid_analysis_module_type(client_valid_access_token):
     assert get.json()["analysis_module_type"]["uuid"] == analysis_module_type_uuid
 
 
-def test_create_valid_parent_observable_uuid(client_valid_access_token):
+def test_create_valid_parent_observable_uuid(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
@@ -154,8 +154,8 @@ def test_create_valid_parent_observable_uuid(client_valid_access_token):
     # Create an observable instance
     observable_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "uuid": observable_uuid,
         "value": "test",

--- a/backend/app/tests/api/analysis/test_create.py
+++ b/backend/app/tests/api/analysis/test_create.py
@@ -128,69 +128,54 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
         assert get.json()[key] == value
 
 
-def test_create_valid_analysis_module_type(client_valid_access_token):
+def test_create_valid_analysis_module_type(client_valid_access_token, db):
     # Create an analysis module type
-    analysis_module_type_uuid = str(uuid.uuid4())
-    client_valid_access_token.post(
-        "/api/analysis/module_type/", json={"uuid": analysis_module_type_uuid, "value": "test", "version": "1.0.0"}
-    )
+    analysis_module_type = helpers.create_analysis_module_type(value="test", db=db)
 
     # Use the analysis module type to create a new analysis
-    create = client_valid_access_token.post("/api/analysis/", json={"analysis_module_type": analysis_module_type_uuid})
+    create = client_valid_access_token.post(
+        "/api/analysis/", json={"analysis_module_type": str(analysis_module_type.uuid)}
+    )
     assert create.status_code == status.HTTP_201_CREATED
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["analysis_module_type"]["uuid"] == analysis_module_type_uuid
+    assert get.json()["analysis_module_type"]["uuid"] == str(analysis_module_type.uuid)
 
 
 def test_create_valid_parent_observable_uuid(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
-
     # Create an observable instance
-    observable_uuid = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "uuid": observable_uuid,
-        "value": "test",
-    }
-    observable_create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-    assert observable_create.status_code == status.HTTP_201_CREATED
-
-    # Read the observable instance back to get its current version
-    get_observable = client_valid_access_token.get(observable_create.headers["Content-Location"])
-    initial_version = get_observable.json()["version"]
+    observable_instance = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = observable_instance.version
 
     # Use the observable instance as the parent for a new analysis
-    child_analysis_uuid = str(uuid.uuid4())
+    child_analysis_uuid = uuid.uuid4()
     create = client_valid_access_token.post(
         "/api/analysis/",
         json={
-            "parent_observable_uuid": observable_uuid,
-            "uuid": child_analysis_uuid,
+            "parent_observable_uuid": str(observable_instance.uuid),
+            "uuid": str(child_analysis_uuid),
         },
     )
     assert create.status_code == status.HTTP_201_CREATED
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["parent_observable_uuid"] == observable_uuid
+    assert get.json()["parent_observable_uuid"] == str(observable_instance.uuid)
 
-    # Read the observable instance back. By creating the analysis and setting its parent_observable_uuid,
-    # you should be able to read that observable instance back and see the analysis listed in its
+    # By creating the analysis and setting its parent_observable_uuid, you should be
+    # able to read that observable instance back and see the analysis listed in its
     # performed_analysis_uuids list even though it was not explictly added.
-    get_observable = client_valid_access_token.get(observable_create.headers["Content-Location"])
-    assert get_observable.json()["performed_analysis_uuids"] == [child_analysis_uuid]
+    assert observable_instance.performed_analysis_uuids == [child_analysis_uuid]
 
-    # Additionally, adding the child analysis to the observable instance should trigger the observable instance
-    # to get a new version.
-    assert get_observable.json()["version"] != initial_version
+    # Additionally, adding the child analysis to the observable instance should trigger
+    # the observable instance to get a new version.
+    assert observable_instance.version != initial_observable_instance_version
 
 
 def test_create_valid_required_fields(client_valid_access_token):
@@ -207,11 +192,10 @@ def test_create_valid_required_fields(client_valid_access_token):
     "values",
     VALID_DIRECTIVES,
 )
-def test_create_valid_node_directives(client_valid_access_token, values):
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
+def test_create_valid_node_directives(client_valid_access_token, db, values):
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/analysis/", json={"directives": values})
@@ -226,11 +210,10 @@ def test_create_valid_node_directives(client_valid_access_token, values):
     "values",
     VALID_TAGS,
 )
-def test_create_valid_node_tags(client_valid_access_token, values):
-    # Create the tags. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/tag/", json={"value": value})
+def test_create_valid_node_tags(client_valid_access_token, db, values):
+    # Create the tags
+    for value in values:
+        helpers.create_node_tag(value=value, db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/analysis/", json={"tags": values})
@@ -245,11 +228,10 @@ def test_create_valid_node_tags(client_valid_access_token, values):
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_create_valid_node_threat_actor(client_valid_access_token, value):
-    # Create the threat actor. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
+def test_create_valid_node_threat_actor(client_valid_access_token, db, value):
+    # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/analysis/", json={"threat_actor": value})
@@ -267,14 +249,10 @@ def test_create_valid_node_threat_actor(client_valid_access_token, value):
     "values",
     VALID_THREATS,
 )
-def test_create_valid_node_threats(client_valid_access_token, values):
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
+def test_create_valid_node_threats(client_valid_access_token, db, values):
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/analysis/", json={"threats": values})
@@ -282,4 +260,4 @@ def test_create_valid_node_threats(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["threats"]) == len(list(set(values)))
+    assert len(get.json()["threats"]) == len(set(values))

--- a/backend/app/tests/api/analysis_module_type/test_create.py
+++ b/backend/app/tests/api/analysis_module_type/test_create.py
@@ -4,6 +4,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -153,27 +155,33 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
 
 
 @pytest.mark.parametrize(
-    "api_endpoint,key,values",
+    "key,values",
     [
-        ("/api/observable/type/", "observable_types", []),
-        ("/api/observable/type/", "observable_types", ["test"]),
-        ("/api/observable/type/", "observable_types", ["test1", "test2"]),
-        ("/api/observable/type/", "observable_types", ["test", "test"]),
-        ("/api/node/directive/", "required_directives", []),
-        ("/api/node/directive/", "required_directives", ["test"]),
-        ("/api/node/directive/", "required_directives", ["test1", "test2"]),
-        ("/api/node/directive/", "required_directives", ["test", "test"]),
-        ("/api/node/tag/", "required_tags", []),
-        ("/api/node/tag/", "required_tags", ["test"]),
-        ("/api/node/tag/", "required_tags", ["test1", "test2"]),
-        ("/api/node/tag/", "required_tags", ["test", "test"]),
+        ("observable_types", []),
+        ("observable_types", ["test"]),
+        ("observable_types", ["test1", "test2"]),
+        ("observable_types", ["test", "test"]),
+        ("required_directives", []),
+        ("required_directives", ["test"]),
+        ("required_directives", ["test1", "test2"]),
+        ("required_directives", ["test", "test"]),
+        ("required_tags", []),
+        ("required_tags", ["test"]),
+        ("required_tags", ["test1", "test2"]),
+        ("required_tags", ["test", "test"]),
     ],
 )
-def test_create_valid_list_fields(client_valid_access_token, api_endpoint, key, values):
-    # Create the objects. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post(api_endpoint, json={"value": value})
+def test_create_valid_list_fields(client_valid_access_token, db, key, values):
+    # Create the objects
+    if key == "observable_types":
+        create_func = helpers.create_observable_type
+    elif key == "required_directives":
+        create_func = helpers.create_node_directive
+    else:
+        create_func = helpers.create_node_tag
+
+    for value in values:
+        create_func(value=value, db=db)
 
     # Create the analysis module type
     create = client_valid_access_token.post(

--- a/backend/app/tests/api/analysis_module_type/test_delete.py
+++ b/backend/app/tests/api/analysis_module_type/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,52 +31,42 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
-    # Create a node directive
-    directive_create = client_valid_access_token.post("/api/node/directive/", json={"value": "test_directive"})
-
-    # Create a node tag
-    tag_create = client_valid_access_token.post("/api/node/tag/", json={"value": "test_tag"})
-
-    # Create an observable type
-    type_create = client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
-
-    # Create the analysis module type
-    create = client_valid_access_token.post(
-        "/api/analysis/module_type/",
-        json={
-            "observable_types": ["test_type"],
-            "required_directives": ["test_directive"],
-            "required_tags": ["test_tag"],
-            "value": "initial",
-            "version": "1.0.0",
-        },
+def test_delete(client_valid_access_token, db):
+    # Create an analysis module type
+    analysis_module_type = helpers.create_analysis_module_type(
+        value="test",
+        observable_types=["test_type"],
+        required_directives=["test_directive"],
+        required_tags=["test_tag"],
+        db=db,
     )
-    assert create.status_code == status.HTTP_201_CREATED
+    directive_uuid = analysis_module_type.required_directives[0].uuid
+    observable_type_uuid = analysis_module_type.observable_types[0].uuid
+    tag_uuid = analysis_module_type.required_tags[0].uuid
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/analysis/module_type/{analysis_module_type.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/analysis/module_type/{analysis_module_type.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/analysis/module_type/{analysis_module_type.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND
 
     # Make sure the node directive is still there
-    get = client_valid_access_token.get(directive_create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/directive/{directive_uuid}")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["value"] == "test_directive"
 
     # Make sure the node tag is still there
-    get = client_valid_access_token.get(tag_create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/tag/{tag_uuid}")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["value"] == "test_tag"
 
     # Make sure the observable type is still there
-    get = client_valid_access_token.get(type_create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/observable/type/{observable_type_uuid}")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["value"] == "test_type"

--- a/backend/app/tests/api/analysis_module_type/test_read.py
+++ b/backend/app/tests/api/analysis_module_type/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/analysis/module_type/", json={"value": "test", "version": "1.0.0"})
-    client_valid_access_token.post("/api/analysis/module_type/", json={"value": "test2", "version": "1.0.0"})
+    helpers.create_analysis_module_type(value="test", db=db)
+    helpers.create_analysis_module_type(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/analysis/module_type/")

--- a/backend/app/tests/api/event/test_create.py
+++ b/backend/app/tests/api/event/test_create.py
@@ -11,6 +11,7 @@ from tests.api.node import (
     VALID_THREAT_ACTOR,
     VALID_THREATS,
 )
+from tests import helpers
 
 
 #
@@ -100,9 +101,9 @@ def test_create_invalid_node_fields(client_valid_access_token, key, value):
         ("uuid"),
     ],
 )
-def test_create_duplicate_unique_fields(client_valid_access_token, key):
+def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create1_json = {"uuid": str(uuid.uuid4()), "name": "test", "status": "OPEN"}
@@ -115,9 +116,9 @@ def test_create_duplicate_unique_fields(client_valid_access_token, key):
     assert create2.status_code == status.HTTP_409_CONFLICT
 
 
-def test_create_nonexistent_owner(client_valid_access_token):
+def test_create_nonexistent_owner(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/event/", json={"owner": "johndoe", "name": "test", "status": "OPEN"})
@@ -125,9 +126,9 @@ def test_create_nonexistent_owner(client_valid_access_token):
     assert "user" in create.text
 
 
-def test_create_nonexistent_prevention_tools(client_valid_access_token):
+def test_create_nonexistent_prevention_tools(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -137,9 +138,9 @@ def test_create_nonexistent_prevention_tools(client_valid_access_token):
     assert "event_prevention_tool" in create.text
 
 
-def test_create_nonexistent_remediations(client_valid_access_token):
+def test_create_nonexistent_remediations(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -149,9 +150,9 @@ def test_create_nonexistent_remediations(client_valid_access_token):
     assert "event_remediation" in create.text
 
 
-def test_create_nonexistent_risk_level(client_valid_access_token):
+def test_create_nonexistent_risk_level(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
@@ -161,9 +162,9 @@ def test_create_nonexistent_risk_level(client_valid_access_token):
     assert "event_risk_level" in create.text
 
 
-def test_create_nonexistent_source(client_valid_access_token):
+def test_create_nonexistent_source(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/event/", json={"source": "test", "name": "test", "status": "OPEN"})
@@ -178,9 +179,9 @@ def test_create_nonexistent_status(client_valid_access_token):
     assert "event_status" in create.text
 
 
-def test_create_nonexistent_type(client_valid_access_token):
+def test_create_nonexistent_type(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/event/", json={"type": "test", "name": "test", "status": "OPEN"})
@@ -188,9 +189,9 @@ def test_create_nonexistent_type(client_valid_access_token):
     assert "event_type" in create.text
 
 
-def test_create_nonexistent_vectors(client_valid_access_token):
+def test_create_nonexistent_vectors(client_valid_access_token, db):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post("/api/event/", json={"vectors": ["test"], "name": "test", "status": "OPEN"})
@@ -202,9 +203,9 @@ def test_create_nonexistent_vectors(client_valid_access_token):
     "key,value",
     NONEXISTENT_FIELDS,
 )
-def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
+def test_create_nonexistent_node_fields(client_valid_access_token, db, key, value):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     create = client_valid_access_token.post("/api/event/", json={key: value, "name": "test", "status": "OPEN"})
     assert create.status_code == status.HTTP_404_NOT_FOUND
@@ -257,9 +258,9 @@ def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
         ("uuid", str(uuid.uuid4())),
     ],
 )
-def test_create_valid_optional_fields(client_valid_access_token, key, value):
+def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the object
     create = client_valid_access_token.post("/api/event/", json={key: value, "name": "test", "status": "OPEN"})
@@ -275,26 +276,12 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
         assert get.json()[key] == value
 
 
-def test_create_valid_owner(client_valid_access_token):
-    # Create an alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-
-    # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
-
+def test_create_valid_owner(client_valid_access_token, db):
     # Create a user
-    create_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "John Doe",
-        "email": "john@test.com",
-        "password": "abcd1234",
-        "roles": ["test_role"],
-        "username": "johndoe",
-    }
-    client_valid_access_token.post("/api/user/", json=create_json)
+    helpers.create_user(username="johndoe", db=db)
 
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Use the user to create a new event
     create = client_valid_access_token.post("/api/event/", json={"owner": "johndoe", "name": "test", "status": "OPEN"})
@@ -305,10 +292,10 @@ def test_create_valid_owner(client_valid_access_token):
     assert get.json()["owner"]["username"] == "johndoe"
 
 
-def test_create_valid_prevention_tools(client_valid_access_token):
+def test_create_valid_prevention_tools(client_valid_access_token, db):
     # Create an event status and prevention tool
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/prevention_tool/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_prevention_tool(value="test", db=db)
 
     # Use the prevention tool to create a new event
     create = client_valid_access_token.post(
@@ -321,10 +308,10 @@ def test_create_valid_prevention_tools(client_valid_access_token):
     assert get.json()["prevention_tools"][0]["value"] == "test"
 
 
-def test_create_valid_remediations(client_valid_access_token):
+def test_create_valid_remediations(client_valid_access_token, db):
     # Create an event status and remediation
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/remediation/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_remediation(value="test", db=db)
 
     # Use the remediation to create a new event
     create = client_valid_access_token.post(
@@ -337,10 +324,10 @@ def test_create_valid_remediations(client_valid_access_token):
     assert get.json()["remediations"][0]["value"] == "test"
 
 
-def test_create_valid_risk_level(client_valid_access_token):
+def test_create_valid_risk_level(client_valid_access_token, db):
     # Create an event status and risk level
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/risk_level/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_risk_level(value="test", db=db)
 
     # Use the risk level to create a new event
     create = client_valid_access_token.post(
@@ -353,10 +340,10 @@ def test_create_valid_risk_level(client_valid_access_token):
     assert get.json()["risk_level"]["value"] == "test"
 
 
-def test_create_valid_source(client_valid_access_token):
+def test_create_valid_source(client_valid_access_token, db):
     # Create an event status and source
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/source/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_source(value="test", db=db)
 
     # Use the source to create a new event
     create = client_valid_access_token.post("/api/event/", json={"source": "test", "name": "test", "status": "OPEN"})
@@ -367,10 +354,10 @@ def test_create_valid_source(client_valid_access_token):
     assert get.json()["source"]["value"] == "test"
 
 
-def test_create_valid_type(client_valid_access_token):
+def test_create_valid_type(client_valid_access_token, db):
     # Create an event status and type
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/type/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_type(value="test", db=db)
 
     # Use the type to create a new event
     create = client_valid_access_token.post("/api/event/", json={"type": "test", "name": "test", "status": "OPEN"})
@@ -381,10 +368,10 @@ def test_create_valid_type(client_valid_access_token):
     assert get.json()["type"]["value"] == "test"
 
 
-def test_create_valid_vectors(client_valid_access_token):
+def test_create_valid_vectors(client_valid_access_token, db):
     # Create an event status and vector
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
-    client_valid_access_token.post("/api/event/vector/", json={"value": "test"})
+    helpers.create_event_status(value="OPEN", db=db)
+    helpers.create_event_vector(value="test", db=db)
 
     # Use the vector to create a new event
     create = client_valid_access_token.post("/api/event/", json={"vectors": ["test"], "name": "test", "status": "OPEN"})
@@ -395,9 +382,9 @@ def test_create_valid_vectors(client_valid_access_token):
     assert get.json()["vectors"][0]["value"] == "test"
 
 
-def test_create_valid_required_fields(client_valid_access_token):
-    # Create an event status and remediation
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+def test_create_valid_required_fields(client_valid_access_token, db):
+    # Create an event status
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the object
     create = client_valid_access_token.post("/api/event/", json={"name": "test", "status": "OPEN"})
@@ -414,14 +401,13 @@ def test_create_valid_required_fields(client_valid_access_token):
     "values",
     VALID_DIRECTIVES,
 )
-def test_create_valid_node_directives(client_valid_access_token, values):
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
+def test_create_valid_node_directives(client_valid_access_token, db, values):
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the node
     create = client_valid_access_token.post(
@@ -431,21 +417,20 @@ def test_create_valid_node_directives(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["directives"]) == len(list(set(values)))
+    assert len(get.json()["directives"]) == len(set(values))
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_TAGS,
 )
-def test_create_valid_node_tags(client_valid_access_token, values):
-    # Create the tags. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/tag/", json={"value": value})
+def test_create_valid_node_tags(client_valid_access_token, db, values):
+    # Create the tags
+    for value in values:
+        helpers.create_node_tag(value=value, db=db)
 
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/event/", json={"tags": values, "name": "test", "status": "OPEN"})
@@ -453,21 +438,20 @@ def test_create_valid_node_tags(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["tags"]) == len(list(set(values)))
+    assert len(get.json()["tags"]) == len(set(values))
 
 
 @pytest.mark.parametrize(
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_create_valid_node_threat_actor(client_valid_access_token, value):
-    # Create the threat actor. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
+def test_create_valid_node_threat_actor(client_valid_access_token, db, value):
+    # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the node
     create = client_valid_access_token.post(
@@ -487,17 +471,13 @@ def test_create_valid_node_threat_actor(client_valid_access_token, value):
     "values",
     VALID_THREATS,
 )
-def test_create_valid_node_threats(client_valid_access_token, values):
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
+def test_create_valid_node_threats(client_valid_access_token, db, values):
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Create an event status
-    client_valid_access_token.post("/api/event/status/", json={"value": "OPEN"})
+    helpers.create_event_status(value="OPEN", db=db)
 
     # Create the node
     create = client_valid_access_token.post("/api/event/", json={"threats": values, "name": "test", "status": "OPEN"})
@@ -505,4 +485,4 @@ def test_create_valid_node_threats(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["threats"]) == len(list(set(values)))
+    assert len(get.json()["threats"]) == len(set(values))

--- a/backend/app/tests/api/event_prevention_tool/test_delete.py
+++ b/backend/app/tests/api/event_prevention_tool/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/prevention_tool/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_prevention_tool(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/prevention_tool/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/prevention_tool/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/prevention_tool/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_prevention_tool/test_read.py
+++ b/backend/app/tests/api/event_prevention_tool/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/prevention_tool/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/prevention_tool/", json={"value": "test2"})
+    helpers.create_event_prevention_tool(value="test", db=db)
+    helpers.create_event_prevention_tool(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/prevention_tool/")

--- a/backend/app/tests/api/event_prevention_tool/test_update.py
+++ b/backend/app/tests/api/event_prevention_tool/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/prevention_tool/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/prevention_tool/", json=create2_json)
+    obj1 = helpers.create_event_prevention_tool(value="test", db=db)
+    obj2 = helpers.create_event_prevention_tool(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/prevention_tool/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/prevention_tool/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_prevention_tool(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/prevention_tool/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_remediation/test_delete.py
+++ b/backend/app/tests/api/event_remediation/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/remediation/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_remediation(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/remediation/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/remediation/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/remediation/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_remediation/test_read.py
+++ b/backend/app/tests/api/event_remediation/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/remediation/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/remediation/", json={"value": "test2"})
+    helpers.create_event_remediation(value="test", db=db)
+    helpers.create_event_remediation(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/remediation/")

--- a/backend/app/tests/api/event_remediation/test_update.py
+++ b/backend/app/tests/api/event_remediation/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/remediation/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/remediation/", json=create2_json)
+    obj1 = helpers.create_event_remediation(value="test", db=db)
+    obj2 = helpers.create_event_remediation(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/remediation/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/remediation/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_remediation(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/remediation/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_risk_level/test_delete.py
+++ b/backend/app/tests/api/event_risk_level/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/risk_level/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_risk_level(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/risk_level/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/risk_level/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/risk_level/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_risk_level/test_read.py
+++ b/backend/app/tests/api/event_risk_level/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/risk_level/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/risk_level/", json={"value": "test2"})
+    helpers.create_event_risk_level(value="test", db=db)
+    helpers.create_event_risk_level(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/risk_level/")

--- a/backend/app/tests/api/event_risk_level/test_update.py
+++ b/backend/app/tests/api/event_risk_level/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/risk_level/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/risk_level/", json=create2_json)
+    obj1 = helpers.create_event_risk_level(value="test", db=db)
+    obj2 = helpers.create_event_risk_level(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/risk_level/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/risk_level/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_risk_level(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/risk_level/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_source/test_delete.py
+++ b/backend/app/tests/api/event_source/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/source/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_source(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/source/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/source/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/source/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_source/test_read.py
+++ b/backend/app/tests/api/event_source/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/source/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/source/", json={"value": "test2"})
+    helpers.create_event_source(value="test", db=db)
+    helpers.create_event_source(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/source/")

--- a/backend/app/tests/api/event_source/test_update.py
+++ b/backend/app/tests/api/event_source/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/source/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/source/", json=create2_json)
+    obj1 = helpers.create_event_source(value="test", db=db)
+    obj2 = helpers.create_event_source(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/source/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/source/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_source(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/source/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_status/test_delete.py
+++ b/backend/app/tests/api/event_status/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/status/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_status(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/status/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/status/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/status/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_status/test_read.py
+++ b/backend/app/tests/api/event_status/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/status/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/status/", json={"value": "test2"})
+    helpers.create_event_status(value="test", db=db)
+    helpers.create_event_status(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/status/")

--- a/backend/app/tests/api/event_status/test_update.py
+++ b/backend/app/tests/api/event_status/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/status/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/status/", json=create2_json)
+    obj1 = helpers.create_event_status(value="test", db=db)
+    obj2 = helpers.create_event_status(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/status/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/status/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_status(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/status/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_type/test_delete.py
+++ b/backend/app/tests/api/event_type/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/type/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_type(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/type/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/type/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/type/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_type/test_read.py
+++ b/backend/app/tests/api/event_type/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/type/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/type/", json={"value": "test2"})
+    helpers.create_event_type(value="test", db=db)
+    helpers.create_event_type(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/type/")

--- a/backend/app/tests/api/event_type/test_update.py
+++ b/backend/app/tests/api/event_type/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/type/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/type/", json=create2_json)
+    obj1 = helpers.create_event_type(value="test", db=db)
+    obj2 = helpers.create_event_type(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/type/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/type/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_type(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/type/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/event_vector/test_delete.py
+++ b/backend/app/tests/api/event_vector/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/event/vector/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_vector(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/vector/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/event/vector/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/event/vector/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_vector/test_read.py
+++ b/backend/app/tests/api/event_vector/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/event/vector/", json={"value": "test"})
-    client_valid_access_token.post("/api/event/vector/", json={"value": "test2"})
+    helpers.create_event_vector(value="test", db=db)
+    helpers.create_event_vector(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/event/vector/")

--- a/backend/app/tests/api/event_vector/test_update.py
+++ b/backend/app/tests/api/event_vector/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/event/vector/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/event/vector/", json=create2_json)
+    obj1 = helpers.create_event_vector(value="test", db=db)
+    obj2 = helpers.create_event_vector(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/event/vector/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/event/vector/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_event_vector(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/event/vector/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_directive/test_delete.py
+++ b/backend/app/tests/api/node_directive/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/node/directive/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_directive(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/directive/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/node/directive/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/directive/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_directive/test_read.py
+++ b/backend/app/tests/api/node_directive/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/directive/", json={"value": "test"})
-    client_valid_access_token.post("/api/node/directive/", json={"value": "test2"})
+    helpers.create_node_directive(value="test", db=db)
+    helpers.create_node_directive(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/directive/")

--- a/backend/app/tests/api/node_directive/test_update.py
+++ b/backend/app/tests/api/node_directive/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/node/directive/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/node/directive/", json=create2_json)
+    obj1 = helpers.create_node_directive(value="test", db=db)
+    obj2 = helpers.create_node_directive(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/node/directive/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/node/directive/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_directive(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/directive/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_history_action/test_delete.py
+++ b/backend/app/tests/api/node_history_action/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/node/history/action/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_history_action(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/history/action/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/node/history/action/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/history/action/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_history_action/test_read.py
+++ b/backend/app/tests/api/node_history_action/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/history/action/", json={"value": "test"})
-    client_valid_access_token.post("/api/node/history/action/", json={"value": "test2"})
+    helpers.create_node_history_action(value="test", db=db)
+    helpers.create_node_history_action(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/history/action/")

--- a/backend/app/tests/api/node_history_action/test_update.py
+++ b/backend/app/tests/api/node_history_action/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/node/history/action/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/node/history/action/", json=create2_json)
+    obj1 = helpers.create_node_history_action(value="test", db=db)
+    obj2 = helpers.create_node_history_action(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/node/history/action/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/node/history/action/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_history_action(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/history/action/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_tag/test_delete.py
+++ b/backend/app/tests/api/node_tag/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/node/tag/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_tag(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/tag/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/node/tag/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/tag/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_tag/test_read.py
+++ b/backend/app/tests/api/node_tag/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/tag/", json={"value": "test"})
-    client_valid_access_token.post("/api/node/tag/", json={"value": "test2"})
+    helpers.create_node_tag(value="test", db=db)
+    helpers.create_node_tag(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/tag/")

--- a/backend/app/tests/api/node_tag/test_update.py
+++ b/backend/app/tests/api/node_tag/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/node/tag/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/node/tag/", json=create2_json)
+    obj1 = helpers.create_node_tag(value="test", db=db)
+    obj2 = helpers.create_node_tag(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/node/tag/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/node/tag/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_tag(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/tag/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_threat/test_read.py
+++ b/backend/app/tests/api/node_threat/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,13 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
-    # Create a node threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": "test"})
-    client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": "test2"})
+    helpers.create_node_threat(value="test", types=["test_type"], db=db)
+    helpers.create_node_threat(value="test2", types=["test_type"], db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/threat/")

--- a/backend/app/tests/api/node_threat_actor/test_delete.py
+++ b/backend/app/tests/api/node_threat_actor/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/node/threat_actor/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_threat_actor(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/threat_actor/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/node/threat_actor/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/threat_actor/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_threat_actor/test_read.py
+++ b/backend/app/tests/api/node_threat_actor/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/threat_actor/", json={"value": "test"})
-    client_valid_access_token.post("/api/node/threat_actor/", json={"value": "test2"})
+    helpers.create_node_threat_actor(value="test", db=db)
+    helpers.create_node_threat_actor(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/threat_actor/")

--- a/backend/app/tests/api/node_threat_actor/test_update.py
+++ b/backend/app/tests/api/node_threat_actor/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/node/threat_actor/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/node/threat_actor/", json=create2_json)
+    obj1 = helpers.create_node_threat_actor(value="test", db=db)
+    obj2 = helpers.create_node_threat_actor(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/node/threat_actor/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/node/threat_actor/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_threat_actor(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/threat_actor/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_threat_type/test_delete.py
+++ b/backend/app/tests/api/node_threat_type/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/node/threat/type/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_threat_type(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/threat/type/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/node/threat/type/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/node/threat/type/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_threat_type/test_read.py
+++ b/backend/app/tests/api/node_threat_type/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test"})
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test2"})
+    helpers.create_node_threat_type(value="test", db=db)
+    helpers.create_node_threat_type(value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/node/threat/type/")

--- a/backend/app/tests/api/node_threat_type/test_update.py
+++ b/backend/app/tests/api/node_threat_type/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/node/threat/type/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/node/threat/type/", json=create2_json)
+    obj1 = helpers.create_node_threat_type(value="test", db=db)
+    obj2 = helpers.create_node_threat_type(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/node/threat/type/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/node/threat/type/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_node_threat_type(value="test", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/threat/type/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/observable/test_create.py
+++ b/backend/app/tests/api/observable/test_create.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -44,9 +46,9 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
         ("uuid"),
     ],
 )
-def test_create_duplicate_unique_fields(client_valid_access_token, key):
+def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an object
     create1_json = {"type": "test_type", "uuid": str(uuid.uuid4()), "value": "test"}
@@ -59,9 +61,9 @@ def test_create_duplicate_unique_fields(client_valid_access_token, key):
     assert create2.status_code == status.HTTP_409_CONFLICT
 
 
-def test_create_duplicate_type_value(client_valid_access_token):
+def test_create_duplicate_type_value(client_valid_access_token, db):
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an object
     client_valid_access_token.post("/api/observable/", json={"type": "test_type", "value": "test"})
@@ -109,9 +111,9 @@ def test_create_nonexistent_type(client_valid_access_token):
         ("uuid", str(uuid.uuid4())),
     ],
 )
-def test_create_valid_optional_fields(client_valid_access_token, key, value):
+def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create the object
     create = client_valid_access_token.post("/api/observable/", json={key: value, "type": "test_type", "value": "test"})
@@ -127,9 +129,9 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
         assert get.json()[key] == value
 
 
-def test_create_valid_required_fields(client_valid_access_token):
+def test_create_valid_required_fields(client_valid_access_token, db):
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create the object
     create = client_valid_access_token.post("/api/observable/", json={"type": "test_type", "value": "test"})

--- a/backend/app/tests/api/observable/test_read.py
+++ b/backend/app/tests/api/observable/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,13 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
-    # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
-
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/observable/", json={"type": "test_type", "value": "test"})
-    client_valid_access_token.post("/api/observable/", json={"type": "test_type", "value": "test2"})
+    helpers.create_observable(type="test_type", value="test", db=db)
+    helpers.create_observable(type="test_type", value="test2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/observable/")

--- a/backend/app/tests/api/observable_instance/test_create.py
+++ b/backend/app/tests/api/observable_instance/test_create.py
@@ -93,7 +93,7 @@ def test_create_duplicate_uuid(client_valid_access_token, db):
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an object
     create_json = {
@@ -115,7 +115,7 @@ def test_create_nonexistent_alert(client_valid_access_token, db):
     analysis = helpers.create_analysis(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent alert
     nonexistent_alert_uuid = str(uuid.uuid4())
@@ -135,7 +135,7 @@ def test_create_nonexistent_analysis(client_valid_access_token, db):
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent analysis
     nonexistent_analysis_uuid = str(uuid.uuid4())
@@ -155,7 +155,7 @@ def test_create_nonexistent_performed_analysis(client_valid_access_token, db):
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent performed analysis
     nonexistent_analysis_uuid = str(uuid.uuid4())
@@ -176,7 +176,7 @@ def test_create_nonexistent_redirection(client_valid_access_token, db):
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent redirection target
     nonexistent_redirection_uuid = str(uuid.uuid4())
@@ -197,7 +197,7 @@ def test_create_nonexistent_type(client_valid_access_token, db):
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent type
     create_json = {
@@ -220,7 +220,7 @@ def test_create_nonexistent_node_fields(client_valid_access_token, db, key, valu
     alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Ensure you cannot create an observable instance with a nonexistent type
     create_json = {

--- a/backend/app/tests/api/observable_instance/test_create.py
+++ b/backend/app/tests/api/observable_instance/test_create.py
@@ -11,7 +11,7 @@ from tests.api.node import (
     VALID_THREAT_ACTOR,
     VALID_THREATS,
 )
-from tests.helpers import create_alert
+from tests import helpers
 
 
 #
@@ -88,9 +88,9 @@ def test_create_invalid_node_fields(client_valid_access_token, key, value):
     assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_create_duplicate_uuid(client_valid_access_token):
+def test_create_duplicate_uuid(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
@@ -98,8 +98,8 @@ def test_create_duplicate_uuid(client_valid_access_token):
     # Create an object
     create_json = {
         "uuid": str(uuid.uuid4()),
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
     }
@@ -110,99 +110,99 @@ def test_create_duplicate_uuid(client_valid_access_token):
     assert create2.status_code == status.HTTP_409_CONFLICT
 
 
-def test_create_nonexistent_alert(client_valid_access_token):
-    # Create an alert
-    _, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
-    alert_uuid = str(uuid.uuid4())
+def test_create_nonexistent_alert(client_valid_access_token, db):
+    # Create an analysis
+    analysis = helpers.create_analysis(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent alert
+    nonexistent_alert_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": nonexistent_alert_uuid,
+        "parent_analysis_uuid": str(analysis.uuid),
         "type": "test_type",
         "value": "test",
     }
     create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
     assert create.status_code == status.HTTP_404_NOT_FOUND
-    assert alert_uuid in create.text
+    assert nonexistent_alert_uuid in create.text
 
 
-def test_create_nonexistent_analysis(client_valid_access_token):
+def test_create_nonexistent_analysis(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, _ = create_alert(client_valid_access_token=client_valid_access_token)
-    analysis_uuid = str(uuid.uuid4())
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent analysis
+    nonexistent_analysis_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": nonexistent_analysis_uuid,
         "type": "test_type",
         "value": "test",
     }
     create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
     assert create.status_code == status.HTTP_404_NOT_FOUND
-    assert analysis_uuid in create.text
+    assert nonexistent_analysis_uuid in create.text
 
 
-def test_create_nonexistent_performed_analysis(client_valid_access_token):
+def test_create_nonexistent_performed_analysis(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent performed analysis
-    performed_analysis_uuid = str(uuid.uuid4())
+    nonexistent_analysis_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
-        "performed_analysis_uuids": [performed_analysis_uuid],
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
+        "performed_analysis_uuids": [nonexistent_analysis_uuid],
         "type": "test_type",
         "value": "test",
     }
     create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
     assert create.status_code == status.HTTP_404_NOT_FOUND
-    assert performed_analysis_uuid in create.text
+    assert nonexistent_analysis_uuid in create.text
 
 
-def test_create_nonexistent_redirection(client_valid_access_token):
+def test_create_nonexistent_redirection(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent redirection target
-    redirection_uuid = str(uuid.uuid4())
+    nonexistent_redirection_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
-        "redirection_uuid": redirection_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
+        "redirection_uuid": nonexistent_redirection_uuid,
         "type": "test_type",
         "value": "test",
     }
     create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
     assert create.status_code == status.HTTP_404_NOT_FOUND
-    assert redirection_uuid in create.text
+    assert nonexistent_redirection_uuid in create.text
 
 
-def test_create_nonexistent_type(client_valid_access_token):
+def test_create_nonexistent_type(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent type
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "abc",
         "value": "test",
     }
@@ -215,17 +215,17 @@ def test_create_nonexistent_type(client_valid_access_token):
     "key,value",
     NONEXISTENT_FIELDS,
 )
-def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
+def test_create_nonexistent_node_fields(client_valid_access_token, db, key, value):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
     client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
 
     # Ensure you cannot create an observable instance with a nonexistent type
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
     }
@@ -239,22 +239,14 @@ def test_create_nonexistent_node_fields(client_valid_access_token, key, value):
 #
 
 
-def test_create_bulk(client_valid_access_token):
+def test_create_bulk(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
-
-    # Read the alert back to get its current version
-    # TODO: Fix this hardcoded URL
-    get_alert = client_valid_access_token.get(f"http://testserver/api/alert/{alert_uuid}")
-    initial_alert_version = get_alert.json()["version"]
-
-    # Read the analysis back to get its current version
-    # TODO: Fix this hardcoded URL
-    get_analysis = client_valid_access_token.get(f"http://testserver/api/analysis/{analysis_uuid}")
-    initial_analysis_version = get_analysis.json()["version"]
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
+    initial_analysis_version = alert.analysis.version
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create some observable instances
     observable_instances = []
@@ -262,8 +254,8 @@ def test_create_bulk(client_valid_access_token):
         observable_uuid = str(uuid.uuid4())
         observable_instances.append(
             {
-                "alert_uuid": alert_uuid,
-                "parent_analysis_uuid": analysis_uuid,
+                "alert_uuid": str(alert.uuid),
+                "parent_analysis_uuid": str(alert.analysis_uuid),
                 "type": "test_type",
                 "uuid": observable_uuid,
                 "value": f"test{i}",
@@ -272,16 +264,12 @@ def test_create_bulk(client_valid_access_token):
     create = client_valid_access_token.post("/api/observable/instance/", json=observable_instances)
     assert create.status_code == status.HTTP_201_CREATED
 
-    # Read the parent analysis back. There should be 3 discovered observable instance UUIDs.
-    # TODO: Fix this hardcoded URL
-    get_analysis = client_valid_access_token.get(f"http://testserver/api/analysis/{analysis_uuid}")
-    assert len(get_analysis.json()["discovered_observable_uuids"]) == 3
+    # The analysis should have 3 discovered observable instance UUIDs.
+    assert len(alert.analysis.discovered_observable_uuids) == 3
 
     # Additionally, creating an observable instance should trigger the alert and analysis to get a new version.
-    # TODO: Fix this hardcoded URL
-    get_alert = client_valid_access_token.get(f"http://testserver/api/alert/{alert_uuid}")
-    assert get_alert.json()["version"] != initial_alert_version
-    assert get_analysis.json()["version"] != initial_analysis_version
+    assert alert.version != initial_alert_version
+    assert alert.analysis.version != initial_analysis_version
 
 
 @pytest.mark.parametrize(
@@ -297,17 +285,17 @@ def test_create_bulk(client_valid_access_token):
         ("uuid", str(uuid.uuid4())),
     ],
 )
-def test_create_valid_optional_fields(client_valid_access_token, key, value):
+def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create the observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
     }
@@ -324,26 +312,22 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
         assert get.json()[key] == value
 
 
-def test_create_valid_performed_analysis_uuids(client_valid_access_token):
+def test_create_valid_performed_analysis_uuids(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create a child analysis for the observable instance
-    child_analysis_uuid = str(uuid.uuid4())
-    analysis_create = client_valid_access_token.post("/api/analysis/", json={"uuid": child_analysis_uuid})
-
-    # Read the analysis back to get its current version
-    get_analysis = client_valid_access_token.get(analysis_create.headers["Content-Location"])
-    initial_version = get_analysis.json()["version"]
+    child_analysis = helpers.create_analysis(db=db)
+    initial_child_analysis_version = child_analysis.version
 
     # Create the observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
-        "performed_analysis_uuids": [child_analysis_uuid],
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
+        "performed_analysis_uuids": [str(child_analysis.uuid)],
         "type": "test_type",
         "value": "test",
     }
@@ -351,30 +335,29 @@ def test_create_valid_performed_analysis_uuids(client_valid_access_token):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["performed_analysis_uuids"] == [child_analysis_uuid]
+    assert get.json()["performed_analysis_uuids"] == [str(child_analysis.uuid)]
 
-    # Read the analysis back. By creating the observable instance and setting its performed_analysis_uuids, you should
-    # be able to read the analysis back and see the observable instance listed as its parent_observable_uuid even
+    # By creating the observable instance and setting its performed_analysis_uuids, you should
+    # be able to see the observable instance listed as the analysis' parent_observable_uuid even
     # though it was not explicitly added.
-    get_analysis = client_valid_access_token.get(analysis_create.headers["Content-Location"])
-    assert get_analysis.json()["parent_observable_uuid"] == get.json()["uuid"]
+    assert str(child_analysis.parent_observable_uuid) == get.json()["uuid"]
 
     # Additionally, adding the observable instance as the parent should trigger the analysis to have a new version.
-    assert get_analysis.json()["version"] != initial_version
+    assert child_analysis.version != initial_child_analysis_version
 
 
-def test_create_valid_redirection(client_valid_access_token):
+def test_create_valid_redirection(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     observable_instance_uuid = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "uuid": observable_instance_uuid,
         "value": "test",
@@ -383,8 +366,8 @@ def test_create_valid_redirection(client_valid_access_token):
 
     # Create another observable instance that redirects to the previously created one
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "redirection_uuid": observable_instance_uuid,
         "type": "test_type",
         "value": "test",
@@ -396,30 +379,22 @@ def test_create_valid_redirection(client_valid_access_token):
     assert get.json()["redirection_uuid"] == observable_instance_uuid
 
 
-def test_create_valid_required_fields(client_valid_access_token):
+def test_create_valid_required_fields(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
-
-    # Read the alert back to get its current version
-    # TODO: Fix this hardcoded URL
-    get_alert = client_valid_access_token.get(f"http://testserver/api/alert/{alert_uuid}")
-    initial_alert_version = get_alert.json()["version"]
-
-    # Read the analysis back to get its current version
-    # TODO: Fix this hardcoded URL
-    get_analysis = client_valid_access_token.get(f"http://testserver/api/analysis/{analysis_uuid}")
-    initial_analysis_version = get_analysis.json()["version"]
+    alert = helpers.create_alert(db=db)
+    initial_alert_version = alert.version
+    initial_analysis_version = alert.analysis.version
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
-    observable_uuid = str(uuid.uuid4())
+    observable_uuid = uuid.uuid4()
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
-        "uuid": observable_uuid,
+        "uuid": str(observable_uuid),
         "value": "test",
     }
     create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
@@ -428,45 +403,40 @@ def test_create_valid_required_fields(client_valid_access_token):
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
     assert get.status_code == 200
-    assert get.json()["alert_uuid"] == alert_uuid
-    assert get.json()["parent_analysis_uuid"] == analysis_uuid
+    assert get.json()["alert_uuid"] == str(alert.uuid)
+    assert get.json()["parent_analysis_uuid"] == str(alert.analysis_uuid)
     assert get.json()["observable"]["type"]["value"] == "test_type"
-    assert get.json()["uuid"] == observable_uuid
+    assert get.json()["uuid"] == str(observable_uuid)
     assert get.json()["observable"]["value"] == "test"
 
-    # Read the parent analysis back. You should see this observable instance in its discovered_observable_uuids list
+    # You should see this observable instance in the analysis' discovered_observable_uuids list
     # even though it was not explicitly added.
-    # TODO: Fix this hardcoded URL
-    get_analysis = client_valid_access_token.get(f"http://testserver/api/analysis/{analysis_uuid}")
-    assert get_analysis.json()["discovered_observable_uuids"] == [observable_uuid]
+    assert alert.analysis.discovered_observable_uuids == [observable_uuid]
 
     # Additionally, creating an observable instance should trigger the alert and analysis to get a new version.
-    # TODO: Fix this hardcoded URL
-    get_alert = client_valid_access_token.get(f"http://testserver/api/alert/{alert_uuid}")
-    assert get_alert.json()["version"] != initial_alert_version
-    assert get_analysis.json()["version"] != initial_analysis_version
+    assert alert.version != initial_alert_version
+    assert alert.analysis.version != initial_analysis_version
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_DIRECTIVES,
 )
-def test_create_valid_node_directives(client_valid_access_token, values):
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
+def test_create_valid_node_directives(client_valid_access_token, db, values):
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "directives": values,
@@ -476,29 +446,28 @@ def test_create_valid_node_directives(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["directives"]) == len(list(set(values)))
+    assert len(get.json()["directives"]) == len(set(values))
 
 
 @pytest.mark.parametrize(
     "values",
     VALID_TAGS,
 )
-def test_create_valid_node_tags(client_valid_access_token, values):
-    # Create the tags. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/tag/", json={"value": value})
+def test_create_valid_node_tags(client_valid_access_token, db, values):
+    # Create the tags
+    for value in values:
+        helpers.create_node_tag(value=value, db=db)
 
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "tags": values,
@@ -515,22 +484,21 @@ def test_create_valid_node_tags(client_valid_access_token, values):
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_create_valid_node_threat_actor(client_valid_access_token, value):
-    # Create the threat actor. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
+def test_create_valid_node_threat_actor(client_valid_access_token, db, value):
+    # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "threat_actor": value,
@@ -550,25 +518,21 @@ def test_create_valid_node_threat_actor(client_valid_access_token, value):
     "values",
     VALID_THREATS,
 )
-def test_create_valid_node_threats(client_valid_access_token, values):
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
+def test_create_valid_node_threats(client_valid_access_token, db, values):
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, db=db)
 
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "threats": values,
@@ -578,4 +542,4 @@ def test_create_valid_node_threats(client_valid_access_token, values):
 
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["threats"]) == len(list(set(values)))
+    assert len(get.json()["threats"]) == len(set(values))

--- a/backend/app/tests/api/observable_instance/test_update.py
+++ b/backend/app/tests/api/observable_instance/test_update.py
@@ -3,7 +3,6 @@ import uuid
 
 from fastapi import status
 
-from tests.api.observable_instance.test_create import create_alert
 from tests.api.node import (
     INVALID_UPDATE_FIELDS,
     NONEXISTENT_FIELDS,
@@ -12,6 +11,7 @@ from tests.api.node import (
     VALID_THREAT_ACTOR,
     VALID_THREATS,
 )
+from tests import helpers
 
 
 #
@@ -72,17 +72,17 @@ def test_update_invalid_uuid(client_valid_access_token):
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
-def test_update_invalid_version(client_valid_access_token):
+def test_update_invalid_version(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
     }
@@ -93,18 +93,18 @@ def test_update_invalid_version(client_valid_access_token):
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
-def test_update_nonexistent_performed_analysis_uuids(client_valid_access_token):
+def test_update_nonexistent_performed_analysis_uuids(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -119,18 +119,18 @@ def test_update_nonexistent_performed_analysis_uuids(client_valid_access_token):
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_update_nonexistent_redirection_uuid(client_valid_access_token):
+def test_update_nonexistent_redirection_uuid(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -149,18 +149,18 @@ def test_update_nonexistent_redirection_uuid(client_valid_access_token):
     "key,value",
     NONEXISTENT_FIELDS,
 )
-def test_update_nonexistent_node_fields(client_valid_access_token, key, value):
+def test_update_nonexistent_node_fields(client_valid_access_token, db, key, value):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -184,18 +184,18 @@ def test_update_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_update_performed_analysis_uuids(client_valid_access_token):
+def test_update_performed_analysis_uuids(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -235,18 +235,18 @@ def test_update_performed_analysis_uuids(client_valid_access_token):
     assert get_analysis.json()["version"] != initial_version
 
 
-def test_update_redirection_uuid(client_valid_access_token):
+def test_update_redirection_uuid(client_valid_access_token, db):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -260,8 +260,8 @@ def test_update_redirection_uuid(client_valid_access_token):
     # Create a second observable instance to use for redirection
     redirection_uuid = str(uuid.uuid4())
     create2_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "uuid": redirection_uuid,
         "value": "test",
@@ -285,18 +285,18 @@ def test_update_redirection_uuid(client_valid_access_token):
     "values",
     VALID_DIRECTIVES,
 )
-def test_update_valid_node_directives(client_valid_access_token, values):
+def test_update_valid_node_directives(client_valid_access_token, db, values):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -328,18 +328,18 @@ def test_update_valid_node_directives(client_valid_access_token, values):
     "values",
     VALID_TAGS,
 )
-def test_update_valid_node_tags(client_valid_access_token, values):
+def test_update_valid_node_tags(client_valid_access_token, db, values):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -371,18 +371,18 @@ def test_update_valid_node_tags(client_valid_access_token, values):
     "value",
     VALID_THREAT_ACTOR,
 )
-def test_update_valid_node_threat_actor(client_valid_access_token, value):
+def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -417,18 +417,18 @@ def test_update_valid_node_threat_actor(client_valid_access_token, value):
     "values",
     VALID_THREATS,
 )
-def test_update_valid_node_threats(client_valid_access_token, values):
+def test_update_valid_node_threats(client_valid_access_token, db, values):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,
@@ -472,18 +472,18 @@ def test_update_valid_node_threats(client_valid_access_token, values):
         ("time", "2021-01-01T00:00:00+00:00", "2021-12-31 19:00:00-05:00"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, key, db, initial_value, updated_value):
     # Create an alert
-    alert_uuid, analysis_uuid = create_alert(client_valid_access_token=client_valid_access_token)
+    alert = helpers.create_alert(db=db)
 
     # Create an observable type
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test_type"})
+    helpers.create_observable_type(value="test_type", db=db)
 
     # Create an observable instance
     version = str(uuid.uuid4())
     create_json = {
-        "alert_uuid": alert_uuid,
-        "parent_analysis_uuid": analysis_uuid,
+        "alert_uuid": str(alert.uuid),
+        "parent_analysis_uuid": str(alert.analysis_uuid),
         "type": "test_type",
         "value": "test",
         "version": version,

--- a/backend/app/tests/api/observable_instance/test_update.py
+++ b/backend/app/tests/api/observable_instance/test_update.py
@@ -1,6 +1,7 @@
 import pytest
 import uuid
 
+from dateutil.parser import parse
 from fastapi import status
 
 from tests.api.node import (
@@ -76,20 +77,15 @@ def test_update_invalid_version(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
 
     # Make sure you cannot update it using an invalid version
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch(
+        f"/api/observable/instance/{obj.uuid}", json={"version": str(uuid.uuid4())}
+    )
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -97,24 +93,15 @@ def test_update_nonexistent_performed_analysis_uuids(client_valid_access_token, 
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
 
     # Make sure you cannot update it to use a nonexistent analysis UUID
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"performed_analysis_uuids": [str(uuid.uuid4())], "version": version}
+        f"/api/observable/instance/{obj.uuid}",
+        json={"performed_analysis_uuids": [str(uuid.uuid4())], "version": str(obj.version)},
     )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
@@ -123,24 +110,15 @@ def test_update_nonexistent_redirection_uuid(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
 
     # Make sure you cannot update it to use a nonexistent redirection UUID
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"redirection_uuid": str(uuid.uuid4()), "version": version}
+        f"/api/observable/instance/{obj.uuid}",
+        json={"redirection_uuid": str(uuid.uuid4()), "version": str(obj.version)},
     )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
@@ -153,22 +131,15 @@ def test_update_nonexistent_node_fields(client_valid_access_token, db, key, valu
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
 
     # Make sure you cannot update it to use a nonexistent node field value
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: value, "version": version})
+    update = client_valid_access_token.patch(
+        f"/api/observable/instance/{obj.uuid}", json={key: value, "version": str(obj.version)}
+    )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -188,97 +159,58 @@ def test_update_performed_analysis_uuids(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["performed_analysis_uuids"] == []
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
+    assert obj.performed_analysis_uuids == []
 
     # Create a child analysis
-    child_analysis_uuid = str(uuid.uuid4())
-    analysis_create = client_valid_access_token.post("/api/analysis/", json={"uuid": child_analysis_uuid})
-
-    # Read the analysis back to get its current version
-    get_analysis = client_valid_access_token.get(analysis_create.headers["Content-Location"])
-    initial_version = get_analysis.json()["version"]
+    child_analysis = helpers.create_analysis(db=db)
+    initial_child_analysis_version = child_analysis.version
 
     # Update the performed analyses
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"performed_analysis_uuids": [child_analysis_uuid], "version": version}
+        f"/api/observable/instance/{obj.uuid}",
+        json={"performed_analysis_uuids": [str(child_analysis.uuid)], "version": str(obj.version)},
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert obj.performed_analysis_uuids == [child_analysis.uuid]
+    assert obj.version != initial_observable_instance_version
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["performed_analysis_uuids"] == [child_analysis_uuid]
-    assert get.json()["version"] != version
-
-    # Read the analysis back. By updating the observable instance and setting its performed_analysis_uuids, you should
-    # be able to read the analysis back and see the observable instance listed as its parent_observable_uuid even
+    # By updating the observable instance and setting its performed_analysis_uuids, you should be able
+    # to read the analysis back and see the observable instance listed as its parent_observable_uuid even
     # though it was not explicitly added.
-    get_analysis = client_valid_access_token.get(analysis_create.headers["Content-Location"])
-    assert get_analysis.json()["parent_observable_uuid"] == get.json()["uuid"]
+    assert child_analysis.parent_observable_uuid == obj.uuid
 
     # Additionally, adding the observable instance as the parent should trigger the analysis to have a new version.
-    assert get_analysis.json()["version"] != initial_version
+    assert child_analysis.version != initial_child_analysis_version
 
 
 def test_update_redirection_uuid(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["redirection_uuid"] is None
+    obj1 = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj1.version
+    assert obj1.redirection is None
 
     # Create a second observable instance to use for redirection
-    redirection_uuid = str(uuid.uuid4())
-    create2_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "uuid": redirection_uuid,
-        "value": "test",
-        "version": version,
-    }
-    client_valid_access_token.post("/api/observable/instance/", json=[create2_json])
+    obj2 = helpers.create_observable_instance(
+        type="test_type", value="test2", alert=alert, parent_analysis=alert.analysis, db=db
+    )
 
     # Update the redirection UUID
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"redirection_uuid": redirection_uuid, "version": version}
+        f"/api/observable/instance/{obj1.uuid}", json={"redirection_uuid": str(obj2.uuid), "version": str(obj1.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["redirection_uuid"] == redirection_uuid
-    assert get.json()["version"] != version
+    assert obj1.redirection_uuid == obj2.uuid
+    assert obj1.version != initial_observable_instance_version
 
 
 @pytest.mark.parametrize(
@@ -289,39 +221,24 @@ def test_update_valid_node_directives(client_valid_access_token, db, values):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
+    assert obj.directives == []
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["directives"] == []
-
-    # Create the directives. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/directive/", json={"value": value})
+    # Create the directives
+    for value in values:
+        helpers.create_node_directive(value=value, db=db)
 
     # Update the node
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"directives": values, "version": version}
+        f"/api/observable/instance/{obj.uuid}", json={"directives": values, "version": str(obj.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["directives"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert len(obj.directives) == len(set(values))
+    assert obj.version != initial_observable_instance_version
 
 
 @pytest.mark.parametrize(
@@ -332,39 +249,24 @@ def test_update_valid_node_tags(client_valid_access_token, db, values):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
+    assert obj.tags == []
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["tags"] == []
-
-    # Create the tags. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/tag/", json={"value": value})
+    # Create the tags
+    for value in values:
+        helpers.create_node_tag(value=value, db=db)
 
     # Update the node
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"tags": values, "version": version}
+        f"/api/observable/instance/{obj.uuid}", json={"tags": values, "version": str(obj.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["tags"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert len(obj.tags) == len(set(values))
+    assert obj.version != initial_observable_instance_version
 
 
 @pytest.mark.parametrize(
@@ -375,42 +277,29 @@ def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["threat_actor"] is None
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
+    assert obj.threat_actor is None
 
     # Create the threat actor
     if value:
-        client_valid_access_token.post("/api/node/threat_actor/", json={"value": value})
+        helpers.create_node_threat_actor(value=value, db=db)
 
     # Update the node
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"threat_actor": value, "version": version}
+        f"/api/observable/instance/{obj.uuid}", json={"threat_actor": value, "version": str(obj.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
     if value:
-        assert get.json()["threat_actor"]["value"] == value
+        assert obj.threat_actor.value == value
     else:
-        assert get.json()["threat_actor"] is None
+        assert obj.threat_actor is None
 
-    assert get.json()["version"] != version
+    assert obj.version != initial_observable_instance_version
 
 
 @pytest.mark.parametrize(
@@ -421,42 +310,24 @@ def test_update_valid_node_threats(client_valid_access_token, db, values):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
+    assert obj.threats == []
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()["directives"] == []
-
-    # Create a threat type
-    client_valid_access_token.post("/api/node/threat/type/", json={"value": "test_type"})
-
-    # Create the threats. Need to only create unique values, otherwise the database will return a 409
-    # conflict exception and will roll back the test's database session (causing the test to fail).
-    for value in list(set(values)):
-        client_valid_access_token.post("/api/node/threat/", json={"types": ["test_type"], "value": value})
+    # Create the threats
+    for value in values:
+        helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Update the node
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"threats": values, "version": version}
+        f"/api/observable/instance/{obj.uuid}", json={"threats": values, "version": str(obj.version)}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert len(get.json()["threats"]) == len(list(set(values)))
-    assert get.json()["version"] != version
+    assert len(obj.threats) == len(set(values))
+    assert obj.version != initial_observable_instance_version
 
 
 @pytest.mark.parametrize(
@@ -476,38 +347,24 @@ def test_update(client_valid_access_token, key, db, initial_value, updated_value
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Create an observable type
-    helpers.create_observable_type(value="test_type", db=db)
-
     # Create an observable instance
-    version = str(uuid.uuid4())
-    create_json = {
-        "alert_uuid": str(alert.uuid),
-        "parent_analysis_uuid": str(alert.analysis_uuid),
-        "type": "test_type",
-        "value": "test",
-        "version": version,
-    }
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/observable/instance/", json=[create_json])
+    obj = helpers.create_observable_instance(
+        type="test_type", value="test", alert=alert, parent_analysis=alert.analysis, db=db
+    )
+    initial_observable_instance_version = obj.version
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
     update = client_valid_access_token.patch(
-        create.headers["Content-Location"], json={"version": version, key: updated_value}
+        f"/api/observable/instance/{obj.uuid}", json={"version": str(obj.version), key: updated_value}
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-
-    # If the test is for time, make sure that the retrieved value matches the proper UTC timestamp
     if key == "time":
-        assert get.json()[key] == "2022-01-01T00:00:00+00:00"
+        assert obj.time == parse("2022-01-01T00:00:00+00:00")
     else:
-        assert get.json()[key] == updated_value
+        assert getattr(obj, key) == updated_value
 
-    assert get.json()["version"] != version
+    assert obj.version != initial_observable_instance_version

--- a/backend/app/tests/api/observable_type/test_delete.py
+++ b/backend/app/tests/api/observable_type/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/observable/type/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_observable_type(value="test_type", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/observable/type/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/observable/type/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/observable/type/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/observable_type/test_read.py
+++ b/backend/app/tests/api/observable_type/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test"})
-    client_valid_access_token.post("/api/observable/type/", json={"value": "test2"})
+    helpers.create_observable_type(value="test_type", db=db)
+    helpers.create_observable_type(value="test_type2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/observable/type/")

--- a/backend/app/tests/api/observable_type/test_update.py
+++ b/backend/app/tests/api/observable_type/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/observable/type/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/observable/type/", json=create2_json)
+    obj1 = helpers.create_observable_type(value="test_type", db=db)
+    obj2 = helpers.create_observable_type(value="test_type2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/observable/type/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/observable/type/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_observable_type(value="test_type", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/observable/type/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/test_auth.py
+++ b/backend/app/tests/api/test_auth.py
@@ -1,12 +1,10 @@
 import pytest
 import time
 
-from datetime import datetime, timedelta
-from fastapi import status, testclient
-from jose import jwt
+from fastapi import status
 
-from core.config import get_settings, Settings
-from tests.helpers import create_test_user
+from core.config import Settings
+from tests import helpers
 from main import app
 
 
@@ -23,7 +21,7 @@ from main import app
     ],
 )
 def test_auth_invalid(client, db, username, password):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": username, "password": password})
@@ -37,7 +35,7 @@ def test_auth_invalid(client, db, username, password):
 
 
 def test_disabled_user(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -77,7 +75,7 @@ def test_expired_token(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -122,7 +120,7 @@ def test_missing_token(client):
 
 
 def test_wrong_token_type(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -171,8 +169,8 @@ def test_missing_route_authentication(client, route):
 #
 
 
-def test_auth_success(client: testclient.TestClient, db):
-    create_test_user(db, "johndoe", "abcd1234")
+def test_auth_success(client, db):
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})

--- a/backend/app/tests/api/test_auth_logout.py
+++ b/backend/app/tests/api/test_auth_logout.py
@@ -1,6 +1,6 @@
 from fastapi import status
 
-from tests.helpers import create_test_user
+from tests import helpers
 
 
 #
@@ -9,7 +9,7 @@ from tests.helpers import create_test_user
 
 
 def test_auth_logout_success(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})

--- a/backend/app/tests/api/test_auth_refresh.py
+++ b/backend/app/tests/api/test_auth_refresh.py
@@ -5,7 +5,7 @@ from sqlalchemy import update as sql_update
 
 from core.config import Settings
 from db.schemas.user import User
-from tests.helpers import create_test_user
+from tests import helpers
 
 
 #
@@ -19,7 +19,7 @@ def test_auth_refresh_invalid_token(client):
 
 
 def test_disabled_user(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -47,7 +47,7 @@ def test_expired_token(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -73,7 +73,7 @@ def test_missing_token(client):
 
 
 def test_reused_token(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -93,7 +93,7 @@ def test_reused_token(client, db):
 
 
 def test_wrong_token_type(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -122,7 +122,7 @@ def test_auth_refresh_success(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})

--- a/backend/app/tests/api/test_auth_validate.py
+++ b/backend/app/tests/api/test_auth_validate.py
@@ -3,7 +3,7 @@ import time
 from fastapi import status
 
 from core.config import Settings
-from tests.helpers import create_test_user
+from tests import helpers
 
 
 #
@@ -25,7 +25,7 @@ def test_expired_token(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -57,7 +57,7 @@ def test_missing_token(client):
 
 
 def test_wrong_token_type(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -78,7 +78,7 @@ def test_wrong_token_type(client, db):
 
 
 def test_auth_validate_success(client, db):
-    create_test_user(db, "johndoe", "abcd1234")
+    helpers.create_user(username="johndoe", password="abcd1234", db=db)
 
     # Attempt to authenticate
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})

--- a/backend/app/tests/api/user/test_create.py
+++ b/backend/app/tests/api/user/test_create.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -72,12 +74,12 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
         ("uuid"),
     ],
 )
-def test_create_duplicate_unique_fields(client_valid_access_token, key):
+def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create an alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
+    helpers.create_alert_queue(value="test_queue", db=db)
 
     # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    helpers.create_user_role(value="test_role", db=db)
 
     # Create an object
     create1_json = {
@@ -140,12 +142,12 @@ def test_create_missing_required_fields(client_valid_access_token, key):
     "key,value",
     [("enabled", False), ("timezone", "America/New_York"), ("uuid", str(uuid.uuid4()))],
 )
-def test_create_valid_optional_fields(client_valid_access_token, key, value):
+def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
     # Create an alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
+    helpers.create_alert_queue(value="test_queue", db=db)
 
     # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    helpers.create_user_role(value="test_role", db=db)
 
     # Create the object
     create_json = {
@@ -165,12 +167,12 @@ def test_create_valid_optional_fields(client_valid_access_token, key, value):
     assert get.json()[key] == value
 
 
-def test_create_valid_required_fields(client_valid_access_token):
+def test_create_valid_required_fields(client_valid_access_token, db):
     # Create an alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
+    helpers.create_alert_queue(value="test_queue", db=db)
 
     # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    helpers.create_user_role(value="test_role", db=db)
 
     # Create the object
     create_json = {

--- a/backend/app/tests/api/user/test_delete.py
+++ b/backend/app/tests/api/user/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,43 +31,32 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create an alert queue
-    alert_queue_create = client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
+    alert_queue = helpers.create_alert_queue(value="test_queue", db=db)
 
     # Create a user role
-    user_role_create = client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
+    user_role = helpers.create_user_role(value="test_role", db=db)
 
-    # Create some objects
-    create_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "John Doe",
-        "email": "john@test.com",
-        "password": "abcd1234",
-        "roles": ["test_role"],
-        "username": "johndoe",
-    }
-    create = client_valid_access_token.post("/api/user/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    # Create a user
+    user = helpers.create_user(username="johndoe", alert_queue="test_queue", roles=["test_role"], db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/user/{user.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/user/{user.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/user/{user.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND
 
     # Make sure the alert queue is still there
-    get = client_valid_access_token.get(alert_queue_create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/alert/queue/{alert_queue.uuid}")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["value"] == "test_queue"
 
     # Make sure the user role is still there
-    get = client_valid_access_token.get(user_role_create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/user/role/{user_role.uuid}")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["value"] == "test_role"

--- a/backend/app/tests/api/user/test_read.py
+++ b/backend/app/tests/api/user/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,33 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
-    # Create an alert queue
-    client_valid_access_token.post("/api/alert/queue/", json={"value": "test_queue"})
-
-    # Create a user role
-    client_valid_access_token.post("/api/user/role/", json={"value": "test_role"})
-
-    # Create some objects
-    create1_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "John Doe",
-        "email": "john@test.com",
-        "password": "abcd1234",
-        "roles": ["test_role"],
-        "username": "johndoe",
-    }
-    client_valid_access_token.post("/api/user/", json=create1_json)
-
-    create2_json = {
-        "default_alert_queue": "test_queue",
-        "display_name": "Jane Doe",
-        "email": "jane@test.com",
-        "password": "wxyz6789",
-        "roles": ["test_role"],
-        "username": "janedoe",
-    }
-    client_valid_access_token.post("/api/user/", json=create2_json)
+def test_get_all(client_valid_access_token, db):
+    # Create some users
+    helpers.create_user(username="johndoe", email="johndoe@test.com", db=db)
+    helpers.create_user(username="janedoe", email="janedoe@test.com", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/user/")

--- a/backend/app/tests/api/user_role/test_delete.py
+++ b/backend/app/tests/api/user_role/test_delete.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 """
 NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
@@ -29,19 +31,18 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_delete(client_valid_access_token):
+def test_delete(client_valid_access_token, db):
     # Create the object
-    create = client_valid_access_token.post("/api/user/role/", json={"value": "test"})
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_user_role(value="test_role", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/user/role/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(create.headers["Content-Location"])
+    delete = client_valid_access_token.delete(f"/api/user/role/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(create.headers["Content-Location"])
+    get = client_valid_access_token.get(f"/api/user/role/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/user_role/test_read.py
+++ b/backend/app/tests/api/user_role/test_read.py
@@ -2,6 +2,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -23,10 +25,10 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token):
+def test_get_all(client_valid_access_token, db):
     # Create some objects
-    client_valid_access_token.post("/api/user/role/", json={"value": "test"})
-    client_valid_access_token.post("/api/user/role/", json={"value": "test2"})
+    helpers.create_user_role(value="test_role", db=db)
+    helpers.create_user_role(value="test_role2", db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/user/role/")

--- a/backend/app/tests/api/user_role/test_update.py
+++ b/backend/app/tests/api/user_role/test_update.py
@@ -3,6 +3,8 @@ import uuid
 
 from fastapi import status
 
+from tests import helpers
+
 
 #
 # INVALID TESTS
@@ -35,16 +37,13 @@ def test_update_invalid_uuid(client_valid_access_token):
         ("value"),
     ],
 )
-def test_update_duplicate_unique_fields(client_valid_access_token, key):
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    create1_json = {"value": "test"}
-    client_valid_access_token.post("/api/user/role/", json=create1_json)
-
-    create2_json = {"value": "test2"}
-    create2 = client_valid_access_token.post("/api/user/role/", json=create2_json)
+    obj1 = helpers.create_user_role(value="test_role", db=db)
+    obj2 = helpers.create_user_role(value="test_role2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(create2.headers["Content-Location"], json={key: create1_json[key]})
+    update = client_valid_access_token.patch(f"/api/user/role/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -67,21 +66,14 @@ def test_update_nonexistent_uuid(client_valid_access_token):
         ("value", "test", "test"),
     ],
 )
-def test_update(client_valid_access_token, key, initial_value, updated_value):
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    create_json = {"value": "test"}
-    create_json[key] = initial_value
-    create = client_valid_access_token.post("/api/user/role/", json=create_json)
-    assert create.status_code == status.HTTP_201_CREATED
+    obj = helpers.create_user_role(value="test_role", db=db)
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == initial_value
+    # Set the initial value
+    setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(create.headers["Content-Location"], json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/user/role/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    assert get.json()[key] == updated_value
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -25,6 +25,7 @@ from db.schemas.event_type import EventType
 from db.schemas.event_vector import EventVector
 from db.schemas.node import Node
 from db.schemas.node_comment import NodeComment
+from db.schemas.node_history_action import NodeHistoryAction
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
@@ -260,6 +261,10 @@ def create_node_directive(value: str, db: Session) -> NodeDirective:
     return _create_basic_object(db_table=NodeDirective, value=value, db=db)
 
 
+def create_node_history_action(value: str, db: Session) -> NodeHistoryAction:
+    return _create_basic_object(db_table=NodeHistoryAction, value=value, db=db)
+
+
 def create_node_tag(value: str, db: Session) -> NodeTag:
     return _create_basic_object(db_table=NodeTag, value=value, db=db)
 
@@ -276,7 +281,7 @@ def create_node_threat(value: str, db: Session, types: List[str] = None) -> Node
     if types is None:
         types = ["test_type"]
 
-    obj = NodeThreat(value=value, types=[create_node_threat_type(value=t, db=db) for t in types])
+    obj = NodeThreat(value=value, types=[create_node_threat_type(value=t, db=db) for t in types], uuid=uuid.uuid4())
     db.add(obj)
     return obj
 
@@ -289,7 +294,11 @@ def create_observable(
     type: str, value: str, db: Session, expires_on: Optional[datetime] = None, for_detection: bool = False
 ) -> Observable:
     obj = Observable(
-        expires_on=expires_on, for_detection=for_detection, type=create_observable_type(value=type, db=db), value=value
+        expires_on=expires_on,
+        for_detection=for_detection,
+        type=create_observable_type(value=type, db=db),
+        uuid=uuid.uuid4(),
+        value=value,
     )
     db.add(obj)
     return obj
@@ -361,6 +370,7 @@ def create_user(
         password=hash_password(password),
         roles=roles,
         username=username,
+        uuid=uuid.uuid4(),
     )
     db.add(obj)
     return obj

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -1,129 +1,221 @@
-from fastapi.testclient import TestClient
+import uuid
+
+from datetime import datetime
 from sqlalchemy.orm import Session
-from typing import Optional, Tuple
+from sqlalchemy.orm.decl_api import DeclarativeMeta
+from typing import List, Optional
 
 from core.auth import hash_password
+from db import crud
+from db.schemas.alert import Alert
+from db.schemas.alert_disposition import AlertDisposition
 from db.schemas.alert_queue import AlertQueue
+from db.schemas.alert_tool import AlertTool
+from db.schemas.alert_tool_instance import AlertToolInstance
+from db.schemas.alert_type import AlertType
+from db.schemas.analysis import Analysis
+from db.schemas.event import Event
+from db.schemas.event_status import EventStatus
+from db.schemas.node_directive import NodeDirective
+from db.schemas.node_tag import NodeTag
+from db.schemas.node_threat import NodeThreat
+from db.schemas.node_threat_actor import NodeThreatActor
+from db.schemas.node_threat_type import NodeThreatType
+from db.schemas.observable_type import ObservableType
 from db.schemas.user import User
 from db.schemas.user_role import UserRole
 
 
+def _create_basic_object(value: str, db_table: DeclarativeMeta, db: Session):
+    existing = crud.read_by_value(value=value, db_table=db_table, db=db, err_on_not_found=False)
+    if existing:
+        return existing
+
+    obj = db_table(value=value)
+    db.add(obj)
+    crud.commit(db)
+    return obj
+
+
+def create_alert_disposition(value: str, db: Session, rank: Optional[int] = None) -> AlertDisposition:
+    existing = crud.read_by_value(value=value, db_table=AlertDisposition, db=db, err_on_not_found=False)
+    if existing:
+        return existing
+
+    if rank is None:
+        existing_dispositions = crud.read_all(db_table=AlertDisposition, db=db)
+        rank = len(existing_dispositions)
+
+    disposition = AlertDisposition(value=value, rank=rank)
+    db.add(disposition)
+    crud.commit(db)
+    return disposition
+
+
+def create_alert_queue(value: str, db: Session) -> AlertQueue:
+    return _create_basic_object(db_table=AlertQueue, value=value, db=db)
+
+
+def create_alert_tool(value: str, db: Session) -> AlertTool:
+    return _create_basic_object(db_table=AlertTool, value=value, db=db)
+
+
+def create_alert_tool_instance(value: str, db: Session) -> AlertToolInstance:
+    return _create_basic_object(db_table=AlertToolInstance, value=value, db=db)
+
+
+def create_alert_type(value: str, db: Session) -> AlertType:
+    return _create_basic_object(db_table=AlertType, value=value, db=db)
+
+
 def create_alert(
-    client_valid_access_token: TestClient,
+    db: Session,
     alert_queue: str = "test_queue",
     alert_type: str = "test_type",
     disposition: Optional[str] = None,
-    name: Optional[str] = None,
+    disposition_time: Optional[datetime] = None,
+    disposition_user: Optional[str] = None,
+    event_time: datetime = None,
+    insert_time: datetime = None,
+    name: str = "Test Alert",
     owner: Optional[str] = None,
-    tool: Optional[str] = None,
-    tool_instance: Optional[str] = None,
-) -> Tuple[str, str]:
+    tool: str = "test_tool",
+    tool_instance: str = "test_tool_instance",
+) -> Alert:
     """
     Helper function to create an alert. Returns a tuple of (alert_uuid, analysis_uuid)
     """
 
-    # Create the alert queue if needed. Creating a duplicate will rollback the session.
-    alert_queues = client_valid_access_token.get("/api/alert/queue/")
-    if not any(q["value"] == alert_queue for q in alert_queues.json()):
-        client_valid_access_token.post("/api/alert/queue/", json={"value": alert_queue})
+    if event_time is None:
+        event_time = datetime.utcnow()
 
-    # Create the alert type if needed. Creating a duplicate will rollback the session.
-    alert_types = client_valid_access_token.get("/api/alert/type/")
-    if not any(t["value"] == alert_type for t in alert_types.json()):
-        client_valid_access_token.post("/api/alert/type/", json={"value": alert_type})
+    if insert_time is None:
+        insert_time = datetime.utcnow()
 
-    # Create the alert
-    create_json = {"queue": alert_queue, "type": alert_type, "name": name}
-    create = client_valid_access_token.post("/api/alert/", json=create_json)
+    alert = Alert(
+        analysis=Analysis(version=uuid.uuid4()),
+        event_time=event_time,
+        insert_time=insert_time,
+        name=name,
+        queue=create_alert_queue(value=alert_queue, db=db),
+        tool=create_alert_tool(value=tool, db=db),
+        tool_instance=create_alert_tool_instance(value=tool_instance, db=db),
+        type=create_alert_type(value=alert_type, db=db),
+        version=uuid.uuid4()
+    )
 
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-
-    # Set the disposition if one was given
     if disposition:
-        dispositions = client_valid_access_token.get("/api/alert/disposition/")
-        if not any(d["value"] == disposition for d in dispositions.json()):
-            client_valid_access_token.post(
-                "/api/alert/disposition/", json={"value": disposition, "rank": len(dispositions.json()) + 1}
-            )
+        alert.disposition = create_alert_disposition(value=disposition, db=db)
 
-        client_valid_access_token.patch(
-            create.headers["Content-Location"], json={"disposition": disposition, "version": get.json()["version"]}
-        )
+    if disposition_time:
+        alert.disposition_time = disposition_time
 
-        # Read it back to get the new version
-        get = client_valid_access_token.get(create.headers["Content-Location"])
+    if disposition_user:
+        alert.disposition_user = create_user(username=disposition_user, db=db, alert_queue=alert_queue)
 
-    # Set the owner if one was given
+    if event_time:
+        alert.event_time = event_time
+
+    if insert_time:
+        alert.insert_time = insert_time
+
     if owner:
-        client_valid_access_token.patch(
-            create.headers["Content-Location"], json={"owner": owner, "version": get.json()["version"]}
-        )
+        alert.owner = create_user(username=owner, db=db, alert_queue=alert_queue)
 
-        # Read it back to get the new version
-        get = client_valid_access_token.get(create.headers["Content-Location"])
+    db.add(alert)
+    crud.commit(db)
 
-    # Set the tool if one was given
-    if tool:
-        tools = client_valid_access_token.get("/api/alert/tool/")
-        if not any(t["value"] == tool for t in tools.json()):
-            client_valid_access_token.post("/api/alert/tool/", json={"value": tool})
-
-        client_valid_access_token.patch(
-            create.headers["Content-Location"], json={"tool": tool, "version": get.json()["version"]}
-        )
-
-        # Read it back to get the new version
-        get = client_valid_access_token.get(create.headers["Content-Location"])
-
-    # Set the tool instance if one was given
-    if tool_instance:
-        tool_instances = client_valid_access_token.get("/api/alert/tool/instance/")
-        if not any(t["value"] == tool_instance for t in tool_instances.json()):
-            client_valid_access_token.post("/api/alert/tool/instance/", json={"value": tool_instance})
-
-        client_valid_access_token.patch(
-            create.headers["Content-Location"], json={"tool_instance": tool_instance, "version": get.json()["version"]}
-        )
-
-        # Read it back to get the new version
-        get = client_valid_access_token.get(create.headers["Content-Location"])
-
-    return get.json()["uuid"], get.json()["analysis"]["uuid"]
+    return alert
 
 
-def create_event(client_valid_access_token: TestClient, name: str, status: str = "OPEN") -> str:
+def create_analysis(db: Session) -> Analysis:
+    obj = Analysis(version=uuid.uuid4())
+    db.add(obj)
+    return obj
+
+
+def create_event(name: str, db: Session) -> Event:
     """
-    Helper function to create an event. Returns the event UUID.
+    Helper function to create an event. Returns the event.
     """
 
-    # Create an event status and remediation
-    client_valid_access_token.post("/api/event/status/", json={"value": status})
-
-    # Create the event
-    create = client_valid_access_token.post("/api/event/", json={"name": name, "status": status})
-
-    # Read it back
-    get = client_valid_access_token.get(create.headers["Content-Location"])
-    return get.json()["uuid"]
+    obj = Event(name=name, version=uuid.uuid4())
+    db.add(obj)
+    return obj
 
 
-def create_test_user(db: Session, username: str, password: str):
-    # Create an alert queue
-    alert_queue = AlertQueue(value="test_queue")
-    db.add(alert_queue)
+def create_event_status(value: str, db: Session) -> EventStatus:
+    return _create_basic_object(db_table=EventStatus, value=value, db=db)
 
-    # Create a user role
-    user_role = UserRole(value="test_role")
-    db.add(user_role)
 
-    # Create a user
-    user = User(
-        default_alert_queue=alert_queue,
-        display_name="John Doe",
-        email="john@test.com",
+def create_node_directive(value: str, db: Session) -> NodeDirective:
+    return _create_basic_object(db_table=NodeDirective, value=value, db=db)
+
+
+def create_node_tag(value: str, db: Session) -> NodeTag:
+    return _create_basic_object(db_table=NodeTag, value=value, db=db)
+
+
+def create_node_threat_actor(value: str, db: Session) -> NodeThreatActor:
+    return _create_basic_object(db_table=NodeThreatActor, value=value, db=db)
+
+
+def create_node_threat(value: str, db: Session, types: List[str] = None) -> NodeThreat:
+    existing = crud.read_by_value(value=value, db_table=NodeThreat, db=db, err_on_not_found=False)
+    if existing:
+        return existing
+
+    if types is None:
+        types = ["test_type"]
+
+    obj = NodeThreat(
+        value=value,
+        types=[create_node_threat_type(value=t, db=db) for t in types]
+    )
+    db.add(obj)
+    return obj
+
+
+def create_node_threat_type(value: str, db: Session) -> NodeThreatType:
+    return _create_basic_object(db_table=NodeThreatType, value=value, db=db)
+
+
+def create_observable_type(value: str, db: Session) -> ObservableType:
+    return _create_basic_object(db_table=ObservableType, value=value, db=db)
+
+
+def create_user(
+    username: str,
+    db: Session,
+    alert_queue: str = "test_queue",
+    display_name: str = "Analyst",
+    email: Optional[str] = None,
+    password: str = "asdfasdf",
+    roles: List[str] = None,
+) -> User:
+    existing = crud.read_user_by_username(username=username, db=db, err_on_not_found=False)
+    if existing:
+        return existing
+
+    if email is None:
+        email = f"{username}@test.com"
+
+    if roles is None:
+        roles = [create_user_role(value="test_role", db=db)]
+    else:
+        roles = [create_user_role(value=r, db=db) for r in roles]
+
+    obj = User(
+        default_alert_queue=create_alert_queue(value=alert_queue, db=db),
+        display_name=display_name,
+        email=email,
         password=hash_password(password),
-        roles=[user_role],
+        roles=roles,
         username=username,
     )
-    db.add(user)
+    db.add(obj)
+    return obj
+
+
+def create_user_role(value: str, db: Session) -> UserRole:
+    return _create_basic_object(db_table=UserRole, value=value, db=db)

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -23,6 +23,8 @@ from db.schemas.event_source import EventSource
 from db.schemas.event_status import EventStatus
 from db.schemas.event_type import EventType
 from db.schemas.event_vector import EventVector
+from db.schemas.node import Node
+from db.schemas.node_comment import NodeComment
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
@@ -239,6 +241,19 @@ def create_event_type(value: str, db: Session) -> EventType:
 
 def create_event_vector(value: str, db: Session) -> EventVector:
     return _create_basic_object(db_table=EventVector, value=value, db=db)
+
+
+def create_node_comment(
+    node: Node, username: str, value: str, db: Session, insert_time: Optional[datetime] = None
+) -> NodeComment:
+    if insert_time is None:
+        insert_time = datetime.utcnow()
+
+    user = create_user(username=username, db=db)
+
+    obj = NodeComment(insert_time=insert_time, node_uuid=node.uuid, user=user, uuid=uuid.uuid4(), value=value)
+    db.add(obj)
+    return obj
 
 
 def create_node_directive(value: str, db: Session) -> NodeDirective:

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -16,7 +16,13 @@ from db.schemas.alert_type import AlertType
 from db.schemas.analysis import Analysis
 from db.schemas.analysis_module_type import AnalysisModuleType
 from db.schemas.event import Event
+from db.schemas.event_prevention_tool import EventPreventionTool
+from db.schemas.event_remediation import EventRemediation
+from db.schemas.event_risk_level import EventRiskLevel
+from db.schemas.event_source import EventSource
 from db.schemas.event_status import EventStatus
+from db.schemas.event_type import EventType
+from db.schemas.event_vector import EventVector
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
@@ -171,10 +177,6 @@ def create_analysis_module_type(
     required_tags: List[str] = None,
     version: str = "1.0.0",
 ) -> AnalysisModuleType:
-    existing = crud.read_by_value(value=value, db_table=AnalysisModuleType, db=db, err_on_not_found=False)
-    if existing:
-        return existing
-
     if observable_types:
         observable_types = [create_observable_type(value=o, db=db) for o in observable_types]
     else:
@@ -205,14 +207,38 @@ def create_analysis_module_type(
     return obj
 
 
-def create_event(name: str, db: Session) -> Event:
-    obj = Event(name=name, uuid=uuid.uuid4(), version=uuid.uuid4())
+def create_event(name: str, db: Session, status: str = "OPEN") -> Event:
+    obj = Event(name=name, status=create_event_status(value=status, db=db), uuid=uuid.uuid4(), version=uuid.uuid4())
     db.add(obj)
     return obj
 
 
+def create_event_prevention_tool(value: str, db: Session) -> EventPreventionTool:
+    return _create_basic_object(db_table=EventPreventionTool, value=value, db=db)
+
+
+def create_event_remediation(value: str, db: Session) -> EventRemediation:
+    return _create_basic_object(db_table=EventRemediation, value=value, db=db)
+
+
+def create_event_risk_level(value: str, db: Session) -> EventRiskLevel:
+    return _create_basic_object(db_table=EventRiskLevel, value=value, db=db)
+
+
+def create_event_source(value: str, db: Session) -> EventSource:
+    return _create_basic_object(db_table=EventSource, value=value, db=db)
+
+
 def create_event_status(value: str, db: Session) -> EventStatus:
     return _create_basic_object(db_table=EventStatus, value=value, db=db)
+
+
+def create_event_type(value: str, db: Session) -> EventType:
+    return _create_basic_object(db_table=EventType, value=value, db=db)
+
+
+def create_event_vector(value: str, db: Session) -> EventVector:
+    return _create_basic_object(db_table=EventVector, value=value, db=db)
 
 
 def create_node_directive(value: str, db: Session) -> NodeDirective:

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -101,7 +101,8 @@ def create_alert(
         tool=create_alert_tool(value=tool, db=db),
         tool_instance=create_alert_tool_instance(value=tool_instance, db=db),
         type=create_alert_type(value=alert_type, db=db),
-        version=uuid.uuid4()
+        uuid=uuid.uuid4(),
+        version=uuid.uuid4(),
     )
 
     if disposition:
@@ -139,7 +140,7 @@ def create_event(name: str, db: Session) -> Event:
     Helper function to create an event. Returns the event.
     """
 
-    obj = Event(name=name, version=uuid.uuid4())
+    obj = Event(name=name, uuid=uuid.uuid4(), version=uuid.uuid4())
     db.add(obj)
     return obj
 
@@ -168,10 +169,7 @@ def create_node_threat(value: str, db: Session, types: List[str] = None) -> Node
     if types is None:
         types = ["test_type"]
 
-    obj = NodeThreat(
-        value=value,
-        types=[create_node_threat_type(value=t, db=db) for t in types]
-    )
+    obj = NodeThreat(value=value, types=[create_node_threat_type(value=t, db=db) for t in types])
     db.add(obj)
     return obj
 

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -14,6 +14,7 @@ from db.schemas.alert_tool import AlertTool
 from db.schemas.alert_tool_instance import AlertToolInstance
 from db.schemas.alert_type import AlertType
 from db.schemas.analysis import Analysis
+from db.schemas.analysis_module_type import AnalysisModuleType
 from db.schemas.event import Event
 from db.schemas.event_status import EventStatus
 from db.schemas.node_directive import NodeDirective
@@ -21,6 +22,8 @@ from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
 from db.schemas.node_threat_actor import NodeThreatActor
 from db.schemas.node_threat_type import NodeThreatType
+from db.schemas.observable import Observable
+from db.schemas.observable_instance import ObservableInstance
 from db.schemas.observable_type import ObservableType
 from db.schemas.user import User
 from db.schemas.user_role import UserRole
@@ -82,10 +85,6 @@ def create_alert(
     tool: str = "test_tool",
     tool_instance: str = "test_tool_instance",
 ) -> Alert:
-    """
-    Helper function to create an alert. Returns a tuple of (alert_uuid, analysis_uuid)
-    """
-
     if event_time is None:
         event_time = datetime.utcnow()
 
@@ -129,17 +128,84 @@ def create_alert(
     return alert
 
 
-def create_analysis(db: Session) -> Analysis:
-    obj = Analysis(version=uuid.uuid4())
+def create_analysis(
+    db: Session,
+    amt_value: Optional[str] = None,
+    amt_description: Optional[str] = None,
+    amt_extended_version: Optional[dict] = None,
+    amt_manual: bool = False,
+    amt_observable_types: List[str] = None,
+    amt_required_directives: List[str] = None,
+    amt_required_tags: List[str] = None,
+    amt_version: str = "1.0.0",
+) -> Analysis:
+    if amt_value:
+        analysis_module_type = create_analysis_module_type(
+            value=amt_value,
+            description=amt_description,
+            extended_version=amt_extended_version,
+            manual=amt_manual,
+            observable_types=amt_observable_types,
+            required_directives=amt_required_directives,
+            required_tags=amt_required_tags,
+            version=amt_version,
+            db=db,
+        )
+
+        obj = Analysis(analysis_module_type=analysis_module_type, uuid=uuid.uuid4(), version=uuid.uuid4())
+    else:
+        obj = Analysis(uuid=uuid.uuid4(), version=uuid.uuid4())
+
+    db.add(obj)
+    return obj
+
+
+def create_analysis_module_type(
+    value: str,
+    db: Session,
+    description: Optional[str] = None,
+    extended_version: Optional[dict] = None,
+    manual: bool = False,
+    observable_types: List[str] = None,
+    required_directives: List[str] = None,
+    required_tags: List[str] = None,
+    version: str = "1.0.0",
+) -> AnalysisModuleType:
+    existing = crud.read_by_value(value=value, db_table=AnalysisModuleType, db=db, err_on_not_found=False)
+    if existing:
+        return existing
+
+    if observable_types:
+        observable_types = [create_observable_type(value=o, db=db) for o in observable_types]
+    else:
+        observable_types = []
+
+    if required_directives:
+        required_directives = [create_node_directive(value=d, db=db) for d in required_directives]
+    else:
+        required_directives = []
+
+    if required_tags:
+        required_tags = [create_node_tag(value=t, db=db) for t in required_tags]
+    else:
+        required_tags = []
+
+    obj = AnalysisModuleType(
+        value=value,
+        description=description,
+        extended_version=extended_version,
+        manual=manual,
+        observable_types=observable_types,
+        required_directives=required_directives,
+        required_tags=required_tags,
+        uuid=uuid.uuid4(),
+        version=version,
+    )
     db.add(obj)
     return obj
 
 
 def create_event(name: str, db: Session) -> Event:
-    """
-    Helper function to create an event. Returns the event.
-    """
-
     obj = Event(name=name, uuid=uuid.uuid4(), version=uuid.uuid4())
     db.add(obj)
     return obj
@@ -176,6 +242,50 @@ def create_node_threat(value: str, db: Session, types: List[str] = None) -> Node
 
 def create_node_threat_type(value: str, db: Session) -> NodeThreatType:
     return _create_basic_object(db_table=NodeThreatType, value=value, db=db)
+
+
+def create_observable(
+    type: str, value: str, db: Session, expires_on: Optional[datetime] = None, for_detection: bool = False
+) -> Observable:
+    obj = Observable(
+        expires_on=expires_on, for_detection=for_detection, type=create_observable_type(value=type, db=db), value=value
+    )
+    db.add(obj)
+    return obj
+
+
+def create_observable_instance(
+    type: str,
+    value: str,
+    alert: Alert,
+    parent_analysis: Analysis,
+    db: Session,
+    context: Optional[str] = None,
+    performed_analyses: List[Analysis] = None,
+    redirection: Optional[ObservableInstance] = None,
+    time: Optional[datetime] = None,
+) -> ObservableInstance:
+    observable = create_observable(type=type, value=value, db=db)
+
+    if performed_analyses is None:
+        performed_analyses = []
+
+    if time is None:
+        time = datetime.utcnow()
+
+    obj = ObservableInstance(
+        observable=observable,
+        alert_uuid=alert.uuid,
+        parent_analysis=parent_analysis,
+        context=context,
+        performed_analyses=performed_analyses,
+        redirection=redirection,
+        time=time,
+        uuid=uuid.uuid4(),
+        version=uuid.uuid4(),
+    )
+    db.add(obj)
+    return obj
 
 
 def create_observable_type(value: str, db: Session) -> ObservableType:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -7,6 +7,7 @@ passlib[bcrypt]==1.7.4
 psycopg2-binary==2.9.1
 pytest==6.2.5
 pytest-cov==2.12.1
+python-dateutil==2.8.2
 python-jose==3.3.0
 python-multipart==0.0.5
 pytz==2021.1
@@ -14,3 +15,4 @@ pyyaml==5.4.1
 requests==2.26.0
 semver==2.13.0
 SQLAlchemy==1.4.23
+types-python-dateutil==2.8.2


### PR DESCRIPTION
The backend API tests were rather messy and at times confusing. Since the tests relied on making API calls to do anything, you would run into scenarios such as testing the updating of a user where you would first have to know to make the correct API calls to create an alert queue, user role, and then the user... all so that you could get to what you _actually_ wanted to test: the update user endpoint.

This meant that the tests were not only long/confusing, but they were actually testing several API endpoints in a single test.

This PR adds several helper functions for the tests to use so that they can directly create various objects in the database, which greatly simplifies (and even speeds up) the tests.