### PR TITLE
Adds serialize_for_node_tree functions to Node subclasses

### DIFF
--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -251,10 +251,7 @@ def read_node_tree(root_node_uuid: UUID, db: Session) -> List[Node]:
         node.parent_tree_uuid = leaf.parent_tree_uuid
 
         # Serialize the database objects into their correct Pydantic models
-        if isinstance(node, Analysis):
-            tree.append(AnalysisNodeTreeRead(**node.__dict__))
-        elif isinstance(node, Observable):
-            tree.append(ObservableRead(**node.__dict__))
+        tree.append(node.serialize_for_node_tree())
 
     return tree
 

--- a/backend/app/db/schemas/alert.py
+++ b/backend/app/db/schemas/alert.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, DateTime, ForeignKey, Index, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
+from api.models.alert import AlertRead
 from db.schemas.node import Node
 from db.schemas.helpers import utcnow
 
@@ -65,3 +66,6 @@ class Alert(Node):
             postgresql_using="gin",
         ),
     )
+
+    def serialize_for_node_tree(self) -> AlertRead:
+        return AlertRead(**self.__dict__)

--- a/backend/app/db/schemas/analysis.py
+++ b/backend/app/db/schemas/analysis.py
@@ -2,6 +2,7 @@ from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import deferred, relationship
 
+from api.models.analysis import AnalysisNodeTreeRead
 from db.schemas.node import Node
 
 
@@ -29,3 +30,6 @@ class Analysis(Node):
     summary = Column(String)
 
     __mapper_args__ = {"polymorphic_identity": "analysis", "polymorphic_load": "inline"}
+
+    def serialize_for_node_tree(self) -> AnalysisNodeTreeRead:
+        return AnalysisNodeTreeRead(**self.__dict__)

--- a/backend/app/db/schemas/event.py
+++ b/backend/app/db/schemas/event.py
@@ -3,6 +3,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
 
+from api.models.event import EventRead
 from db.schemas.event_prevention_tool_mapping import event_prevention_tool_mapping
 from db.schemas.event_remediation_mapping import event_remediation_mapping
 from db.schemas.event_vector_mapping import event_vector_mapping
@@ -62,3 +63,6 @@ class Event(Node):
     vectors = relationship("EventVector", secondary=event_vector_mapping)
 
     __mapper_args__ = {"polymorphic_identity": "event", "polymorphic_load": "inline"}
+
+    def serialize_for_node_tree(self) -> EventRead:
+        return EventRead(**self.__dict__)

--- a/backend/app/db/schemas/node.py
+++ b/backend/app/db/schemas/node.py
@@ -31,3 +31,6 @@ class Node(Base):
     version = Column(UUID(as_uuid=True), nullable=False)
 
     __mapper_args__ = {"polymorphic_identity": "node", "polymorphic_on": node_type, "with_polymorphic": "*"}
+
+    def serialize_for_node_tree(self):
+        raise NotImplementedError("A Node subclass must implement serialize_for_node_tree")

--- a/backend/app/db/schemas/observable.py
+++ b/backend/app/db/schemas/observable.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
+from api.models.observable import ObservableRead
 from db.schemas.helpers import utcnow
 from db.schemas.node import Node
 
@@ -51,3 +52,6 @@ class Observable(Node):
         Index("type_value", type_uuid, value),
         UniqueConstraint("type_uuid", "value", name="type_value_uc"),
     )
+
+    def serialize_for_node_tree(self) -> ObservableRead:
+        return ObservableRead(**self.__dict__)


### PR DESCRIPTION
This cleans up the logic when reading a NodeTree from the database. Instead of having to manually check the type of each node in order to serialize it to its corresponding Pydantic model, each Node subclass now has a `serialize_for_node_tree` function that gets called.