### PR TITLE
API alert sorting

### DIFF
--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -571,3 +571,165 @@ def test_get_multiple_filters(client_valid_access_token, db):
     assert get.json()["total"] == 1
     assert get.json()["items"][0]["type"]["value"] == "test_type1"
     assert get.json()["items"][0]["disposition"]["value"] == "FALSE_POSITIVE"
+
+
+def test_get_sort_by_disposition(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, disposition="DELIVERY")
+    alert2 = helpers.create_alert(db, disposition="FALSE_POSITIVE")
+
+    # If you sort descending, the FALSE_POSITIVE alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, the DELIVERY alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_disposition_time(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, disposition_time=datetime.utcnow())
+    alert2 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
+
+    # If you sort descending, the newest alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition_time|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, the oldest alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition_time|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_disposition_user(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, disposition_user="alice")
+    alert2 = helpers.create_alert(db, disposition_user="bob")
+
+    # If you sort descending, bob's alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition_user|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, alice's alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=disposition_user|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_event_time(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, event_time=datetime.utcnow())
+    alert2 = helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
+
+    # If you sort descending, the newest alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=event_time|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, the oldest alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=event_time|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_insert_time(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, insert_time=datetime.utcnow())
+    alert2 = helpers.create_alert(db, insert_time=datetime.utcnow() + timedelta(seconds=5))
+
+    # If you sort descending, the newest alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=insert_time|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, the oldest alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=insert_time|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_name(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, name="alert1")
+    alert2 = helpers.create_alert(db, name="alert2")
+
+    # If you sort descending, alert2 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=name|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, alert1 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=name|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_owner(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, owner="alice")
+    alert2 = helpers.create_alert(db, owner="bob")
+
+    # If you sort descending, bob's alert (alert2) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=owner|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, alice's alert (alert1) should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=owner|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_queue(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, alert_queue="detect")
+    alert2 = helpers.create_alert(db, alert_queue="intel")
+
+    # If you sort descending, alert2 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=queue|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, alert1 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=queue|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+
+
+def test_get_sort_by_type(client_valid_access_token, db):
+    # Create some alerts
+    alert1 = helpers.create_alert(db, alert_type="type1")
+    alert2 = helpers.create_alert(db, alert_type="type2")
+
+    # If you sort descending, alert2 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=type|desc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+
+    # If you sort ascending, alert1 should appear first
+    get = client_valid_access_token.get("/api/alert/?sort=type|asc")
+    assert get.json()["total"] == 2
+    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)

--- a/docs/usage/api/alert_sorting.md
+++ b/docs/usage/api/alert_sorting.md
@@ -1,0 +1,157 @@
+# Alert Sorting
+
+The API provides several ways to sort the alerts that are returned by the `/api/alert/` endpoint.
+
+## Disposition
+
+To sort the alerts by their disposition:
+
+**Ascending**
+
+```
+/api/alert/?sort=disposition|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=disposition|desc
+```
+
+> **NOTE:** Sorting by disposition will be skipped if you are also filtering the alerts by disposition.
+
+## Disposition Time
+
+To sort the alerts by their disposition time:
+
+**Ascending**
+
+```
+/api/alert/?sort=disposition_time|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=disposition_time|desc
+```
+
+## Disposition User
+
+To sort the alerts by their disposition user:
+
+**Ascending**
+
+```
+/api/alert/?sort=disposition_user|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=disposition_user|desc
+```
+
+> **NOTE:** Sorting by disposition user will be skipped if you are also filtering the alerts by disposition user.
+
+## Event Time
+
+To sort the alerts by their event time:
+
+**Ascending**
+
+```
+/api/alert/?sort=event_time|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=event_time|desc
+```
+
+## Insert Time
+
+To sort the alerts by their insert time:
+
+**Ascending**
+
+```
+/api/alert/?sort=insert_time|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=insert_time|desc
+```
+
+## Name
+
+To sort the alerts by their name:
+
+**Ascending**
+
+```
+/api/alert/?sort=name|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=name|desc
+```
+
+## Owner
+
+To sort the alerts by their owner:
+
+**Ascending**
+
+```
+/api/alert/?sort=owner|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=owner|desc
+```
+
+> **NOTE:** Sorting by owner will be skipped if you are also filtering the alerts by owner.
+
+## Queue
+
+To sort the alerts by their queue:
+
+**Ascending**
+
+```
+/api/alert/?sort=queue|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=queue|desc
+```
+
+> **NOTE:** Sorting by queue will be skipped if you are also filtering the alerts by queue.
+
+## Type
+
+To sort the alerts by their type:
+
+**Ascending**
+
+```
+/api/alert/?sort=type|asc
+```
+
+**Descending**
+
+```
+/api/alert/?sort=type|desc
+```
+
+> **NOTE:** Sorting by type will be skipped if you are also filtering the alerts by type.

--- a/docs/usage/index.md
+++ b/docs/usage/index.md
@@ -1,1 +1,0 @@
-# ACE2 AMS Usage


### PR DESCRIPTION
Fixes #30

This adds the ability to sort the alerts returned by the `/api/alert/` endpoint by:

* Disposition
* Disposition time
* Disposition user
* Event time
* Insert time
* Name
* Owner
* Queue
* Type