### PR TITLE
Pagination for all the things and other minor enhancements

### DIFF
--- a/backend/app/api/routes/alert.py
+++ b/backend/app/api/routes/alert.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi.exceptions import HTTPException
-from fastapi_pagination import LimitOffsetPage
 from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy import and_, func, select
 from sqlalchemy.orm import Session, joinedload
@@ -417,7 +416,7 @@ def get_alert(uuid: UUID, db: Session = Depends(get_db)):
     return AlertTreeRead(alert=alert, analyses=analyses, observable_instances=observable_instances)
 
 
-helpers.api_route_read_all(router, get_all_alerts, LimitOffsetPage[AlertRead])
+helpers.api_route_read_all(router, get_all_alerts, AlertRead)
 helpers.api_route_read(router, get_alert, AlertTreeRead)
 
 

--- a/backend/app/api/routes/alert_disposition.py
+++ b/backend/app/api/routes/alert_disposition.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.alert_disposition import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_disposition)
 
 
 def get_all_dispositions(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AlertDisposition, db=db)
+    return paginate(db, select(AlertDisposition))
 
 
 def get_disposition(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AlertDisposition, db=db)
 
 
-helpers.api_route_read_all(router, get_all_dispositions, List[AlertDispositionRead])
+helpers.api_route_read_all(router, get_all_dispositions, AlertDispositionRead)
 helpers.api_route_read(router, get_disposition, AlertDispositionRead)
 
 

--- a/backend/app/api/routes/alert_queue.py
+++ b/backend/app/api/routes/alert_queue.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.alert_queue import AlertQueueCreate, AlertQueueRead, AlertQueueUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_alert_queue)
 
 
 def get_all_alert_queues(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AlertQueue, db=db)
+    return paginate(db, select(AlertQueue))
 
 
 def get_alert_queue(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AlertQueue, db=db)
 
 
-helpers.api_route_read_all(router, get_all_alert_queues, List[AlertQueueRead])
+helpers.api_route_read_all(router, get_all_alert_queues, AlertQueueRead)
 helpers.api_route_read(router, get_alert_queue, AlertQueueRead)
 
 

--- a/backend/app/api/routes/alert_tool.py
+++ b/backend/app/api/routes/alert_tool.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.alert_tool import AlertToolCreate, AlertToolRead, AlertToolUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_alert_tool)
 
 
 def get_all_alert_tools(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AlertTool, db=db)
+    return paginate(db, select(AlertTool))
 
 
 def get_alert_tool(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AlertTool, db=db)
 
 
-helpers.api_route_read_all(router, get_all_alert_tools, List[AlertToolRead])
+helpers.api_route_read_all(router, get_all_alert_tools, AlertToolRead)
 helpers.api_route_read(router, get_alert_tool, AlertToolRead)
 
 

--- a/backend/app/api/routes/alert_tool_instance.py
+++ b/backend/app/api/routes/alert_tool_instance.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.alert_tool_instance import AlertToolInstanceCreate, AlertToolInstanceRead, AlertToolInstanceUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_alert_tool_instance)
 
 
 def get_all_alert_tool_instances(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AlertToolInstance, db=db)
+    return paginate(db, select(AlertToolInstance))
 
 
 def get_alert_tool_instance(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AlertToolInstance, db=db)
 
 
-helpers.api_route_read_all(router, get_all_alert_tool_instances, List[AlertToolInstanceRead])
+helpers.api_route_read_all(router, get_all_alert_tool_instances, AlertToolInstanceRead)
 helpers.api_route_read(router, get_alert_tool_instance, AlertToolInstanceRead)
 
 

--- a/backend/app/api/routes/alert_type.py
+++ b/backend/app/api/routes/alert_type.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.alert_type import AlertTypeCreate, AlertTypeRead, AlertTypeUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_alert_type)
 
 
 def get_all_alert_types(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AlertType, db=db)
+    return paginate(db, select(AlertType))
 
 
 def get_alert_type(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AlertType, db=db)
 
 
-helpers.api_route_read_all(router, get_all_alert_types, List[AlertTypeRead])
+helpers.api_route_read_all(router, get_all_alert_types, AlertTypeRead)
 helpers.api_route_read(router, get_alert_type, AlertTypeRead)
 
 

--- a/backend/app/api/routes/analysis_module_type.py
+++ b/backend/app/api/routes/analysis_module_type.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.analysis_module_type import (
@@ -77,14 +78,14 @@ helpers.api_route_create(router, create_analysis_module_type)
 
 
 def get_all_analysis_module_types(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=AnalysisModuleType, db=db)
+    return paginate(db, select(AnalysisModuleType))
 
 
 def get_analysis_module_type(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=AnalysisModuleType, db=db)
 
 
-helpers.api_route_read_all(router, get_all_analysis_module_types, List[AnalysisModuleTypeRead])
+helpers.api_route_read_all(router, get_all_analysis_module_types, AnalysisModuleTypeRead)
 helpers.api_route_read(router, get_analysis_module_type, AnalysisModuleTypeRead)
 
 

--- a/backend/app/api/routes/event_prevention_tool.py
+++ b/backend/app/api/routes/event_prevention_tool.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_prevention_tool import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_prevention_tool)
 
 
 def get_all_event_prevention_tools(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventPreventionTool, db=db)
+    return paginate(db, select(EventPreventionTool))
 
 
 def get_event_prevention_tool(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventPreventionTool, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_prevention_tools, List[EventPreventionToolRead])
+helpers.api_route_read_all(router, get_all_event_prevention_tools, EventPreventionToolRead)
 helpers.api_route_read(router, get_event_prevention_tool, EventPreventionToolRead)
 
 

--- a/backend/app/api/routes/event_remediation.py
+++ b/backend/app/api/routes/event_remediation.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_remediation import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_remediation)
 
 
 def get_all_event_remediations(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventRemediation, db=db)
+    return paginate(db, select(EventRemediation))
 
 
 def get_event_remediation(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventRemediation, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_remediations, List[EventRemediationRead])
+helpers.api_route_read_all(router, get_all_event_remediations, EventRemediationRead)
 helpers.api_route_read(router, get_event_remediation, EventRemediationRead)
 
 

--- a/backend/app/api/routes/event_risk_level.py
+++ b/backend/app/api/routes/event_risk_level.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_risk_level import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_risk_level)
 
 
 def get_all_event_risk_levels(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventRiskLevel, db=db)
+    return paginate(db, select(EventRiskLevel))
 
 
 def get_event_risk_level(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventRiskLevel, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_risk_levels, List[EventRiskLevelRead])
+helpers.api_route_read_all(router, get_all_event_risk_levels, EventRiskLevelRead)
 helpers.api_route_read(router, get_event_risk_level, EventRiskLevelRead)
 
 

--- a/backend/app/api/routes/event_source.py
+++ b/backend/app/api/routes/event_source.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_source import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_source)
 
 
 def get_all_event_sources(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventSource, db=db)
+    return paginate(db, select(EventSource))
 
 
 def get_event_source(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventSource, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_sources, List[EventSourceRead])
+helpers.api_route_read_all(router, get_all_event_sources, EventSourceRead)
 helpers.api_route_read(router, get_event_source, EventSourceRead)
 
 

--- a/backend/app/api/routes/event_status.py
+++ b/backend/app/api/routes/event_status.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_status import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_status)
 
 
 def get_all_event_statuses(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventStatus, db=db)
+    return paginate(db, select(EventStatus))
 
 
 def get_event_status(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventStatus, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_statuses, List[EventStatusRead])
+helpers.api_route_read_all(router, get_all_event_statuses, EventStatusRead)
 helpers.api_route_read(router, get_event_status, EventStatusRead)
 
 

--- a/backend/app/api/routes/event_type.py
+++ b/backend/app/api/routes/event_type.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_type import EventTypeCreate, EventTypeRead, EventTypeUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_event_type)
 
 
 def get_all_event_types(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventType, db=db)
+    return paginate(db, select(EventType))
 
 
 def get_event_type(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventType, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_types, List[EventTypeRead])
+helpers.api_route_read_all(router, get_all_event_types, EventTypeRead)
 helpers.api_route_read(router, get_event_type, EventTypeRead)
 
 

--- a/backend/app/api/routes/event_vector.py
+++ b/backend/app/api/routes/event_vector.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.event_vector import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_event_vector)
 
 
 def get_all_event_vectors(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=EventVector, db=db)
+    return paginate(db, select(EventVector))
 
 
 def get_event_vector(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=EventVector, db=db)
 
 
-helpers.api_route_read_all(router, get_all_event_vectors, List[EventVectorRead])
+helpers.api_route_read_all(router, get_all_event_vectors, EventVectorRead)
 helpers.api_route_read(router, get_event_vector, EventVectorRead)
 
 

--- a/backend/app/api/routes/helpers.py
+++ b/backend/app/api/routes/helpers.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter, Depends, Response, status
+from fastapi_pagination.limit_offset import LimitOffsetPage
 from pydantic import BaseModel
 from typing import Callable
 
@@ -71,7 +72,7 @@ def api_route_read_all(router: APIRouter, endpoint: Callable, response_model: Ba
         path=path,
         endpoint=endpoint,
         methods=["GET"],
-        response_model=response_model,
+        response_model=LimitOffsetPage[response_model],
     )
 
 

--- a/backend/app/api/routes/node_directive.py
+++ b/backend/app/api/routes/node_directive.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_directive import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_node_directive)
 
 
 def get_all_node_directives(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeDirective, db=db)
+    return paginate(db, select(NodeDirective))
 
 
 def get_node_directive(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeDirective, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_directives, List[NodeDirectiveRead])
+helpers.api_route_read_all(router, get_all_node_directives, NodeDirectiveRead)
 helpers.api_route_read(router, get_node_directive, NodeDirectiveRead)
 
 

--- a/backend/app/api/routes/node_history_action.py
+++ b/backend/app/api/routes/node_history_action.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_history_action import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_node_history_action)
 
 
 def get_all_node_history_actions(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeHistoryAction, db=db)
+    return paginate(db, select(NodeHistoryAction))
 
 
 def get_node_history_action(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeHistoryAction, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_history_actions, List[NodeHistoryActionRead])
+helpers.api_route_read_all(router, get_all_node_history_actions, NodeHistoryActionRead)
 helpers.api_route_read(router, get_node_history_action, NodeHistoryActionRead)
 
 

--- a/backend/app/api/routes/node_tag.py
+++ b/backend/app/api/routes/node_tag.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_tag import NodeTagCreate, NodeTagRead, NodeTagUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_node_tag)
 
 
 def get_all_node_tags(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeTag, db=db)
+    return paginate(db, select(NodeTag))
 
 
 def get_node_tag(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeTag, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_tags, List[NodeTagRead])
+helpers.api_route_read_all(router, get_all_node_tags, NodeTagRead)
 helpers.api_route_read(router, get_node_tag, NodeTagRead)
 
 

--- a/backend/app/api/routes/node_threat.py
+++ b/backend/app/api/routes/node_threat.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_threat import NodeThreatCreate, NodeThreatRead, NodeThreatUpdate
@@ -53,14 +54,14 @@ helpers.api_route_create(router, create_node_threat)
 
 
 def get_all_node_threats(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeThreat, db=db)
+    return paginate(db, select(NodeThreat))
 
 
 def get_node_threat(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeThreat, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_threats, List[NodeThreatRead])
+helpers.api_route_read_all(router, get_all_node_threats, NodeThreatRead)
 helpers.api_route_read(router, get_node_threat, NodeThreatRead)
 
 

--- a/backend/app/api/routes/node_threat_actor.py
+++ b/backend/app/api/routes/node_threat_actor.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_threat_actor import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_node_threat_actor)
 
 
 def get_all_node_threat_actors(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeThreatActor, db=db)
+    return paginate(db, select(NodeThreatActor))
 
 
 def get_node_threat_actor(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeThreatActor, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_threat_actors, List[NodeThreatActorRead])
+helpers.api_route_read_all(router, get_all_node_threat_actors, NodeThreatActorRead)
 helpers.api_route_read(router, get_node_threat_actor, NodeThreatActorRead)
 
 

--- a/backend/app/api/routes/node_threat_type.py
+++ b/backend/app/api/routes/node_threat_type.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.node_threat_type import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_node_threat_type)
 
 
 def get_all_node_threat_types(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=NodeThreatType, db=db)
+    return paginate(db, select(NodeThreatType))
 
 
 def get_node_threat_type(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeThreatType, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_threat_types, List[NodeThreatTypeRead])
+helpers.api_route_read_all(router, get_all_node_threat_types, NodeThreatTypeRead)
 helpers.api_route_read(router, get_node_threat_type, NodeThreatTypeRead)
 
 

--- a/backend/app/api/routes/observable.py
+++ b/backend/app/api/routes/observable.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.observable import (
@@ -54,14 +55,14 @@ helpers.api_route_create(router, create_observable)
 
 
 def get_all_observables(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=Observable, db=db)
+    return paginate(db, select(Observable))
 
 
 def get_observable(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=Observable, db=db)
 
 
-helpers.api_route_read_all(router, get_all_observables, List[ObservableRead])
+helpers.api_route_read_all(router, get_all_observables, ObservableRead)
 helpers.api_route_read(router, get_observable, ObservableRead)
 
 

--- a/backend/app/api/routes/observable_instance.py
+++ b/backend/app/api/routes/observable_instance.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Request, Response
 from sqlalchemy.orm import Session
-from typing import List, Optional, Union
+from typing import List, Union
 from uuid import UUID, uuid4
 
 from api.models.observable_instance import (

--- a/backend/app/api/routes/observable_type.py
+++ b/backend/app/api/routes/observable_type.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.observable_type import (
@@ -45,14 +46,14 @@ helpers.api_route_create(router, create_observable_type)
 
 
 def get_all_observable_types(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=ObservableType, db=db)
+    return paginate(db, select(ObservableType))
 
 
 def get_observable_type(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=ObservableType, db=db)
 
 
-helpers.api_route_read_all(router, get_all_observable_types, List[ObservableTypeRead])
+helpers.api_route_read_all(router, get_all_observable_types, ObservableTypeRead)
 helpers.api_route_read(router, get_observable_type, ObservableTypeRead)
 
 

--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.user import (
@@ -63,14 +64,14 @@ helpers.api_route_create(router, create_user)
 
 
 def get_all_users(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=User, db=db)
+    return paginate(db, select(User))
 
 
 def get_user(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=User, db=db)
 
 
-helpers.api_route_read_all(router, get_all_users, List[UserRead])
+helpers.api_route_read_all(router, get_all_users, UserRead)
 helpers.api_route_read(router, get_user, UserRead)
 
 

--- a/backend/app/api/routes/user_role.py
+++ b/backend/app/api/routes/user_role.py
@@ -1,6 +1,7 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from typing import List
+from sqlalchemy.sql.expression import select
 from uuid import UUID
 
 from api.models.user_role import UserRoleCreate, UserRoleRead, UserRoleUpdate
@@ -41,14 +42,14 @@ helpers.api_route_create(router, create_user_role)
 
 
 def get_all_user_roles(db: Session = Depends(get_db)):
-    return crud.read_all(db_table=UserRole, db=db)
+    return paginate(db, select(UserRole))
 
 
 def get_user_role(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=UserRole, db=db)
 
 
-helpers.api_route_read_all(router, get_all_user_roles, List[UserRoleRead])
+helpers.api_route_read_all(router, get_all_user_roles, UserRoleRead)
 helpers.api_route_read(router, get_user_role, UserRoleRead)
 
 

--- a/backend/app/tests/api/alert_disposition/test_read.py
+++ b/backend/app/tests/api/alert_disposition/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/disposition/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/alert/disposition/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/alert_queue/test_read.py
+++ b/backend/app/tests/api/alert_queue/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/queue/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/alert/queue/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/alert_tool/test_read.py
+++ b/backend/app/tests/api/alert_tool/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/tool/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/alert/tool/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/alert_tool_instance/test_read.py
+++ b/backend/app/tests/api/alert_tool_instance/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/tool/instance/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/alert/tool/instance/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/alert_type/test_read.py
+++ b/backend/app/tests/api/alert_type/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/alert/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/analysis_module_type/test_read.py
+++ b/backend/app/tests/api/analysis_module_type/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/analysis/module_type/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/analysis/module_type/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_prevention_tool/test_read.py
+++ b/backend/app/tests/api/event_prevention_tool/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/prevention_tool/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/prevention_tool/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_remediation/test_read.py
+++ b/backend/app/tests/api/event_remediation/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/remediation/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/remediation/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_risk_level/test_read.py
+++ b/backend/app/tests/api/event_risk_level/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/risk_level/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/risk_level/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_source/test_read.py
+++ b/backend/app/tests/api/event_source/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/source/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/source/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_status/test_read.py
+++ b/backend/app/tests/api/event_status/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/status/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/status/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_type/test_read.py
+++ b/backend/app/tests/api/event_type/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_vector/test_read.py
+++ b/backend/app/tests/api/event_vector/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/vector/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/event/vector/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_directive/test_read.py
+++ b/backend/app/tests/api/node_directive/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/directive/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/directive/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_history_action/test_read.py
+++ b/backend/app/tests/api/node_history_action/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/history/action/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/history/action/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_tag/test_read.py
+++ b/backend/app/tests/api/node_tag/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/tag/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/tag/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_threat/test_read.py
+++ b/backend/app/tests/api/node_threat/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/threat/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/threat/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_threat_actor/test_read.py
+++ b/backend/app/tests/api/node_threat_actor/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/threat_actor/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/threat_actor/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_threat_type/test_read.py
+++ b/backend/app/tests/api/node_threat_type/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/node/threat/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/node/threat/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/observable/test_read.py
+++ b/backend/app/tests/api/observable/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/observable/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/observable/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/observable_type/test_read.py
+++ b/backend/app/tests/api/observable_type/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/observable/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/observable/type/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/test_auth.py
+++ b/backend/app/tests/api/test_auth.py
@@ -48,17 +48,17 @@ def test_disabled_user(client, db):
     headers = {"Authorization": f"Bearer {access_token}"}
     get = client.get("/api/user/", headers=headers)
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1
 
     # Disable the user
-    user_uuid = get.json()[0]["uuid"]
+    user_uuid = get.json()["items"][0]["uuid"]
     update = client.patch(f"/api/user/{user_uuid}", headers=headers, json={"enabled": False})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # The user is disabled, but the token is still valid, so they will still have access until it expires.
     get = client.get("/api/user/", headers=headers)
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1
 
     # However, they will not be able to authenticate again to receive a new token.
     auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
@@ -87,7 +87,7 @@ def test_expired_token(client, db, monkeypatch):
     # Attempt to use the token to access a protected API endpoint
     get = client.get("/api/user/", headers={"Authorization": f"Bearer {access_token}"})
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1
 
     # Wait for the token to expire
     time.sleep(2)
@@ -186,4 +186,4 @@ def test_auth_success(client, db):
     # Attempt to use the token to access a protected API endpoint
     get = client.get("/api/user/", headers={"Authorization": f"Bearer {access_token}"})
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1

--- a/backend/app/tests/api/test_auth_refresh.py
+++ b/backend/app/tests/api/test_auth_refresh.py
@@ -136,7 +136,7 @@ def test_auth_refresh_success(client, db, monkeypatch):
     # Attempt to use the token to access a protected API endpoint
     get = client.get("/api/user/", headers={"Authorization": f"Bearer {access_token}"})
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1
 
     # Wait for the access token to expire
     time.sleep(2)
@@ -157,4 +157,4 @@ def test_auth_refresh_success(client, db, monkeypatch):
     # Attempt to use the new access token to access a protected API endpoint
     get = client.get("/api/user/", headers={"Authorization": f"Bearer {new_access_token}"})
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1

--- a/backend/app/tests/api/test_auth_validate.py
+++ b/backend/app/tests/api/test_auth_validate.py
@@ -38,7 +38,7 @@ def test_expired_token(client, db, monkeypatch):
     # Attempt to use the token to access a protected API endpoint
     get = client.get("/api/user/", headers={"Authorization": f"Bearer {access_token}"})
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 1
+    assert get.json()["total"] == 1
 
     # Wait for the token to expire
     time.sleep(2)

--- a/backend/app/tests/api/user/test_read.py
+++ b/backend/app/tests/api/user/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/user/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/user/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/user_role/test_read.py
+++ b/backend/app/tests/api/user_role/test_read.py
@@ -33,10 +33,10 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/user/role/")
     assert get.status_code == status.HTTP_200_OK
-    assert len(get.json()) == 2
+    assert get.json()["total"] == 2
 
 
 def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/user/role/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == []
+    assert get.json()["total"] == 0

--- a/bin/test-backend.sh
+++ b/bin/test-backend.sh
@@ -6,7 +6,7 @@ set -a
 source "$ACE2_ENV_PATH"
 set +a
 
-# Remove the leading app/ from the command line argument so the path works inside of the container.
+# Remove the leading backend/app/ from the command line argument so the path works inside of the container.
 new_path=${1#backend/app/}
 
 docker-compose up -d

--- a/bin/test-frontend-unit.sh
+++ b/bin/test-frontend-unit.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-TEST_FILE=${1:---}
 
 # Load the environment variables for the dev containers
 ACE2_ENV_PATH="$HOME/.ace2.env"
@@ -7,5 +6,8 @@ set -a
 source "$ACE2_ENV_PATH"
 set +a
 
+# Remove the leading frontend/ from the command line argument so the path works inside of the container.
+TEST_FILE=${1#frontend/}
+
 docker-compose up -d
-docker exec ace2-ams-gui npm run test:unit $TEST_FILE --coverage
+docker exec ace2-ams-gui npm run test:unit "$TEST_FILE" --coverage

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -244,8 +244,6 @@
 
   import moment from "moment-timezone";
 
-  import ObservableInstance from "@/services/api/observableInstance";
-
   export default {
     name: "AnalyzeAlertForm",
     components: {
@@ -314,10 +312,10 @@
     methods: {
       ...mapActions({
         createAlert: "alerts/createAlert",
-        getAllAlertQueue: "alertQueue/getAll",
-        getAllAlertType: "alertType/getAll",
-        getAllNodeDirective: "nodeDirective/getAll",
-        getAllObservableType: "observableType/getAll",
+        readAllAlertQueue: "alertQueue/readAll",
+        readAllAlertType: "alertType/readAll",
+        readAllNodeDirective: "nodeDirective/readAll",
+        readAllObservableType: "observableType/readAll",
       }),
       initData() {
         this.alertDate = new Date();
@@ -331,10 +329,10 @@
         this.addFormObservable();
       },
       async initExternalData() {
-        await this.getAllAlertQueue();
-        await this.getAllAlertType();
-        await this.getAllNodeDirective();
-        await this.getAllObservableType();
+        await this.readAllAlertQueue();
+        await this.readAllAlertType();
+        await this.readAllNodeDirective();
+        await this.readAllObservableType();
       },
       adjustForTimezone(datetime, timezone) {
         return moment(datetime).tz(timezone).format();

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -95,6 +95,9 @@
             }}</Tag>
           </span>
         </div>
+        <span v-else-if="col.field.includes('Time')">
+          {{ formatDateTime(data[col.field]) }}</span
+        >
         <span v-else> {{ data[col.field] }}</span>
       </template>
     </Column>
@@ -289,6 +292,15 @@
 
       getAlertLink(uuid) {
         return "/alert/" + uuid;
+      },
+
+      formatDateTime(dateTime) {
+        if (dateTime) {
+          const d = new Date(dateTime);
+          return d.toLocaleString("en-US");
+        }
+
+        return "None";
       },
     },
   };

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -207,7 +207,7 @@
         alertUnselect: "selectedAlerts/unselect",
         alertUnselectAll: "selectedAlerts/unselectAll",
         alertSelectAll: "selectedAlerts/selectAll",
-        getAllAlerts: "alerts/getAll",
+        getAlertPage: "alerts/getPage",
       }),
 
       reset() {
@@ -250,7 +250,7 @@
       async loadAlerts() {
         this.isLoading = true;
         try {
-          await this.getAllAlerts({ ...this.pageOptions, ...this.filters });
+          await this.getAlertPage({ ...this.pageOptions, ...this.filters });
         } catch (error) {
           this.error = error.message || "Something went wrong!";
         }

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -83,7 +83,11 @@
       <template #body="{ data }">
         <!-- NAME COLUMN - INCL. TAGS AND TODO: ALERT ICONS-->
         <div v-if="col.field === 'name'">
-          <span class="p-m-1"> {{ data.name }}</span>
+          <span class="p-m-1">
+            <router-link :to="getAlertLink(data.uuid)">{{
+              data.name
+            }}</router-link></span
+          >
           <br />
           <span>
             <Tag v-for="tag in data.tags" :key="tag" class="p-mr-2" rounded>{{
@@ -281,6 +285,10 @@
           this.error = error.message || "Something went wrong!";
         }
         this.isLoading = false;
+      },
+
+      getAlertLink(uuid) {
+        return "/alert/" + uuid;
       },
     },
   };

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -156,8 +156,8 @@
 
         columns: [
           { field: "dispositionTime", header: "Dispositioned Time" },
-          { field: "insertTime", header: "Insert Date" },
-          { field: "eventTime", header: "Event Date" },
+          { field: "insertTime", header: "Insert Time" },
+          { field: "eventTime", header: "Event Time" },
           { field: "name", header: "Name" },
           { field: "owner", header: "Owner" },
           { field: "disposition", header: "Disposition" },

--- a/frontend/src/components/Modals/AssignModal.vue
+++ b/frontend/src/components/Modals/AssignModal.vue
@@ -97,7 +97,7 @@
       async loadUsers() {
         this.isLoading = true;
         try {
-          await this.$store.dispatch("users/getAll");
+          await this.$store.dispatch("users/readAll");
         } catch (error) {
           this.error = error.message || "Something went wrong!";
         }

--- a/frontend/src/models/alert.ts
+++ b/frontend/src/models/alert.ts
@@ -103,6 +103,7 @@ export interface alertFilterParams extends pageOptionParams {
   observableValue?: string;
   owner?: string;
   queue?: string;
+  sort?: string;
   tags?: string[];
   threatActor?: string;
   threats?: string[];

--- a/frontend/src/models/alert.ts
+++ b/frontend/src/models/alert.ts
@@ -1,57 +1,93 @@
 import { alertFilters } from "@/etc/constants";
-import { UUID } from "./base";
-import { genericObject } from "./base";
+import { pageOptionParams, UUID } from "./base";
+import { nodeCreate, nodeRead, nodeReadPage, nodeUpdate } from "./node";
+import { alertDispositionRead } from "./alertDisposition";
+import { alertQueueRead } from "./alertQueue";
+import { alertToolRead } from "./alertTool";
+import { alertToolInstanceRead } from "./alertToolInstance";
+import { alertTypeRead } from "./alertType";
+import { observableInstanceRead } from "./observableInstance";
+import { userRead } from "./user";
+import { nodeCommentRead } from "./nodeComment";
+import { nodeTagRead } from "./nodeTag";
 
-export type alert = {
-  comments?: genericObject[];
+export interface alertCreate extends nodeCreate {
   description?: string;
-  directives?: genericObject[];
-  disposition?: genericObject;
-  dispositionTime?: Date;
-  dispositionUser?: genericObject;
+  eventTime?: Date;
+  insertTime?: Date;
+  instructions?: string;
+  name: string;
+  observableInstances: { type: string; value: string }[];
+  owner?: string;
+  queue: string;
+  tool?: string;
+  toolInstance?: string;
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface alertSummaryRead extends nodeRead {
+  description: string | null;
+  disposition: alertDispositionRead | null;
+  dispositionTime: Date | null;
+  dispositionUser: userRead | null;
+  eventTime: Date;
+  eventUuid: UUID | null;
+  insertTime: Date;
+  instructions: string | null;
+  name: string;
+  owner: userRead | null;
+  queue: alertQueueRead;
+  tool: alertToolRead | null;
+  toolInstance: alertToolInstanceRead | null;
+  type: alertTypeRead;
+}
+
+// High-level alert data that will be displayed in Manage Alerts or in an event
+export interface alertTableSummary {
+  comments: nodeCommentRead[];
+  description: string;
+  disposition: string;
+  dispositionTime: Date | null;
+  dispositionUser: string;
+  eventTime: Date;
+  insertTime: Date;
+  name: string;
+  owner: string;
+  queue: string;
+  tags: nodeTagRead[];
+  tool: string;
+  type: string;
+  uuid: UUID;
+}
+
+export interface alertTreeRead {
+  alert: alertSummaryRead;
+  analyses: {
+    analysisModuleType: { uuid: UUID; value: string };
+    parentUuid: UUID | null;
+    uuid: UUID;
+  }[];
+  observableInstances: observableInstanceRead[];
+}
+
+export interface alertReadPage extends nodeReadPage {
+  items: alertSummaryRead[];
+}
+
+export interface alertUpdate extends nodeUpdate {
+  description?: string | null;
+  disposition?: string;
   eventTime?: Date;
   eventUuid?: UUID;
   insertTime?: Date;
-  instructions?: string;
-  name?: string;
-  owner?: genericObject;
-  queue?: genericObject;
-  tags?: genericObject[];
-  threatActor?: genericObject;
-  threats?: genericObject[];
-  tool?: genericObject;
-  toolInstance?: genericObject;
-  type?: genericObject;
-  uuid: UUID;
-  version?: UUID;
-};
+  instructions?: string | null;
+  owner?: string;
+  queue?: string;
+  [key: string]: unknown;
+}
 
-// High-level alert data that will be displayed in Manage Alerts or in an event
-export type alertSummary = {
-  comments: genericObject[];
-  description: string;
-  disposition: genericObject | string;
-  dispositionTime: Date | null;
-  dispositionUser: genericObject | string;
-  eventTime: Date | null;
-  insertTime: Date | null;
-  name: string;
-  owner: genericObject | string;
-  queue: genericObject | string;
-  tags: genericObject[];
-  tool: genericObject | string;
-  type: genericObject | string;
-  uuid: UUID;
-};
-
-export type alertGetAll = {
-  items: alert[];
-  limit: number;
-  offset: number;
-  total: number;
-};
-
-export type alertFilterParams = {
+export interface alertFilterParams extends pageOptionParams {
   disposition?: string;
   dispositionUser?: string;
   dispositionedAfter?: Date;
@@ -73,7 +109,7 @@ export type alertFilterParams = {
   tool?: string;
   toolInstance?: string;
   type?: string;
-};
+}
 
 export type alertFilterNames = typeof alertFilters[number];
 export type alertFilterValues =

--- a/frontend/src/models/alertDisposition.ts
+++ b/frontend/src/models/alertDisposition.ts
@@ -1,0 +1,22 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export interface alertDispositionCreate extends genericObjectCreate {
+  rank: number;
+}
+
+export interface alertDispositionRead extends genericObjectRead {
+  rank: number;
+}
+
+export interface alertDispositionReadPage extends genericObjectReadPage {
+  items: alertDispositionRead[];
+}
+
+export interface alertDispositionUpdate extends genericObjectUpdate {
+  rank?: number;
+}

--- a/frontend/src/models/alertQueue.ts
+++ b/frontend/src/models/alertQueue.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type alertQueueCreate = genericObjectCreate;
+
+export type alertQueueRead = genericObjectRead;
+
+export interface alertQueueReadPage extends genericObjectReadPage {
+  items: alertQueueRead[];
+}
+
+export type alertQueueUpdate = genericObjectUpdate;

--- a/frontend/src/models/alertTool.ts
+++ b/frontend/src/models/alertTool.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type alertToolCreate = genericObjectCreate;
+
+export type alertToolRead = genericObjectRead;
+
+export interface alertToolReadPage extends genericObjectReadPage {
+  items: alertToolRead[];
+}
+
+export type alertToolUpdate = genericObjectUpdate;

--- a/frontend/src/models/alertToolInstance.ts
+++ b/frontend/src/models/alertToolInstance.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type alertToolInstanceCreate = genericObjectCreate;
+
+export type alertToolInstanceRead = genericObjectRead;
+
+export interface alertToolInstanceReadPage extends genericObjectReadPage {
+  items: alertToolInstanceRead[];
+}
+
+export type alertToolInstanceUpdate = genericObjectUpdate;

--- a/frontend/src/models/alertType.ts
+++ b/frontend/src/models/alertType.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type alertTypeCreate = genericObjectCreate;
+
+export type alertTypeRead = genericObjectRead;
+
+export interface alertTypeReadPage extends genericObjectReadPage {
+  items: alertTypeRead[];
+}
+
+export type alertTypeUpdate = genericObjectUpdate;

--- a/frontend/src/models/analysis.ts
+++ b/frontend/src/models/analysis.ts
@@ -1,0 +1,31 @@
+import { UUID } from "./base";
+import { nodeCreate, nodeRead, nodeUpdate } from "./node";
+import { analysisModuleTypeRead } from "./analysisModuleType";
+
+export interface analysisCreate extends nodeCreate {
+  alertUuid: UUID;
+  analysisModuleType?: UUID;
+  details?: Record<string, unknown>;
+  errorMessage?: string;
+  parentUuid?: UUID;
+  stackTrace?: string;
+  summary?: string;
+}
+
+export interface analysisRead extends nodeRead {
+  alertUuid: UUID;
+  analysisModuleType: analysisModuleTypeRead;
+  details: Record<string, unknown> | null;
+  errorMessage: string | null;
+  parentUuid: UUID | null;
+  stackTrace: string | null;
+  summary: string | null;
+}
+
+export interface analysisUpdate extends nodeUpdate {
+  analysisModuleType?: UUID;
+  details?: Record<string, unknown> | null;
+  errorMessage?: string | null;
+  stackTrace?: string | null;
+  summary?: string | null;
+}

--- a/frontend/src/models/analysisModuleType.ts
+++ b/frontend/src/models/analysisModuleType.ts
@@ -1,0 +1,41 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+import { nodeDirectiveRead } from "./nodeDirective";
+import { nodeTagRead } from "./nodeTag";
+import { observableTypeRead } from "./observableType";
+
+export interface analysisModuleTypeCreate extends genericObjectCreate {
+  extendedVersion?: Record<string, unknown>;
+  manual?: boolean;
+  observableTypes?: string[];
+  requiredDirectives?: string[];
+  requiredTags?: string[];
+  version: string;
+}
+
+export interface analysisModuleTypeRead extends genericObjectRead {
+  extendedVersion: Record<string, unknown> | null;
+  manual: boolean;
+  observableTypes: observableTypeRead[];
+  requiredDirectives: nodeDirectiveRead[];
+  requiredTags: nodeTagRead[];
+  version: string;
+}
+
+export interface analysisModuleTypeReadPage extends genericObjectReadPage {
+  items: analysisModuleTypeRead[];
+}
+
+export interface analysisModuleTypeUpdate extends genericObjectUpdate {
+  extendedVersion?: Record<string, unknown> | null;
+  manual?: boolean;
+  observableTypes?: string[];
+  requiredDirectives?: string[];
+  requiredTags?: string[];
+  version?: string;
+}

--- a/frontend/src/models/api.ts
+++ b/frontend/src/models/api.ts
@@ -1,7 +1,0 @@
-import { genericObject, genericGetAll } from "./base";
-import { alert, alertGetAll, alertFilterParams } from "./alert";
-
-export type anyGetSingle = genericObject & alert;
-export type anyGetAll = genericGetAll & alertGetAll;
-export type pageOptionParams = { limit: number; offset: number };
-export type getAllParams = pageOptionParams & alertFilterParams;

--- a/frontend/src/models/base.ts
+++ b/frontend/src/models/base.ts
@@ -1,9 +1,38 @@
 export type UUID = string;
-export type genericObject = {
-  description: string;
+
+export interface genericObjectCreate {
+  description?: string;
+  uuid?: UUID;
   value: string;
+  [key: string]: unknown;
+}
+
+export interface genericObjectRead {
+  description: string | null;
   uuid: UUID;
-  rank?: string;
-  types?: string;
-};
-export type genericGetAll = genericObject[];
+  value: string;
+}
+
+export interface genericObjectReadPage extends page {
+  items: genericObjectRead[];
+}
+
+export interface genericObjectUpdate {
+  description?: string;
+  value?: string;
+  [key: string]: unknown;
+}
+
+export interface page {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  items: any[];
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface pageOptionParams {
+  limit?: number;
+  offset?: number;
+  [key: string]: unknown;
+}

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,0 +1,79 @@
+import { UUID } from "./base";
+import { eventPreventionToolRead } from "./eventPreventionTool";
+import { eventRemediationRead } from "./eventRemediation";
+import { eventRiskLevelRead } from "./eventRiskLevel";
+import { eventSourceRead } from "./eventSource";
+import { eventStatusRead } from "./eventStatus";
+import { eventTypeRead } from "./eventType";
+import { eventVectorRead } from "./eventVector";
+import { nodeCreate, nodeRead, nodeReadPage, nodeUpdate } from "./node";
+import { userRead } from "./user";
+
+export interface eventCreate extends nodeCreate {
+  alertTime?: Date;
+  containTime?: Date;
+  dispositionTime?: Date;
+  eventTime?: Date;
+  name: string;
+  owner?: string;
+  ownershipTime?: Date;
+  preventionTools?: string[];
+  remediationTime?: Date;
+  riskLevel?: string;
+  source?: string;
+  status?: string;
+  type?: string;
+  vectors?: string[];
+}
+
+export interface eventSummaryRead extends nodeRead {
+  alertTime: Date | null;
+  alertUuids: UUID[];
+  containTime: Date | null;
+  creationTime: Date;
+  dispositionTime: Date | null;
+  eventTime: Date | null;
+  name: string;
+  owner: userRead | null;
+  ownershipTime: Date | null;
+  preventionTools: eventPreventionToolRead[];
+  remediations: eventRemediationRead[];
+  remediationTime: Date | null;
+  riskLevel: eventRiskLevelRead | null;
+  source: eventSourceRead | null;
+  status: eventStatusRead | null;
+  type: eventTypeRead | null;
+  vectors: eventVectorRead[];
+}
+
+// TODO: Event pages are not implemented yet
+// export interface eventTreeRead {
+//   event: eventSummaryRead;
+//   analyses: {
+//     analysisModuleType: { uuid: UUID; value: string };
+//     parentUuid: UUID | null;
+//     uuid: UUID;
+//   }[];
+//   observableInstances: observableInstanceRead[];
+// }
+
+export interface eventReadPage extends nodeReadPage {
+  items: eventSummaryRead[];
+}
+
+export interface eventUpdate extends nodeUpdate {
+  alertTime?: Date | null;
+  containTime?: Date | null;
+  dispositionTime?: Date | null;
+  eventTime?: Date | null;
+  name?: string;
+  owner?: string | null;
+  ownershipTime?: Date | null;
+  preventionTools?: string[];
+  remediationTime?: Date | null;
+  riskLevel?: string | null;
+  source?: string | null;
+  status?: string | null;
+  type?: string | null;
+  vectors?: string[];
+}

--- a/frontend/src/models/eventPreventionTool.ts
+++ b/frontend/src/models/eventPreventionTool.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventPreventionToolCreate = genericObjectCreate;
+
+export type eventPreventionToolRead = genericObjectRead;
+
+export interface eventPreventionToolReadPage extends genericObjectReadPage {
+  items: eventPreventionToolRead[];
+}
+
+export type eventPreventionToolUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventRemediation.ts
+++ b/frontend/src/models/eventRemediation.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventRemediationCreate = genericObjectCreate;
+
+export type eventRemediationRead = genericObjectRead;
+
+export interface eventRemediationReadPage extends genericObjectReadPage {
+  items: eventRemediationRead[];
+}
+
+export type eventRemediationUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventRiskLevel.ts
+++ b/frontend/src/models/eventRiskLevel.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventRiskLevelCreate = genericObjectCreate;
+
+export type eventRiskLevelRead = genericObjectRead;
+
+export interface eventRiskLevelReadPage extends genericObjectReadPage {
+  items: eventRiskLevelRead[];
+}
+
+export type eventRiskLevelUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventSource.ts
+++ b/frontend/src/models/eventSource.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventSourceCreate = genericObjectCreate;
+
+export type eventSourceRead = genericObjectRead;
+
+export interface eventSourceReadPage extends genericObjectReadPage {
+  items: eventSourceRead[];
+}
+
+export type eventSourceUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventStatus.ts
+++ b/frontend/src/models/eventStatus.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventStatusCreate = genericObjectCreate;
+
+export type eventStatusRead = genericObjectRead;
+
+export interface eventStatusReadPage extends genericObjectReadPage {
+  items: eventStatusRead[];
+}
+
+export type eventStatusUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventType.ts
+++ b/frontend/src/models/eventType.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventTypeCreate = genericObjectCreate;
+
+export type eventTypeRead = genericObjectRead;
+
+export interface eventTypeReadPage extends genericObjectReadPage {
+  items: eventTypeRead[];
+}
+
+export type eventTypeUpdate = genericObjectUpdate;

--- a/frontend/src/models/eventVector.ts
+++ b/frontend/src/models/eventVector.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventVectorCreate = genericObjectCreate;
+
+export type eventVectorRead = genericObjectRead;
+
+export interface eventVectorReadPage extends genericObjectReadPage {
+  items: eventVectorRead[];
+}
+
+export type eventVectorUpdate = genericObjectUpdate;

--- a/frontend/src/models/node.ts
+++ b/frontend/src/models/node.ts
@@ -1,0 +1,40 @@
+import { UUID } from "./base";
+import { nodeCommentRead } from "./nodeComment";
+import { nodeDirectiveRead } from "./nodeDirective";
+import { nodeTagRead } from "./nodeTag";
+import { nodeThreatActorRead } from "./nodeThreatActor";
+import { nodeThreatRead } from "./nodeThreat";
+
+export interface nodeCreate {
+  directives?: string[];
+  tags?: string[];
+  threatActor?: string;
+  threats?: string[];
+  uuid?: UUID;
+  version?: UUID;
+}
+
+export interface nodeRead {
+  comments: nodeCommentRead[];
+  directives: nodeDirectiveRead[];
+  tags: nodeTagRead[];
+  threatActor: nodeThreatActorRead | null;
+  threats: nodeThreatRead[];
+  uuid: UUID;
+  version: UUID;
+}
+
+export interface nodeReadPage {
+  items: nodeRead[];
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface nodeUpdate {
+  directives?: string[];
+  tags?: string[];
+  threatActor?: string;
+  threats?: string[];
+  version: UUID;
+}

--- a/frontend/src/models/nodeComment.ts
+++ b/frontend/src/models/nodeComment.ts
@@ -1,0 +1,22 @@
+import { UUID } from "./base";
+import { userRead } from "./user";
+
+export interface nodeCommentCreate {
+  nodeUuid: UUID;
+  user: string;
+  uuid?: UUID;
+  value: string;
+}
+
+export interface nodeCommentRead {
+  insertTime: Date;
+  nodeUuid: UUID;
+  user: userRead;
+  uuid: UUID;
+  value: string;
+}
+
+export interface nodeCommentUpdate {
+  uuid: UUID;
+  value: string;
+}

--- a/frontend/src/models/nodeDirective.ts
+++ b/frontend/src/models/nodeDirective.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeDirectiveCreate = genericObjectCreate;
+
+export type nodeDirectiveRead = genericObjectRead;
+
+export interface nodeDirectiveReadPage extends genericObjectReadPage {
+  items: nodeDirectiveRead[];
+}
+
+export type nodeDirectiveUpdate = genericObjectUpdate;

--- a/frontend/src/models/nodeHistoryAction.ts
+++ b/frontend/src/models/nodeHistoryAction.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeHistoryActionCreate = genericObjectCreate;
+
+export type nodeHistoryActionRead = genericObjectRead;
+
+export interface nodeHistoryActionReadPage extends genericObjectReadPage {
+  items: nodeHistoryActionRead[];
+}
+
+export type nodeHistoryActionUpdate = genericObjectUpdate;

--- a/frontend/src/models/nodeTag.ts
+++ b/frontend/src/models/nodeTag.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeTagCreate = genericObjectCreate;
+
+export type nodeTagRead = genericObjectRead;
+
+export interface nodeTagReadPage extends genericObjectReadPage {
+  items: nodeTagRead[];
+}
+
+export type nodeTagUpdate = genericObjectUpdate;

--- a/frontend/src/models/nodeThreat.ts
+++ b/frontend/src/models/nodeThreat.ts
@@ -1,0 +1,24 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+import { nodeThreatTypeRead } from "./nodeThreatType";
+
+export interface nodeThreatCreate extends genericObjectCreate {
+  types: string[];
+}
+
+export interface nodeThreatRead extends genericObjectRead {
+  types: nodeThreatTypeRead[];
+}
+
+export interface nodeThreatReadPage extends genericObjectReadPage {
+  items: nodeThreatRead[];
+}
+
+export interface nodeThreatUpdate extends genericObjectUpdate {
+  types?: string[];
+}

--- a/frontend/src/models/nodeThreatActor.ts
+++ b/frontend/src/models/nodeThreatActor.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeThreatActorCreate = genericObjectCreate;
+
+export type nodeThreatActorRead = genericObjectRead;
+
+export interface nodeThreatActorReadPage extends genericObjectReadPage {
+  items: nodeThreatActorRead[];
+}
+
+export type nodeThreatActorUpdate = genericObjectUpdate;

--- a/frontend/src/models/nodeThreatType.ts
+++ b/frontend/src/models/nodeThreatType.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeThreatTypeCreate = genericObjectCreate;
+
+export type nodeThreatTypeRead = genericObjectRead;
+
+export interface nodeThreatTypeReadPage extends genericObjectReadPage {
+  items: nodeThreatTypeRead[];
+}
+
+export type nodeThreatTypeUpdate = genericObjectUpdate;

--- a/frontend/src/models/observable.ts
+++ b/frontend/src/models/observable.ts
@@ -1,0 +1,32 @@
+import { UUID } from "./base";
+import { observableTypeRead } from "./observableType";
+
+export interface observableCreate {
+  expiresOn?: Date;
+  forDetection: boolean;
+  type: string;
+  uuid?: UUID;
+  value: string;
+}
+
+export interface observableRead {
+  expiresOn: Date | null;
+  forDetection: boolean;
+  type: observableTypeRead;
+  uuid: UUID;
+  value: string;
+}
+
+export interface observableReadPage {
+  items: observableRead[];
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface observableUpdate {
+  expiresOn?: Date;
+  forDetection?: boolean;
+  type?: string;
+  value?: string;
+}

--- a/frontend/src/models/observableInstance.ts
+++ b/frontend/src/models/observableInstance.ts
@@ -1,0 +1,30 @@
+import { UUID } from "./base";
+import { nodeCreate, nodeRead, nodeUpdate } from "./node";
+import { observableRead } from "./observable";
+
+export interface observableInstanceCreate extends nodeCreate {
+  alertUuid: UUID;
+  context?: string;
+  parentUuid: UUID;
+  redirectionUuid?: UUID;
+  time?: Date;
+  type: string;
+  value: string;
+  [key: string]: unknown;
+}
+
+export interface observableInstanceRead extends nodeRead {
+  alertUuid: UUID;
+  context: string | null;
+  observable: observableRead;
+  parentUuid: UUID;
+  redirectionUuid: UUID | null;
+  time: Date;
+}
+
+export interface observableInstanceUpdate extends nodeUpdate {
+  context?: string;
+  redirectionUuid?: UUID;
+  time?: Date;
+  [key: string]: unknown;
+}

--- a/frontend/src/models/observableType.ts
+++ b/frontend/src/models/observableType.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type observableTypeCreate = genericObjectCreate;
+
+export type observableTypeRead = genericObjectRead;
+
+export interface observableTypeReadPage extends genericObjectReadPage {
+  items: observableTypeRead[];
+}
+
+export type observableTypeUpdate = genericObjectUpdate;

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -1,0 +1,46 @@
+import { UUID } from "./base";
+import { alertQueueRead } from "./alertQueue";
+import { userRoleRead } from "./userRole";
+
+export interface userCreate {
+  defaultAlertQueue: string;
+  displayName: string;
+  email: string;
+  enabled?: boolean;
+  roles: string[];
+  timezone?: string;
+  username: string;
+  password: string;
+  uuid?: UUID;
+  [key: string]: unknown;
+}
+
+export interface userRead {
+  defaultAlertQueue: alertQueueRead;
+  displayName: string;
+  email: string;
+  enabled: boolean;
+  roles: userRoleRead[];
+  timezone: string;
+  username: string;
+  uuid: UUID;
+}
+
+export interface userReadPage {
+  items: userRead[];
+  limit: number;
+  offset: number;
+  total: number;
+}
+
+export interface userUpdate {
+  defaultAlertQueue?: string;
+  displayName?: string;
+  email?: string;
+  enabled?: boolean;
+  roles?: string[];
+  timezone?: string;
+  username?: string;
+  password?: string;
+  [key: string]: unknown;
+}

--- a/frontend/src/models/userRole.ts
+++ b/frontend/src/models/userRole.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type userRoleCreate = genericObjectCreate;
+
+export type userRoleRead = genericObjectRead;
+
+export interface userRoleReadPage extends genericObjectReadPage {
+  items: userRoleRead[];
+}
+
+export type userRoleUpdate = genericObjectUpdate;

--- a/frontend/src/services/api/alertQueue.ts
+++ b/frontend/src/services/api/alertQueue.ts
@@ -1,3 +1,33 @@
-import { GenericEndpoint } from "./base";
+import {
+  alertQueueCreate,
+  alertQueueRead,
+  alertQueueReadPage,
+  alertQueueUpdate,
+} from "@/models/alertQueue";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/alert/queue/");
+const api = new BaseApi();
+const endpoint = "/alert/queue/";
+
+export const AlertQueue = {
+  create: (data: alertQueueCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<alertQueueRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<alertQueueRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<alertQueueReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: alertQueueUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/alertType.ts
+++ b/frontend/src/services/api/alertType.ts
@@ -1,3 +1,26 @@
-import { GenericEndpoint } from "./base";
+import {
+  alertTypeCreate,
+  alertTypeRead,
+  alertTypeReadPage,
+  alertTypeUpdate,
+} from "@/models/alertType";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/alert/type/");
+const api = new BaseApi();
+const endpoint = "/alert/type/";
+
+export const AlertType = {
+  create: (data: alertTypeCreate, getAfterCreate = false): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<alertTypeRead> => api.read(`${endpoint}${uuid}`),
+
+  readAll: (): Promise<alertTypeRead[]> => api.readAll(endpoint),
+
+  readPage: (params?: pageOptionParams): Promise<alertTypeReadPage> =>
+    api.read(`${endpoint}`, params),
+
+  update: (uuid: UUID, data: alertTypeUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/services/api/alerts.ts
+++ b/frontend/src/services/api/alerts.ts
@@ -1,3 +1,25 @@
-import { GenericEndpoint } from "./base";
+import {
+  alertCreate,
+  alertFilterParams,
+  alertReadPage,
+  alertTreeRead,
+  alertUpdate,
+} from "@/models/alert";
+import { UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/alert/");
+const api = new BaseApi();
+const endpoint = "/alert/";
+
+export const Alert = {
+  create: (data: alertCreate, getAfterCreate = true): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<alertTreeRead> => api.read(`${endpoint}${uuid}`),
+
+  readPage: (params?: alertFilterParams): Promise<alertReadPage> =>
+    api.read(`${endpoint}`, params),
+
+  update: (uuid: UUID, data: alertUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/services/api/axios.ts
+++ b/frontend/src/services/api/axios.ts
@@ -18,6 +18,10 @@ instance.interceptors.response.use(
   },
 
   async function (error) {
+    if (typeof error.response === "undefined") {
+      throw error;
+    }
+
     // Reject the promise if it was not a 401 error
     if (error.response.status !== 401) {
       return Promise.reject(error);

--- a/frontend/src/services/api/nodeDirective.ts
+++ b/frontend/src/services/api/nodeDirective.ts
@@ -1,3 +1,27 @@
-import { GenericEndpoint } from "./base";
+import {
+  nodeDirectiveCreate,
+  nodeDirectiveRead,
+  nodeDirectiveReadPage,
+  nodeDirectiveUpdate,
+} from "@/models/nodeDirective";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/node/directive/");
+const api = new BaseApi();
+const endpoint = "/node/directive/";
+
+export const NodeDirective = {
+  create: (data: nodeDirectiveCreate, getAfterCreate = false): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<nodeDirectiveRead> =>
+    api.read(`${endpoint}${uuid}`),
+
+  readAll: (): Promise<nodeDirectiveRead[]> => api.readAll(endpoint),
+
+  readPage: (params?: pageOptionParams): Promise<nodeDirectiveReadPage> =>
+    api.read(`${endpoint}`, params),
+
+  update: (uuid: UUID, data: nodeDirectiveUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/services/api/observableInstance.ts
+++ b/frontend/src/services/api/observableInstance.ts
@@ -1,9 +1,23 @@
-import { GenericEndpoint } from "./base";
+import {
+  observableInstanceCreate,
+  observableInstanceRead,
+  observableInstanceUpdate,
+} from "@/models/observableInstance";
+import { UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-class observableInstance extends GenericEndpoint {
-  getAll() {
-    return Promise.reject(Error("Not implemented."));
-  }
-}
+const api = new BaseApi();
+const endpoint = "/observable/instance/";
 
-export default new observableInstance("/observable/instance/");
+export const ObservableInstance = {
+  create: (
+    data: observableInstanceCreate,
+    getAfterCreate = false,
+  ): Promise<void> => api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<observableInstanceRead> =>
+    api.read(`${endpoint}${uuid}`),
+
+  update: (uuid: UUID, data: observableInstanceUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/services/api/observableType.ts
+++ b/frontend/src/services/api/observableType.ts
@@ -1,3 +1,27 @@
-import { GenericEndpoint } from "./base";
+import {
+  observableTypeCreate,
+  observableTypeRead,
+  observableTypeReadPage,
+  observableTypeUpdate,
+} from "@/models/observableType";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/observable/type/");
+const api = new BaseApi();
+const endpoint = "/observable/type/";
+
+export const ObservableType = {
+  create: (data: observableTypeCreate, getAfterCreate = false): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<observableTypeRead> =>
+    api.read(`${endpoint}${uuid}`),
+
+  readAll: (): Promise<observableTypeRead[]> => api.readAll(endpoint),
+
+  readPage: (params?: pageOptionParams): Promise<observableTypeReadPage> =>
+    api.read(`${endpoint}`, params),
+
+  update: (uuid: UUID, data: observableTypeUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/services/api/users.ts
+++ b/frontend/src/services/api/users.ts
@@ -1,3 +1,21 @@
-import { GenericEndpoint } from "./base";
+import { userCreate, userRead, userReadPage, userUpdate } from "@/models/user";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
 
-export default new GenericEndpoint("/user/");
+const api = new BaseApi();
+const endpoint = "/user/";
+
+export const User = {
+  create: (data: userCreate, getAfterCreate = false): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<userRead> => api.read(`${endpoint}${uuid}`),
+
+  readAll: (): Promise<userRead[]> => api.readAll(endpoint),
+
+  readPage: (params?: pageOptionParams): Promise<userReadPage> =>
+    api.read(`${endpoint}`, params),
+
+  update: (uuid: UUID, data: userUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};

--- a/frontend/src/store/generic.ts
+++ b/frontend/src/store/generic.ts
@@ -1,20 +1,20 @@
-// Taken from: https://markus.oberlehner.net/blog/generic-content-vuex-modules/
+/* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { genericObject } from "@/models/base";
+// Taken from: https://markus.oberlehner.net/blog/generic-content-vuex-modules/
 
 // Many of our API calls serve solely to get a list of data types from the backend to display in the GUI
 // To reduce the number of nearly identical vuex stores, we can use this base vuex module
-// Note that only the getAll action is implemented at the moment
+// Note that only the readAll action is implemented at the moment
 // As the need arises for more actions/state complexity, that can be added to this module
 
 export default function makeGenericModule(service: any = {}): {
   namespaced: boolean;
-  state: { items: genericObject[] };
+  state: { items: any[] };
   getters: {
     allItems: (state: any, getters: any) => any;
   };
   mutations: { addItems: (state: any, items: any[]) => void };
-  actions: { getAll: ({ commit }: { commit: any }) => Promise<void> };
+  actions: { readAll: ({ commit }: { commit: any }) => Promise<void> };
 } {
   return {
     namespaced: true,
@@ -35,13 +35,13 @@ export default function makeGenericModule(service: any = {}): {
     },
 
     actions: {
-      getAll: async ({ commit }) => {
+      readAll: async ({ commit }) => {
         // It is not strictly necessary to pass a service,
         // but if none was passed, no data can be loaded.
         if (!service) throw new Error("No service specified!");
 
         return await service
-          .getAll()
+          .readAll()
           .then((items: any[]) => {
             commit("addItems", items);
           })

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -1,16 +1,16 @@
 import { Commit, createStore } from "vuex";
 
 import makeGenericModule from "@/store/generic";
-import alertQueue from "@/services/api/alertQueue";
-import alertType from "@/services/api/alertType";
-import observableType from "@/services/api/observableType";
+import { AlertQueue } from "@/services/api/alertQueue";
+import { AlertType } from "@/services/api/alertType";
+import { ObservableType } from "@/services/api/observableType";
 import auth from "@/store/auth";
 import alerts from "@/store/alerts";
 import filters from "@/store/filters";
 import modals from "@/store/modals";
-import nodeDirective from "@/services/api/nodeDirective";
+import { NodeDirective } from "@/services/api/nodeDirective";
 import selectedAlerts from "@/store/selectedAlerts";
-import users from "@/services/api/users";
+import { User } from "@/services/api/users";
 
 export interface CommitFunction {
   commit: Commit;
@@ -29,10 +29,10 @@ const store = createStore({
   },
 });
 
-store.registerModule("alertQueue", makeGenericModule(alertQueue));
-store.registerModule("alertType", makeGenericModule(alertType));
-store.registerModule("nodeDirective", makeGenericModule(nodeDirective));
-store.registerModule("observableType", makeGenericModule(observableType));
-store.registerModule("users", makeGenericModule(users));
+store.registerModule("alertQueue", makeGenericModule(AlertQueue));
+store.registerModule("alertType", makeGenericModule(AlertType));
+store.registerModule("nodeDirective", makeGenericModule(NodeDirective));
+store.registerModule("observableType", makeGenericModule(ObservableType));
+store.registerModule("users", makeGenericModule(User));
 
 export default store;

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -29,9 +29,9 @@ describe("TheAlertsTable.vue", () => {
   it("has default columns visible", () => {
     cy.get(".p-multiselect-label").should(
       "have.text",
-      "Event Date, Name, Owner, Disposition",
+      "Event Time, Name, Owner, Disposition",
     );
-    cy.get("tr > .p-highlight").should("have.text", "Event Date");
+    cy.get("tr > .p-highlight").should("have.text", "Event Time");
     cy.get(".p-datatable-thead > tr > :nth-child(4)").should(
       "have.text",
       "Name",
@@ -54,7 +54,7 @@ describe("TheAlertsTable.vue", () => {
     // Test that all of the selected columns are there
     cy.get(".p-multiselect-label").should(
       "have.text",
-      "Dispositioned Time, Insert Date, Event Date, Name, Owner, Disposition, Dispositioned By, Queue, Type",
+      "Dispositioned Time, Insert Time, Event Time, Name, Owner, Disposition, Dispositioned By, Queue, Type",
     );
     // Close the column multiselect
     cy.get(".p-multiselect-close").click();
@@ -65,7 +65,7 @@ describe("TheAlertsTable.vue", () => {
     // Test that it's gone back to the normal columns
     cy.get(".p-multiselect-label").should(
       "have.text",
-      "Event Date, Name, Owner, Disposition",
+      "Event Time, Name, Owner, Disposition",
     );
   });
 

--- a/frontend/tests/unit/src/components/Alerts/AnalyzeAlertForm.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AnalyzeAlertForm.spec.ts
@@ -311,10 +311,19 @@ describe("AnalyzeAlertForm async methods", () => {
     'Could not create alert Manual Alert: Error: Request failed with status code 404 "Create failed"';
 
   beforeEach(async () => {
-    myNock.persist().get("/alert/queue/").reply(200, ["default"]);
-    myNock.persist().get("/alert/type/").reply(200, ["manual"]);
-    myNock.persist().get("/node/directive/").reply(200, []);
-    myNock.persist().get("/observable/type/").reply(200, ["file", "ipv4"]);
+    myNock
+      .persist()
+      .get("/alert/queue/?offset=0")
+      .reply(200, { items: ["default"] });
+    myNock
+      .persist()
+      .get("/alert/type/?offset=0")
+      .reply(200, { items: ["manual"] });
+    myNock.persist().get("/node/directive/?offset=0").reply(200, { items: [] });
+    myNock
+      .persist()
+      .get("/observable/type/?offset=0")
+      .reply(200, { items: ["file", "ipv4"] });
     wrapper.vm.initData();
     await wrapper.vm.initExternalData();
     expectedAlertCreate.eventTime = moment(wrapper.vm.alertDate)

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -87,7 +87,7 @@ describe("TheAlertsTable data/creation", () => {
       global: { matchMode: "contains", value: null },
     });
     expect(wrapper.vm.selectedColumns).toStrictEqual([
-      { field: "eventTime", header: "Event Date" },
+      { field: "eventTime", header: "Event Time" },
       { field: "name", header: "Name" },
       { field: "owner", header: "Owner" },
       { field: "disposition", header: "Disposition" },
@@ -96,8 +96,8 @@ describe("TheAlertsTable data/creation", () => {
     expect(wrapper.vm.expandedRows).toStrictEqual([]);
     expect(wrapper.vm.columns).toStrictEqual([
       { field: "dispositionTime", header: "Dispositioned Time" },
-      { field: "insertTime", header: "Insert Date" },
-      { field: "eventTime", header: "Event Date" },
+      { field: "insertTime", header: "Insert Time" },
+      { field: "eventTime", header: "Event Time" },
       { field: "name", header: "Name" },
       { field: "owner", header: "Owner" },
       { field: "disposition", header: "Disposition" },
@@ -166,7 +166,7 @@ describe("TheAlertsTable methods success", () => {
     });
     wrapper.vm.reset();
     expect(wrapper.vm.selectedColumns).toStrictEqual([
-      { field: "eventTime", header: "Event Date" },
+      { field: "eventTime", header: "Event Time" },
       { field: "name", header: "Name" },
       { field: "owner", header: "Owner" },
       { field: "disposition", header: "Disposition" },

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -14,6 +14,31 @@ import Button from "primevue/button";
 import Column from "primevue/column";
 import Paginator from "primevue/paginator";
 import nock from "nock";
+import { alertSummaryRead } from "@/models/alert";
+
+const mockAPIAlert: alertSummaryRead = {
+  comments: [],
+  description: "",
+  directives: [],
+  disposition: null,
+  dispositionTime: null,
+  dispositionUser: null,
+  eventTime: new Date(0),
+  eventUuid: null,
+  insertTime: new Date(0),
+  instructions: null,
+  name: "Test Alert",
+  owner: null,
+  queue: { value: "Default", description: "queue", uuid: "uuid1" },
+  tags: [],
+  threatActor: null,
+  threats: [],
+  tool: null,
+  toolInstance: null,
+  type: { value: "Manual", description: "type", uuid: "uuid1" },
+  uuid: "uuid1",
+  version: "uuid2",
+};
 
 // DATA/CREATION
 describe("TheAlertsTable data/creation", () => {
@@ -28,7 +53,7 @@ describe("TheAlertsTable data/creation", () => {
     myNock
       .get("/alert/?limit=10&offset=0")
       .reply(200, {
-        items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
+        items: [mockAPIAlert, mockAPIAlert],
         total: 2,
       })
       .persist();
@@ -114,7 +139,7 @@ describe("TheAlertsTable methods success", () => {
     myNock
       .get("/alert/?limit=10&offset=0")
       .reply(200, {
-        items: [{ uuid: "alert_1" }, { uuid: "alert_2" }],
+        items: [mockAPIAlert, mockAPIAlert],
         total: 2,
       })
       .persist();
@@ -160,7 +185,7 @@ describe("TheAlertsTable methods success", () => {
       .get("/alert/?limit=1&offset=1")
       .thrice()
       .reply(200, {
-        items: [{ uuid: "alert_2" }],
+        items: [mockAPIAlert],
         total: 2,
       });
     await wrapper.vm.onPage({ rows: 1, page: 1 });

--- a/frontend/tests/unit/src/components/mockStore.ts
+++ b/frontend/tests/unit/src/components/mockStore.ts
@@ -56,7 +56,7 @@ const usersStore = {
   mutations: usersMutations,
 
   actions: {
-    getAll({ commit }: CommitFunction) {
+    readAll({ commit }: CommitFunction) {
       let promise = Promise.resolve<Array<string> | Error>(["Alice", "Bob"]);
 
       if (testVars.errorCondition) {

--- a/frontend/tests/unit/src/services/api/alertQueue.spec.ts
+++ b/frontend/tests/unit/src/services/api/alertQueue.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * @jest-environment node
+ */
+
+import snakecaseKeys from "snakecase-keys";
+import { AlertQueue } from "@/services/api/alertQueue";
+import myNock from "@unit/services/api/nock";
+import { alertQueueCreate, alertQueueRead } from "@/models/alertQueue";
+
+describe("AlertQueue API calls", () => {
+  const successMessage = "Request successful";
+  const secondSuccessMessage = "Request 2 successful";
+  const failureMessage = "Request failed";
+  const mockObjectCreate: alertQueueCreate = {
+    description: "This is an alert queue",
+    value: "Test",
+  };
+  const mockObjectRead: alertQueueRead = {
+    uuid: "1",
+    description: "This is an alert queue",
+    value: "Test",
+  };
+
+  it("will make only a post request when create is called and return create results if getAfterCreate is false and there is NOT a content-location header", async () => {
+    myNock
+      .post("/alert/queue/", JSON.stringify(snakecaseKeys(mockObjectCreate)))
+      .reply(200, successMessage);
+
+    const res = await AlertQueue.create(mockObjectCreate, false);
+    expect(res).toEqual(successMessage);
+  });
+
+  it("will make only a post request when create is called and return create results if getAfterCreate is false and there is a content-location header", async () => {
+    myNock
+      .post("/alert/queue/", JSON.stringify(snakecaseKeys(mockObjectCreate)))
+      .reply(200, successMessage, {
+        "content-location": "http://test_app.com:1234/newItem",
+      });
+
+    const res = await AlertQueue.create(mockObjectCreate, false);
+    expect(res).toEqual(successMessage);
+  });
+
+  it("will make only a post request when create is called and return create results if getAfterCreate is true and there is NOT a content-location header", async () => {
+    myNock
+      .post("/alert/queue/", JSON.stringify(snakecaseKeys(mockObjectCreate)))
+      .reply(200, successMessage);
+
+    const res = await AlertQueue.create(mockObjectCreate);
+    expect(res).toEqual(successMessage);
+  });
+
+  it("will make a post and get request when create is called and return GET results if getAfterCreate is true and there is a content-location header", async () => {
+    myNock
+      .post("/alert/queue/", JSON.stringify(snakecaseKeys(mockObjectCreate)))
+      .reply(200, successMessage, {
+        "content-location": "http://test_app.com:1234/newItem",
+      })
+      .get("/newItem")
+      .reply(200, secondSuccessMessage);
+
+    const res = await AlertQueue.create(mockObjectCreate, true);
+    expect(res).toEqual(secondSuccessMessage);
+  });
+
+  it("will make a get request to /alert/queue/{uuid} when getSingle is called", async () => {
+    myNock.get("/alert/queue/1").reply(200, successMessage);
+
+    const res = await AlertQueue.read("1");
+    expect(res).toEqual(successMessage);
+  });
+
+  it("will make a get request to /alert/queue/ when readAll is called", async () => {
+    myNock
+      .get("/alert/queue/?offset=0")
+      .reply(200, JSON.stringify({ items: [mockObjectRead, mockObjectRead] }));
+
+    const res = await AlertQueue.readAll();
+    expect(res).toEqual([mockObjectRead, mockObjectRead]);
+  });
+
+  it("will make a patch request to /alert/queue/{uuid} when updateSingle is called", async () => {
+    myNock
+      .patch("/alert/queue/1", JSON.stringify({ value: "New Name" }))
+      .reply(200, successMessage);
+
+    const res = await AlertQueue.update("1", { value: "New Name" });
+    expect(res).toEqual(successMessage);
+  });
+
+  it("will throw an error if a request fails", async () => {
+    myNock.get("/alert/queue/1").reply(404, failureMessage);
+
+    await expect(AlertQueue.read("1")).rejects.toEqual(
+      new Error("Request failed with status code 404"),
+    );
+  });
+});

--- a/frontend/tests/unit/src/services/api/base.spec.ts
+++ b/frontend/tests/unit/src/services/api/base.spec.ts
@@ -2,8 +2,7 @@
  * @jest-environment node
  */
 
-import snakecaseKeys from "snakecase-keys";
-import { BaseApi, GenericEndpoint } from "@/services/api/base";
+import { BaseApi } from "@/services/api/base";
 import myNock from "@unit/services/api/nock";
 
 describe("BaseAPI calls", () => {
@@ -17,13 +16,13 @@ describe("BaseAPI calls", () => {
       })
       .get("/newItem")
       .reply(200, "Read successful");
-    const res = await api.createRequest("/create");
+    const res = await api.create("/create", {}, true);
     expect(res).toEqual("Read successful");
   });
 
   it("will make only a post request when getAfterCreate is true and there is NOT a 'content-location' header", async () => {
     myNock.post("/create").reply(200, "Create successful");
-    const res = await api.createRequest("/create");
+    const res = await api.create("/create", {}, true);
     expect(res).toEqual("Create successful");
   });
 
@@ -31,42 +30,46 @@ describe("BaseAPI calls", () => {
     myNock.post("/create").reply(200, "Create successful", {
       "content-location": "http://test_app.com:1234/newItem",
     });
-    const res = await api.createRequest("/create", {}, false);
+    const res = await api.create("/create", {}, false);
     expect(res).toEqual("Create successful");
   });
 
   it("will make only a post request when getAfterCreate is false and there is NOT a 'content-location' header", async () => {
     myNock.post("/create").reply(200, "Create successful");
-    const res = await api.createRequest("/create", {}, false);
+    const res = await api.create("/create", {}, false);
     expect(res).toEqual("Create successful");
   });
 
   it("make a get request when readRequest called", async () => {
     myNock.get("/read").reply(200, "Read successful");
-    const res = await api.readRequest("/read");
+    const res = await api.read("/read");
     expect(res).toEqual("Read successful");
   });
 
   it("make a patch request when updateRequest called", async () => {
     myNock.patch("/update").reply(200, "Update successful");
-    const res = await api.updateRequest("/update");
+    const res = await api.update("/update");
     expect(res).toEqual("Update successful");
   });
 
   it("will format outgoing data into snake_case keys", async () => {
     myNock
       .post("/create", { first_key: "A", second_key: 2 })
-      .reply(200, "Update successful");
-    const res = await api.createRequest("/create", {
-      firstKey: "A",
-      secondKey: 2,
-    });
-    expect(res).toEqual("Update successful");
+      .reply(200, "Create successful");
+    const res = await api.create(
+      "/create",
+      {
+        firstKey: "A",
+        secondKey: 2,
+      },
+      false,
+    );
+    expect(res).toEqual("Create successful");
   });
 
   it("will format incoming data into camelCase keys", async () => {
     myNock.post("/create").reply(200, { first_key: "A", second_key: 2 });
-    const res = await api.createRequest("/create");
+    const res = await api.create("/create", {}, false);
     expect(res).toEqual({
       firstKey: "A",
       secondKey: 2,
@@ -78,7 +81,7 @@ describe("BaseAPI calls", () => {
       { first_key: "A", second_key: 2 },
       { third_key: "B", fourth_key: 3 },
     ]);
-    const res = await api.createRequest("/create");
+    const res = await api.create("/create", {}, false);
     expect(res).toEqual([
       {
         firstKey: "A",
@@ -93,90 +96,13 @@ describe("BaseAPI calls", () => {
 
   it("will correctly format URL parameters when given", async () => {
     myNock.get("/read?limit=5&offset=0").reply(200, "Read successful");
-    const res = await api.readRequest("/read", { limit: 5, offset: 0 });
+    const res = await api.read("/read", { limit: 5, offset: 0 });
     expect(res).toEqual("Read successful");
   });
 
   it("will throw an error if a request completes, but without a successful response code", async () => {
     myNock.patch("/update").reply(404, "Not found :(");
-    await expect(api.updateRequest("/update")).rejects.toEqual(
-      new Error("Request failed with status code 404"),
-    );
-  });
-});
-
-describe("generic API calls", () => {
-  const genericObject = new GenericEndpoint("/object/");
-  const successMessage = "Request successful";
-  const secondSuccessMessage = "Request 2 successful";
-  const failureMessage = "Request failed";
-  const mockObject = {
-    uuid: "1",
-    name: "Test",
-  };
-
-  it("will make only a post request when create is called and return create results if getAfterCreate is false and there is NOT a content-location header", async () => {
-    myNock
-      .post("/object/", JSON.stringify(snakecaseKeys(mockObject)))
-      .reply(200, successMessage);
-
-    const res = await genericObject.create(mockObject, false);
-    expect(res).toEqual(successMessage);
-  });
-  it("will make only a post request when create is called and return create results if getAfterCreate is false and there is a content-location header", async () => {
-    myNock
-      .post("/object/", JSON.stringify(snakecaseKeys(mockObject)))
-      .reply(200, successMessage, {
-        "content-location": "http://test_app.com:1234/newItem",
-      });
-
-    const res = await genericObject.create(mockObject, false);
-    expect(res).toEqual(successMessage);
-  });
-  it("will make only a post request when create is called and return create results if getAfterCreate is true and there is NOT a content-location header", async () => {
-    myNock
-      .post("/object/", JSON.stringify(snakecaseKeys(mockObject)))
-      .reply(200, successMessage);
-
-    const res = await genericObject.create(mockObject);
-    expect(res).toEqual(successMessage);
-  });
-  it("will make a post and get request when create is called and return GET results if getAfterCreate is true and there is a content-location header", async () => {
-    myNock
-      .post("/object/", JSON.stringify(snakecaseKeys(mockObject)))
-      .reply(200, successMessage, {
-        "content-location": "http://test_app.com:1234/newItem",
-      })
-      .get("/newItem")
-      .reply(200, secondSuccessMessage);
-
-    const res = await genericObject.create(mockObject);
-    expect(res).toEqual(secondSuccessMessage);
-  });
-  it("will make a get request to /object/{uuid} when getSingle is called", async () => {
-    myNock.get("/object/1").reply(200, successMessage);
-
-    const res = await genericObject.getSingle("1");
-    expect(res).toEqual(successMessage);
-  });
-  it("will make a get request to /object/ when getAll is called", async () => {
-    myNock.get("/object/").reply(200, JSON.stringify([mockObject, mockObject]));
-
-    const res = await genericObject.getAll();
-    expect(res).toEqual([mockObject, mockObject]);
-  });
-  it("will make a patch request to /object/{uuid} when updateSingle is called", async () => {
-    myNock
-      .patch("/object/1", JSON.stringify({ name: "New Name" }))
-      .reply(200, successMessage);
-
-    const res = await genericObject.updateSingle({ name: "New Name" }, "1");
-    expect(res).toEqual(successMessage);
-  });
-  it("will throw an error if a request fails", async () => {
-    myNock.get("/object/1").reply(404, failureMessage);
-
-    await expect(genericObject.getSingle("1")).rejects.toEqual(
+    await expect(api.update("/update")).rejects.toEqual(
       new Error("Request failed with status code 404"),
     );
   });

--- a/frontend/tests/unit/src/store/alerts.spec.ts
+++ b/frontend/tests/unit/src/store/alerts.spec.ts
@@ -7,6 +7,9 @@ import alerts from "@/store/alerts";
 import { parseAlertSummary } from "@/store/alerts";
 import myNock from "@unit/services/api/nock";
 import snakecaseKeys from "snakecase-keys";
+import { userRead } from "@/models/user";
+import { nodeCommentRead } from "@/models/nodeComment";
+import { alertSummaryRead } from "@/models/alert";
 
 const actions = alerts.actions;
 const mutations = alerts.mutations;
@@ -37,53 +40,112 @@ const mockAlert = {
   uuid: "uuid1",
 };
 
-const mockAPIAlert = {
-  comments: [{ value: "A comment", description: "comment", uuid: "uuid1" }],
-  description: "A test alert",
-  disposition: { value: "False Positive", description: "fp", uuid: "uuid1" },
-  dispositionTime: new Date(0),
-  dispositionUser: { value: "Analyst", description: "user", uuid: "uuid1" },
-  eventTime: new Date(0),
+const mockUser: userRead = {
+  defaultAlertQueue: {
+    value: "Default",
+    description: "queue",
+    uuid: "uuid1",
+  },
+  displayName: "Imma Analyst",
+  email: "analyst@company.com",
+  enabled: true,
+  roles: [{ value: "test_role", description: null, uuid: "uuid1" }],
+  timezone: "UTC",
+  username: "analyst",
+  uuid: "uuid1",
+};
+
+const mockComment: nodeCommentRead = {
   insertTime: new Date(0),
+  nodeUuid: "uuid1",
+  user: mockUser,
+  uuid: "uuid1",
+  value: "A comment",
+};
+
+const mockAPIAlert: alertSummaryRead = {
+  comments: [],
+  description: "",
+  directives: [],
+  disposition: null,
+  dispositionTime: null,
+  dispositionUser: null,
+  eventTime: new Date(0),
+  eventUuid: null,
+  insertTime: new Date(0),
+  instructions: null,
   name: "Test Alert",
-  owner: { value: "Analyst", description: "user", uuid: "uuid1" },
+  owner: null,
   queue: { value: "Default", description: "queue", uuid: "uuid1" },
-  tags: [{ value: "a tag", description: "tag", uuid: "uuid1" }],
-  tool: { value: "GUI", description: "tool", uuid: "uuid1" },
+  tags: [],
+  threatActor: null,
+  threats: [],
+  tool: null,
+  toolInstance: null,
   type: { value: "Manual", description: "type", uuid: "uuid1" },
   uuid: "uuid1",
+  version: "uuid2",
+};
+
+const mockAPIAlertOptionalProperties: alertSummaryRead = {
+  comments: [mockComment],
+  description: "A test alert",
+  directives: [],
+  disposition: {
+    value: "False Positive",
+    description: "fp",
+    rank: 1,
+    uuid: "uuid1",
+  },
+  dispositionTime: new Date(0),
+  dispositionUser: mockUser,
+  eventTime: new Date(0),
+  eventUuid: null,
+  insertTime: new Date(0),
+  instructions: null,
+  name: "Test Alert",
+  owner: mockUser,
+  queue: { value: "Default", description: "queue", uuid: "uuid1" },
+  tags: [{ value: "a tag", description: "tag", uuid: "uuid1" }],
+  threatActor: null,
+  threats: [],
+  tool: { value: "GUI", description: null, uuid: "uuid1" },
+  toolInstance: null,
+  type: { value: "Manual", description: "type", uuid: "uuid1" },
+  uuid: "uuid1",
+  version: "uuid2",
 };
 
 describe("alerts utilities", () => {
   it("will use default values when parsing an API alert object that has missing properties", () => {
-    expect(parseAlertSummary({ uuid: "uuid1" })).toStrictEqual({
+    expect(parseAlertSummary(mockAPIAlert)).toStrictEqual({
       comments: [],
       description: "",
       disposition: "OPEN",
       dispositionTime: null,
       dispositionUser: "None",
-      eventTime: null,
-      insertTime: null,
-      name: "Unnamed",
+      eventTime: new Date(0),
+      insertTime: new Date(0),
+      name: "Test Alert",
       owner: "None",
-      queue: "None",
+      queue: "Default",
       tags: [],
       tool: "None",
-      type: "",
+      type: "Manual",
       uuid: "uuid1",
     });
   });
   it("will use the available values when parsing an API alert object with all optional properties", () => {
-    expect(parseAlertSummary(mockAPIAlert)).toStrictEqual({
-      comments: [{ value: "A comment", description: "comment", uuid: "uuid1" }],
+    expect(parseAlertSummary(mockAPIAlertOptionalProperties)).toStrictEqual({
+      comments: [mockComment],
       description: "A test alert",
       disposition: "False Positive",
       dispositionTime: new Date(0),
-      dispositionUser: "Analyst",
+      dispositionUser: "Imma Analyst",
       eventTime: new Date(0),
       insertTime: new Date(0),
       name: "Test Alert",
-      owner: "Analyst",
+      owner: "Imma Analyst",
       queue: "Default",
       tags: [{ value: "a tag", description: "tag", uuid: "uuid1" }],
       tool: "GUI",
@@ -162,7 +224,7 @@ describe("alerts Actions", () => {
     expect(state.openAlert).toEqual(mockAlert);
   });
 
-  it("will fetch all alerts when getAll is called and no filter options are set", async () => {
+  it("will fetch all alerts when getPage is called and no filter options are set", async () => {
     const state = {
       openAlert: null,
       visibleQueriedAlerts: [],
@@ -171,8 +233,8 @@ describe("alerts Actions", () => {
     const store = new Vuex.Store({ state, mutations, actions });
     const mockRequest = myNock
       .get("/alert/")
-      .reply(200, { items: [{ uuid: "uuid1" }, { uuid: "uuid2" }], total: 2 });
-    await store.dispatch("getAll");
+      .reply(200, { items: [mockAPIAlert, mockAPIAlert], total: 2 });
+    await store.dispatch("getPage");
 
     expect(mockRequest.isDone()).toEqual(true);
 
@@ -181,7 +243,7 @@ describe("alerts Actions", () => {
     expect(state.visibleQueriedAlerts).toHaveLength(2);
   });
 
-  it("will pass params along when getAll is and pagination options are set", async () => {
+  it("will pass params along when getPage is and pagination options are set", async () => {
     const state = {
       openAlert: null,
       visibleQueriedAlerts: [],
@@ -190,8 +252,8 @@ describe("alerts Actions", () => {
     const store = new Vuex.Store({ state, mutations, actions });
     const mockRequest = myNock
       .get("/alert/?limit=2&offset=0")
-      .reply(200, { items: [{ uuid: "uuid1" }, { uuid: "uuid2" }], total: 2 });
-    await store.dispatch("getAll", { limit: 2, offset: 0 });
+      .reply(200, { items: [mockAPIAlert, mockAPIAlert], total: 2 });
+    await store.dispatch("getPage", { limit: 2, offset: 0 });
 
     expect(mockRequest.isDone()).toEqual(true);
 

--- a/frontend/tests/unit/src/store/alerts.spec.ts
+++ b/frontend/tests/unit/src/store/alerts.spec.ts
@@ -243,7 +243,7 @@ describe("alerts Actions", () => {
     expect(state.visibleQueriedAlerts).toHaveLength(2);
   });
 
-  it("will pass params along when getPage is and pagination options are set", async () => {
+  it("will pass params along when getPage is called and pagination options are set", async () => {
     const state = {
       openAlert: null,
       visibleQueriedAlerts: [],
@@ -262,7 +262,7 @@ describe("alerts Actions", () => {
     expect(state.visibleQueriedAlerts).toHaveLength(2);
   });
 
-  it("will pass params along when getAll is called and sort options are set", async () => {
+  it("will pass params along when getPage is called and sort options are set", async () => {
     const state = {
       openAlert: null,
       visibleQueriedAlerts: [],
@@ -271,8 +271,8 @@ describe("alerts Actions", () => {
     const store = new Vuex.Store({ state, mutations, actions });
     const mockRequest = myNock
       .get("/alert/?sort=event_time%7Casc")
-      .reply(200, { items: [{ uuid: "uuid1" }, { uuid: "uuid2" }], total: 2 });
-    await store.dispatch("getAll", { sort: "event_time|asc" });
+      .reply(200, { items: [mockAPIAlert, mockAPIAlert], total: 2 });
+    await store.dispatch("getPage", { sort: "event_time|asc" });
 
     expect(mockRequest.isDone()).toEqual(true);
 

--- a/frontend/tests/unit/src/store/generic.spec.ts
+++ b/frontend/tests/unit/src/store/generic.spec.ts
@@ -4,7 +4,7 @@ import myNock from "../services/api/nock";
 import axios from "axios";
 
 class stubService {
-  async getAll() {
+  async readAll() {
     const response = await axios
       .get("http://test_app.com:1234/item/")
       .catch((error) => {
@@ -50,24 +50,24 @@ describe("generic Mutations", () => {
 });
 
 describe("generic Actions", () => {
-  it("will call the given service's getAll method upon the getAll action", async () => {
+  it("will call the given service's readAll method upon the readAll action", async () => {
     const state = { items: [] };
     const store = new Vuex.Store({ state, getters, mutations, actions });
     const mockRequest = myNock.get("/item/").reply(200, [mockItem, mockItem]);
 
-    await store.dispatch("getAll");
+    await store.dispatch("readAll");
 
     expect(mockRequest.isDone()).toEqual(true);
     expect(state.items[0]).toEqual(mockItem);
     expect(state.items.length).toEqual(2);
   });
 
-  it("will throw an error if the call to getAll items fails", async () => {
+  it("will throw an error if the call to readAll items fails", async () => {
     const state = { items: [] };
     const store = new Vuex.Store({ state, getters, mutations, actions });
     myNock.get("/item/").reply(403, "Bad request :(");
 
-    await expect(store.dispatch("getAll")).rejects.toEqual(
+    await expect(store.dispatch("readAll")).rejects.toEqual(
       new Error("Request failed with status code 403"),
     );
   });


### PR DESCRIPTION
This PR began as just implementing pagination for the rest of the "get_all_*" API endpoints. Previously, only the get_all_alerts endpoint had pagination. While technically several of the endpoints don't necessarily _need_ pagination, now data is returned in a consistent format regardless.

However, implementing this change in the backend API required some corresponding changes to the frontend. As I was making those changes, I also wanted to ensure that the frontend had the ability to use data models that match the models for what the backend API expects. This required that I refactored the `frontend/src/services/api` code a bit so that we weren't using the "GenericEndpoint" for most things.

The other minor enhancements include:
* Adding clickable links to the alerts table so that you can click its name and be taken to that alert page
* Changed the "Event Date"  and "Insert Date" alert columns to be "Event Time" and "Insert Time" so that the naming is consistent across all the places.
* Formatted the various time columns in the alerts table. Currently it only uses the default format for the "en-US" locale.