### PR TITLE
Backend now generates nested NodeTree structure

### DIFF
--- a/backend/app/api/models/analysis.py
+++ b/backend/app/api/models/analysis.py
@@ -2,11 +2,9 @@ from pydantic import Field, Json, UUID4
 from typing import Optional
 from uuid import uuid4
 
-from pydantic.main import BaseModel
-
 from api.models import type_str
 from api.models.analysis_module_type import AnalysisModuleTypeNodeTreeRead, AnalysisModuleTypeRead
-from api.models.node import NodeBase, NodeCreate, NodeRead, NodeTreeCreateWithNode, NodeUpdate
+from api.models.node import NodeBase, NodeCreate, NodeRead, NodeTreeCreateWithNode, NodeTreeItemRead, NodeUpdate
 
 
 class AnalysisBase(NodeBase):
@@ -38,7 +36,7 @@ class AnalysisCreate(NodeCreate, AnalysisBase):
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the analysis")
 
 
-class AnalysisNodeTreeRead(BaseModel):
+class AnalysisNodeTreeRead(NodeTreeItemRead):
     """Model used to control which information for an Analysis is displayed when getting an alert tree"""
 
     analysis_module_type: Optional[AnalysisModuleTypeNodeTreeRead] = Field(
@@ -46,10 +44,6 @@ class AnalysisNodeTreeRead(BaseModel):
     )
 
     node_type: type_str = Field(description="The type of the Node")
-
-    parent_tree_uuid: UUID4 = Field(description="The analysis' parent leaf UUID inside a NodeTree")
-
-    tree_uuid: UUID4 = Field(description="The UUID of the leaf inside a NodeTree representing this analysis")
 
     uuid: UUID4 = Field(description="The UUID of the analysis")
 

--- a/backend/app/api/models/node.py
+++ b/backend/app/api/models/node.py
@@ -10,6 +10,14 @@ from api.models.node_threat import NodeThreatRead
 from api.models.node_threat_actor import NodeThreatActorRead
 
 
+class NodeTreeItemRead(BaseModel):
+    parent_tree_uuid: Optional[UUID4] = Field(
+        description="The node's parent leaf UUID if the node is inside a NodeTree"
+    )
+
+    tree_uuid: Optional[UUID4] = Field(description="The UUID of the leaf if this Node is inside a NodeTree")
+
+
 class NodeBase(BaseModel):
     """Represents an individual node."""
 
@@ -45,24 +53,18 @@ class NodeCreate(NodeBase):
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the node")
 
 
-class NodeRead(NodeBase):
+class NodeRead(NodeBase, NodeTreeItemRead):
     comments: List[NodeCommentRead] = Field(description="A list of comments added to the node")
 
     directives: List[NodeDirectiveRead] = Field(description="A list of directives added to the node")
 
     node_type: type_str = Field(description="The type of the Node")
 
-    parent_tree_uuid: Optional[UUID4] = Field(
-        description="The node's parent leaf UUID if the node is inside a NodeTree"
-    )
-
     tags: List[NodeTagRead] = Field(description="A list of tags added to the node")
 
     threat_actor: Optional[NodeThreatActorRead] = Field(description="The threat actor added to the node")
 
     threats: List[NodeThreatRead] = Field(description="A list of threats added to the node")
-
-    tree_uuid: Optional[UUID4] = Field(description="The UUID of the leaf if this Node is inside a NodeTree")
 
     uuid: UUID4 = Field(description="The UUID of the node")
 

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -1,16 +1,16 @@
 from fastapi import HTTPException, status
 from pydantic import BaseModel
+from pydantic.types import UUID4
 from sqlalchemy import delete as sql_delete, select, update as sql_update
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import joinedload, undefer, Session
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import join
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 from uuid import UUID, uuid4
 
-from api.models.analysis import AnalysisNodeTreeRead
-from api.models.observable import ObservableRead
+from api.models.node import NodeTreeItemRead
 from core.auth import verify_password
 from db.schemas.analysis import Analysis
 from db.schemas.node import Node
@@ -210,7 +210,7 @@ def read_by_values(values: List[str], db_table: DeclarativeMeta, db: Session):
     return resources
 
 
-def read_node_tree(root_node_uuid: UUID, db: Session) -> List[Node]:
+def read_node_tree(root_node_uuid: UUID, db: Session) -> List[Dict]:
     """Returns a list of Node objects that comprise a Node Tree. The returned objects
     are manually serialized into their Pydantic models since Pydantic cannot handle
     returning a list of multiple types of objects in this case."""
@@ -243,17 +243,51 @@ def read_node_tree(root_node_uuid: UUID, db: Session) -> List[Node]:
         .fetchall()
     )
 
-    tree = []
-
+    node_tree_nodes = []
     for leaf, node in node_tree_and_nodes:
         # Inject the tree information into the Node
         node.tree_uuid = leaf.uuid
         node.parent_tree_uuid = leaf.parent_tree_uuid
 
         # Serialize the database objects into their correct Pydantic models
-        tree.append(node.serialize_for_node_tree())
+        node_tree_nodes.append(node.serialize_for_node_tree())
 
-    return tree
+    return unflatten_node_tree(node_tree_nodes)
+
+
+def unflatten_node_tree(node_tree_nodes: List[NodeTreeItemRead]) -> List[Dict]:
+    """Takes a flat list of nodes from a NodeTree after they've been serialized into
+    their Pydantic models and converts it into a nested structure.
+
+    Adapted from: https://www.npmjs.com/package/performant-array-to-tree"""
+
+    root_nodes = []
+
+    # Used to store the already processed nodes where the node's UUID is the key
+    lookup: Dict[UUID4, dict] = {}
+
+    for node in node_tree_nodes:
+        # If this node is not already in the lookup table, add a preliminary item for it
+        if node.tree_uuid not in lookup:
+            lookup[node.tree_uuid] = {"children": []}
+
+        # Add the node's data to the item in the lookup table. Remember the nodes in the
+        # list are Pydantic model objects, so to update the dictionary in the lookup table,
+        # we have to work with the Pydantic object's dictionary as well.
+        lookup[node.tree_uuid].update(node.dict())
+
+        # If the node does not have a parent, add it as a root node
+        if not node.parent_tree_uuid:
+            root_nodes.append(lookup[node.tree_uuid])
+        else:
+            # If the parent is not already in the lookup table, add a preliminary item for it
+            if node.parent_tree_uuid not in lookup:
+                lookup[node.parent_tree_uuid] = {"children": []}
+
+            # Add the node to its parent
+            lookup[node.parent_tree_uuid]["children"].append(lookup[node.tree_uuid])
+
+    return root_nodes
 
 
 #

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -708,7 +708,6 @@ def test_get_alert_tree(client_valid_access_token, db):
     # Create an alert with a tree of analyses and observable instances
     alert = helpers.create_alert_from_json_file(db=db, json_path="/app/tests/alerts/small.json")
 
-    # The small.json alert has 12 observables and 6 analyses. Even though some of the observables
-    # are in the alert multiple times, the tree should have 18 items.
+    # The small.json alert has 12 observables and 6 analyses. However, it only has two root observables.
     get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
-    assert len(get.json()["tree"]) == 18
+    assert len(get.json()["tree"]) == 2

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,7 +13,6 @@
         "camelcase-keys": "^7.0.0",
         "core-js": "^3.18.1",
         "moment-timezone": "^0.5.33",
-        "performant-array-to-tree": "^1.9.1",
         "pinia": "^2.0.0-rc.10",
         "primeflex": "^3.1.0",
         "primeicons": "4.1.0",
@@ -21611,11 +21610,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "node_modules/performant-array-to-tree": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.9.1.tgz",
-      "integrity": "sha512-t+Hiy1HbKTVXg+mdcDUwPwAGgrLMtNUOhs2vV0M9MG2aAfnXQT9czAadksufMnf75h4xYU014HqlQ91JZ4XdlA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.0",
@@ -46934,11 +46928,6 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
-    },
-    "performant-array-to-tree": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/performant-array-to-tree/-/performant-array-to-tree-1.9.1.tgz",
-      "integrity": "sha512-t+Hiy1HbKTVXg+mdcDUwPwAGgrLMtNUOhs2vV0M9MG2aAfnXQT9czAadksufMnf75h4xYU014HqlQ91JZ4XdlA=="
     },
     "picomatch": {
       "version": "2.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,6 @@
     "camelcase-keys": "^7.0.0",
     "core-js": "^3.18.1",
     "moment-timezone": "^0.5.33",
-    "performant-array-to-tree": "^1.9.1",
     "pinia": "^2.0.0-rc.10",
     "primeflex": "^3.1.0",
     "primeicons": "4.1.0",

--- a/frontend/src/pages/Alerts/ViewAlert.vue
+++ b/frontend/src/pages/Alerts/ViewAlert.vue
@@ -1,13 +1,12 @@
 <!-- ViewAlert.vue -->
 
 <template>
-  <AlertTree v-if="alertStore.openAlert" :items="alertTree" />
+  <AlertTree v-if="alertStore.openAlert" :items="alertStore.openAlert.tree" />
 </template>
 
 <script setup>
-  import { computed, onMounted, onUnmounted } from "vue";
+  import { onMounted, onUnmounted } from "vue";
   import { useRoute } from "vue-router";
-  import { arrayToTree } from "performant-array-to-tree";
 
   import AlertTree from "@/components/Alerts/AlertTree";
   import { useAlertStore } from "@/stores/alert";
@@ -27,12 +26,4 @@
   onUnmounted(() => {
     selectedAlertStore.unselectAll();
   });
-
-  const alertTree = computed(() =>
-    arrayToTree(alertStore.openAlert.tree, {
-      id: "treeUuid",
-      parentId: "parentTreeUuid",
-      dataField: null,
-    }),
-  );
 </script>


### PR DESCRIPTION
Most, if not all, of the time that we request something like an alert from the backend API, we're going to want to work with it in its nested tree form. This PR makes the backend generate that structure out of the flat list of Nodes that it gets from the database instead of relying on the GUI to transform the tree.