### PR TITLE
Sort Alerts Table

### DIFF
--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -227,7 +227,7 @@
         this.selectedColumns = this.columns.filter((column) => {
           return this.defaultColumns.includes(column.field);
         });
-        this.sort({ sortField: "eventTime", sortOrder: "1" });
+        this.sort({ sortField: "eventTime", sortOrder: "-1" });
         this.error = null;
       },
 

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -17,7 +17,8 @@
     data-key="uuid"
     removable-sort
     responsive-layout="scroll"
-    sort-field="eventTime"
+    :sort-field="sortField"
+    @sort="sort"
     @rowSelect="alertSelect($event.data.uuid)"
     @rowUnselect="alertUnselect($event.data.uuid)"
     @rowSelect-all="alertSelectAll(allAlertUuids)"
@@ -120,6 +121,8 @@
 <script>
   import { mapActions, mapGetters } from "vuex";
 
+  import { camelToSnakeCase } from "@/etc/helpers";
+
   import Button from "primevue/button";
   import Column from "primevue/column";
   import DataTable from "primevue/datatable";
@@ -166,6 +169,8 @@
         isLoading: false,
         selectedColumns: null,
         selectedRows: null,
+        sortField: "eventTime",
+        sortOrder: "desc",
         numRows: 10,
         page: 0,
       };
@@ -179,6 +184,11 @@
         selectedAlerts: "selectedAlerts/selected",
         filters: "filters/alerts",
       }),
+      sortFilter() {
+        return this.sortField
+          ? `${camelToSnakeCase(this.sortField)}|${this.sortOrder}`
+          : null;
+      },
       pageOptions() {
         return {
           limit: this.numRows,
@@ -217,6 +227,7 @@
         this.selectedColumns = this.columns.filter((column) => {
           return this.defaultColumns.includes(column.field);
         });
+        this.sort({ sortField: "eventTime", sortOrder: "1" });
         this.error = null;
       },
 
@@ -240,6 +251,17 @@
         this.$refs.dt.exportCSV();
       },
 
+      async sort(event) {
+        if (event.sortField) {
+          this.sortField = event.sortField;
+          this.sortOrder = event.sortOrder > 0 ? "asc" : "desc";
+          await this.loadAlerts();
+        } else {
+          this.sortField = null;
+          this.sortOrder = null;
+        }
+      },
+
       async onPage(event) {
         this.selectedRows = [];
         this.numRows = event.rows;
@@ -250,7 +272,11 @@
       async loadAlerts() {
         this.isLoading = true;
         try {
-          await this.getAllAlerts({ ...this.pageOptions, ...this.filters });
+          await this.getAllAlerts({
+            sort: this.sortFilter,
+            ...this.pageOptions,
+            ...this.filters,
+          });
         } catch (error) {
           this.error = error.message || "Something went wrong!";
         }

--- a/frontend/src/etc/helpers.ts
+++ b/frontend/src/etc/helpers.ts
@@ -1,0 +1,2 @@
+export const camelToSnakeCase = (str: string): string =>
+  str.replace(/[A-Z]/g, (letter) => `_${letter.toLowerCase()}`);

--- a/frontend/src/models/api.ts
+++ b/frontend/src/models/api.ts
@@ -3,5 +3,5 @@ import { alert, alertGetAll, alertFilterParams } from "./alert";
 
 export type anyGetSingle = genericObject & alert;
 export type anyGetAll = genericGetAll & alertGetAll;
-export type pageOptionParams = { limit: number; offset: number };
+export type pageOptionParams = { limit: number; offset: number; sort: string };
 export type getAllParams = pageOptionParams & alertFilterParams;

--- a/frontend/src/models/api.ts
+++ b/frontend/src/models/api.ts
@@ -3,5 +3,5 @@ import { alert, alertGetAll, alertFilterParams } from "./alert";
 
 export type anyGetSingle = genericObject & alert;
 export type anyGetAll = genericGetAll & alertGetAll;
-export type pageOptionParams = { limit: number; offset: number; sort: string };
+export type pageOptionParams = { limit: number; offset: number; sort?: string };
 export type getAllParams = pageOptionParams & alertFilterParams;

--- a/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
+++ b/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
@@ -39,6 +39,11 @@ describe("AnalyzeAlert.vue", () => {
     cy.login();
   });
 
+  after(() => {
+    cy.log("logging out");
+    cy.logout();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.preserveOnce("access_token", "refresh_token");
     cy.visit("/analyze");

--- a/frontend/tests/e2e/specs/Login.spec.js
+++ b/frontend/tests/e2e/specs/Login.spec.js
@@ -6,6 +6,11 @@ describe("TheLogin.vue", () => {
     cy.login();
   });
 
+  after(() => {
+    cy.log("logging out");
+    cy.logout();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.preserveOnce("access_token", "refresh_token");
   });

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -24,7 +24,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'after' filter applied when 'start' input changed by using date picker", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_after=*",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&event_time_after=*",
     ).as("getAlerts");
     // Click the first available day in the date picker for 'start' input
     cy.get(":nth-child(2) > .p-inputgroup > .p-inputtext").click();
@@ -37,7 +37,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'after' filter applied when 'start' input changed by typing", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_after=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&event_time_after=2021-03-02T*",
     ).as("getAlerts");
     // Type the date into the 'start' input
     cy.get(":nth-child(2) > .p-inputgroup > .p-inputtext")
@@ -51,7 +51,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'before' filter applied when 'end' input changed by using date picker", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_before=*",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&event_time_before=*",
     ).as("getAlerts");
     // Click the first available day in the date picker for 'end' input
     cy.get(":nth-child(4) > .p-inputgroup > .p-inputtext").click();
@@ -63,7 +63,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'before' filter applied when 'end' input changed by typing", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_before=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&event_time_before=2021-03-02T*",
     ).as("getAlerts");
     // Type the date into the 'end' input
     cy.get(":nth-child(4) > .p-inputgroup > .p-inputtext")
@@ -166,7 +166,7 @@ describe("ManageAlerts.vue", () => {
   it("will use the set time filter will be used for requests ", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&insert_time_after=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&insert_time_after=2021-03-02T*",
     ).as("getAlerts");
 
     // Set the date range filter type to be "Insert Time"
@@ -204,7 +204,7 @@ describe("ManageAlerts.vue", () => {
 
     cy.intercept(
       "GET",
-      "/api/sort=event_time%7Casc&alert/?limit=10&offset=0",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
     ).as("getAlertsNoFilters");
     // Change the date range filter type to "Insert Time"
     cy.get("#FilterToolbar > .p-toolbar-group-left > :nth-child(1)").click();

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -22,9 +22,10 @@ describe("ManageAlerts.vue", () => {
   });
 
   it("will reload alerts table with 'after' filter applied when 'start' input changed by using date picker", () => {
-    cy.intercept("GET", "/api/alert/?limit=10&offset=0&event_time_after=*").as(
-      "getAlerts",
-    );
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_after=*",
+    ).as("getAlerts");
     // Click the first available day in the date picker for 'start' input
     cy.get(":nth-child(2) > .p-inputgroup > .p-inputtext").click();
     cy.get(".vc-popover-content").should("be.visible");
@@ -36,7 +37,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'after' filter applied when 'start' input changed by typing", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?limit=10&offset=0&event_time_after=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_after=2021-03-02T*",
     ).as("getAlerts");
     // Type the date into the 'start' input
     cy.get(":nth-child(2) > .p-inputgroup > .p-inputtext")
@@ -48,9 +49,10 @@ describe("ManageAlerts.vue", () => {
   });
 
   it("will reload alerts table with 'before' filter applied when 'end' input changed by using date picker", () => {
-    cy.intercept("GET", "/api/alert/?limit=10&offset=0&event_time_before=*").as(
-      "getAlerts",
-    );
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_before=*",
+    ).as("getAlerts");
     // Click the first available day in the date picker for 'end' input
     cy.get(":nth-child(4) > .p-inputgroup > .p-inputtext").click();
     cy.get(".vc-popover-content").should("be.visible");
@@ -61,7 +63,7 @@ describe("ManageAlerts.vue", () => {
   it("will reload alerts table with 'before' filter applied when 'end' input changed by typing", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?limit=10&offset=0&event_time_before=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&event_time_before=2021-03-02T*",
     ).as("getAlerts");
     // Type the date into the 'end' input
     cy.get(":nth-child(4) > .p-inputgroup > .p-inputtext")
@@ -164,7 +166,7 @@ describe("ManageAlerts.vue", () => {
   it("will use the set time filter will be used for requests ", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?limit=10&offset=0&insert_time_after=2021-03-02T*",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0&insert_time_after=2021-03-02T*",
     ).as("getAlerts");
 
     // Set the date range filter type to be "Insert Time"
@@ -200,9 +202,10 @@ describe("ManageAlerts.vue", () => {
       "03/02/2021 13:00",
     );
 
-    cy.intercept("GET", "/api/alert/?limit=10&offset=0").as(
-      "getAlertsNoFilters",
-    );
+    cy.intercept(
+      "GET",
+      "/api/sort=event_time%7Casc&alert/?limit=10&offset=0",
+    ).as("getAlertsNoFilters");
     // Change the date range filter type to "Insert Time"
     cy.get("#FilterToolbar > .p-toolbar-group-left > :nth-child(1)").click();
     cy.get(".p-overlaypanel-content").should("be.visible");

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -7,6 +7,11 @@ describe("TheAlertsTable.vue", () => {
     cy.login();
   });
 
+  after(() => {
+    cy.log("logging out");
+    cy.logout();
+  });
+
   beforeEach(() => {
     Cypress.Cookies.preserveOnce("access_token", "refresh_token");
     cy.visit("/manage_alerts");
@@ -160,15 +165,15 @@ describe("TheAlertsTable.vue", () => {
   it("lazy pagination works correctly when page size or number is changed", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
     ).as("getAlertsDefaultRows");
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=5&offset=0",
+      "/api/alert/?sort=event_time%7Cdesc&limit=5&offset=0",
     ).as("getAlertsChangedRows");
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Casc&limit=5&offset=5",
+      "/api/alert/?sort=event_time%7Cdesc&limit=5&offset=5",
     ).as("getAlertsChangedRowsOffset");
     // Should start with default number of rows
     cy.wait("@getAlertsDefaultRows").its("state").should("eq", "Complete");
@@ -185,6 +190,56 @@ describe("TheAlertsTable.vue", () => {
       .its("state")
       .should("eq", "Complete");
     cy.get("tr").should("have.length", 6);
+  });
+
+  it("correctly changes the sort filter when a column is clicked", () => {
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=name%7Casc&limit=10&offset=0",
+    ).as("nameSortAsc");
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=name%7Cdesc&limit=10&offset=0",
+    ).as("nameSortDesc");
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0",
+    ).as("eventTimeSortAsc");
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
+    ).as("defaultSort");
+
+    // sort by name to start, will default to ascending
+    cy.get('.p-datatable-thead > tr > :nth-child(4)').click();
+    // check api call
+    cy.wait("@nameSortAsc").its("state").should("eq", "Complete");
+    // check first alerts name
+    cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(4)').should('have.text', 'Manual Alert');
+    // sort by name again, will change to descending
+    cy.get('.p-datatable-thead > tr > :nth-child(4)').click();
+    // check api call
+    cy.wait("@nameSortDesc").its("state").should("eq", "Complete");
+    // check first alerts name
+    cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(4)').should('have.text', 'Manual Alert 8.7.6.5');
+    // sort by name again, this time it will remove all sorts
+    cy.get('.p-datatable-thead > tr > :nth-child(4)').click();
+    // there shouldn't be an API call this time
+    // check first alerts name (will be the same)
+    cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(4)').should('have.text', 'Manual Alert 8.7.6.5');
+    // sort by event time again, will default to ascending
+    cy.get('.p-datatable-thead > tr > :nth-child(3)').click();
+    // check api call
+    cy.wait("@eventTimeSortAsc").its("state").should("eq", "Complete");
+    // check first alerts name
+    cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(4)').should('have.text', 'Manual Alert');
+    // click the reset table button
+    cy.get('.p-datatable-header > .p-toolbar > .p-toolbar-group-right > :nth-child(2)').click();
+    // check api call
+    cy.wait("@defaultSort").its("state").should("eq", "Complete");
+    // check first alerts name
+    cy.get('.p-datatable-tbody > :nth-child(1) > :nth-child(4)').should('have.text', 'Manual Alert 4.3.2.1');
+
   });
 
   // This test broken by pagination changes

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -158,15 +158,18 @@ describe("TheAlertsTable.vue", () => {
   });
 
   it("lazy pagination works correctly when page size or number is changed", () => {
-    cy.intercept("GET", "/api/alert/?limit=10&offset=0").as(
-      "getAlertsDefaultRows",
-    );
-    cy.intercept("GET", "/api/alert/?limit=5&offset=0").as(
-      "getAlertsChangedRows",
-    );
-    cy.intercept("GET", "/api/alert/?limit=5&offset=5").as(
-      "getAlertsChangedRowsOffset",
-    );
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=10&offset=0",
+    ).as("getAlertsDefaultRows");
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=5&offset=0",
+    ).as("getAlertsChangedRows");
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Casc&limit=5&offset=5",
+    ).as("getAlertsChangedRowsOffset");
     // Should start with default number of rows
     cy.wait("@getAlertsDefaultRows").its("state").should("eq", "Complete");
     cy.get("tr").should("have.length", 11);

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -26,7 +26,7 @@ describe("TheAlertsTable data/creation", () => {
   beforeAll(async () => {
     nock.cleanAll();
     myNock
-      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
       .reply(200, {
         items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
         total: 2,
@@ -90,6 +90,8 @@ describe("TheAlertsTable data/creation", () => {
     expect(wrapper.vm.error).toBeNull();
     expect(wrapper.vm.alerts).toHaveLength(2);
     expect(wrapper.vm.totalAlerts).toEqual(2);
+    expect(wrapper.vm.sortField).toEqual("eventTime");
+    expect(wrapper.vm.sortOrder).toEqual("desc");
     expect(wrapper.vm.numRows).toEqual(10);
     expect(wrapper.vm.page).toEqual(0);
   });
@@ -98,6 +100,9 @@ describe("TheAlertsTable data/creation", () => {
       limit: 10,
       offset: 0,
     });
+    expect(wrapper.vm.sortFilter).toEqual("event_time|desc");
+    wrapper.setData({sortField: null})
+    expect(wrapper.vm.sortFilter).toBeNull();
   });
 });
 
@@ -112,7 +117,7 @@ describe("TheAlertsTable methods success", () => {
   beforeAll(async () => {
     nock.cleanAll();
     myNock
-      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
       .reply(200, {
         items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
         total: 2,
@@ -157,7 +162,7 @@ describe("TheAlertsTable methods success", () => {
   });
   it("will reload the alerts with new pagination settings on 'onPage'", async () => {
     const mockRequest = myNock
-      .get("/alert/?sort=event_time%7Casc&limit=1&offset=1")
+      .get("/alert/?sort=event_time%7Cdesc&limit=1&offset=1")
       .thrice()
       .reply(200, {
         items: [{ uuid: "alert_2" }],
@@ -167,6 +172,18 @@ describe("TheAlertsTable methods success", () => {
     expect(wrapper.vm.numRows).toEqual(1);
     expect(wrapper.vm.selectedRows).toEqual([]);
     expect(mockRequest.isDone()).toEqual(true);
+  });
+  it("will reload the alerts with new sort settings on 'sort'", async () => {
+    const mockRequestSort = myNock
+      .get("/alert/?sort=name%7Casc&limit=1&offset=1")
+      .reply(200, {
+        items: [{ uuid: "alert_2" }],
+        total: 2,
+      });
+    await wrapper.vm.sort({ sortField: 'name', sortOrder: 1 });
+    expect(wrapper.vm.sortField).toEqual('name');
+    expect(wrapper.vm.sortOrder).toEqual('asc');
+    expect(mockRequestSort.isDone()).toEqual(true);
   });
 });
 
@@ -188,7 +205,7 @@ describe("TheAlertsTable methods failed", () => {
 
   it("will set the error data property to the given error if getAllAlerts fails within loadAlerts", async () => {
     const mockRequest = myNock
-      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
       .twice()
       .reply(403, "Request Failed");
 

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -26,7 +26,7 @@ describe("TheAlertsTable data/creation", () => {
   beforeAll(async () => {
     nock.cleanAll();
     myNock
-      .get("/alert/?limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
       .reply(200, {
         items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
         total: 2,
@@ -112,7 +112,7 @@ describe("TheAlertsTable methods success", () => {
   beforeAll(async () => {
     nock.cleanAll();
     myNock
-      .get("/alert/?limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
       .reply(200, {
         items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
         total: 2,
@@ -157,7 +157,7 @@ describe("TheAlertsTable methods success", () => {
   });
   it("will reload the alerts with new pagination settings on 'onPage'", async () => {
     const mockRequest = myNock
-      .get("/alert/?limit=1&offset=1")
+      .get("/alert/?sort=event_time%7Casc&limit=1&offset=1")
       .thrice()
       .reply(200, {
         items: [{ uuid: "alert_2" }],
@@ -188,7 +188,7 @@ describe("TheAlertsTable methods failed", () => {
 
   it("will set the error data property to the given error if getAllAlerts fails within loadAlerts", async () => {
     const mockRequest = myNock
-      .get("/alert/?limit=10&offset=0")
+      .get("/alert/?sort=event_time%7Casc&limit=10&offset=0")
       .twice()
       .reply(403, "Request Failed");
 

--- a/frontend/tests/unit/src/store/alerts.spec.ts
+++ b/frontend/tests/unit/src/store/alerts.spec.ts
@@ -186,7 +186,7 @@ describe("alerts Actions", () => {
     expect(state.visibleQueriedAlerts).toHaveLength(2);
   });
 
-  it("will pass params along when getAll is and pagination options are set", async () => {
+  it("will pass params along when getAll iscalled and pagination options are set", async () => {
     const state = {
       openAlert: null,
       visibleQueriedAlerts: [],
@@ -197,6 +197,25 @@ describe("alerts Actions", () => {
       .get("/alert/?limit=2&offset=0")
       .reply(200, { items: [{ uuid: "uuid1" }, { uuid: "uuid2" }], total: 2 });
     await store.dispatch("getAll", { limit: 2, offset: 0 });
+
+    expect(mockRequest.isDone()).toEqual(true);
+
+    expect(state.openAlert).toBeNull();
+    expect(state.totalAlerts).toEqual(2);
+    expect(state.visibleQueriedAlerts).toHaveLength(2);
+  });
+
+  it("will pass params along when getAll is called and sort options are set", async () => {
+    const state = {
+      openAlert: null,
+      visibleQueriedAlerts: [],
+      totalAlerts: 0,
+    };
+    const store = new Vuex.Store({ state, mutations, actions });
+    const mockRequest = myNock
+      .get("/alert/?sort=event_time%7Casc")
+      .reply(200, { items: [{ uuid: "uuid1" }, { uuid: "uuid2" }], total: 2 });
+    await store.dispatch("getAll", { sort: "event_time|asc" });
 
     expect(mockRequest.isDone()).toEqual(true);
 


### PR DESCRIPTION
This PR re-adds the ability to sort the alerts table by column value. Now, when a column header is clicked, the sort event is intercepted and an API request is made to update the current getAll query to use the new sort. If no sort is set, there will be no API request and the table will stay as-is. The table reset button will now also work to reset the sort to the default (event time descending).

Mostly just TheAlertsTable.vue that needed to be changed, although there is a new helper function and the 'pageOptionParams' model has been updated to include the optional sort key.

Unit & E2E tests have been written/updated to reflect changes. 