### PR TITLE
Makes the version field optional when updating a Node

### DIFF
--- a/backend/app/api/models/node.py
+++ b/backend/app/api/models/node.py
@@ -82,8 +82,8 @@ class NodeUpdate(NodeBase):
     # The version is optional when updating a Node since certain actions in the GUI do not need to care
     # about the version. However, if the version is given, the update will be rejected if it does not match.
     version: Optional[UUID4] = Field(
-        description="""A version string that automatically changes every time the node is modified. The version
-            must match when updating.""",
+        description="""A version string that automatically changes every time the node is modified. If supplied,
+        the version must match when updating.""",
     )
 
 

--- a/backend/app/api/models/node.py
+++ b/backend/app/api/models/node.py
@@ -79,10 +79,11 @@ class NodeUpdate(NodeBase):
 
     threats: Optional[List[type_str]] = Field(description="A list of threats to add to the node")
 
-    # In order to update any Node, you must pass in the version that you want to update. If the version does not
-    # match, then the update will fail.
-    version: UUID4 = Field(
-        description="""The version of the Node being updated. This must match its current version to succeed."""
+    # The version is optional when updating a Node since certain actions in the GUI do not need to care
+    # about the version. However, if the version is given, the update will be rejected if it does not match.
+    version: Optional[UUID4] = Field(
+        description="""A version string that automatically changes every time the node is modified. The version
+            must match when updating.""",
     )
 
 

--- a/backend/app/api/routes/node.py
+++ b/backend/app/api/routes/node.py
@@ -52,7 +52,7 @@ def update_node(node_update: NodeUpdate, uuid: UUID, db_table: DeclarativeMeta, 
     update_data = node_update.dict(exclude_unset=True)
 
     # Return an exception if the passed in version does not match the Node's current version
-    if update_data["version"] != db_node.version:
+    if "version" in update_data and update_data["version"] != db_node.version:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT, detail="Unable to update Node due to version mismatch"
         )

--- a/backend/app/tests/api/alert/test_update.py
+++ b/backend/app/tests/api/alert/test_update.py
@@ -44,9 +44,7 @@ from tests import helpers
     ],
 )
 def test_update_invalid_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/alert/{uuid.uuid4()}", json={key: value, "version": str(uuid.uuid4())}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert key in update.text
 
@@ -56,15 +54,13 @@ def test_update_invalid_fields(client_valid_access_token, key, value):
     INVALID_UPDATE_FIELDS,
 )
 def test_update_invalid_node_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/alert/{uuid.uuid4()}", json={"version": str(uuid.uuid4()), key: value}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert key in update.text
 
 
 def test_update_invalid_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch("/api/alert/1", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch("/api/alert/1", json={})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -72,7 +68,8 @@ def test_update_invalid_version(client_valid_access_token, db):
     # Create an alert
     alert = helpers.create_alert(db=db)
 
-    # Make sure you cannot update it using an invalid version
+    # Make sure you cannot update it using an invalid version. The version is
+    # optional, but if given, it must match.
     update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"version": str(uuid.uuid4())})
     assert update.status_code == status.HTTP_409_CONFLICT
 
@@ -91,9 +88,7 @@ def test_update_nonexistent_fields(client_valid_access_token, db, key, value):
     alert = helpers.create_alert(db=db)
 
     # Make sure you cannot update it to use a nonexistent field value
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={key: value, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={key: value})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -106,14 +101,12 @@ def test_update_nonexistent_node_fields(client_valid_access_token, db, key, valu
     alert = helpers.create_alert(db=db)
 
     # Make sure you cannot update it to use a nonexistent node field value
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={key: value, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={key: value})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_nonexistent_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch(f"/api/alert/{uuid.uuid4()}", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch(f"/api/alert/{uuid.uuid4()}", json={})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -134,9 +127,7 @@ def test_update_disposition(client_valid_access_token, db):
     helpers.create_alert_disposition(value="test", rank=1, db=db)
 
     # Update the disposition
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"disposition": "test", "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"disposition": "test"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert alert.disposition.value == "test"
     assert alert.version != initial_version
@@ -152,9 +143,7 @@ def test_update_event_uuid(client_valid_access_token, db):
     initial_event_version = event.version
 
     # Update the alert to add it to the event
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"event_uuid": str(event.uuid), "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"event_uuid": str(event.uuid)})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert alert.event_uuid == event.uuid
     assert alert.version != initial_alert_version
@@ -176,9 +165,7 @@ def test_update_owner(client_valid_access_token, db):
     helpers.create_user(username="johndoe", db=db)
 
     # Update the owner
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"owner": "johndoe", "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"owner": "johndoe"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert alert.owner.username == "johndoe"
     assert alert.version != initial_alert_version
@@ -193,9 +180,7 @@ def test_update_queue(client_valid_access_token, db):
     helpers.create_alert_queue(value="test_queue2", db=db)
 
     # Update the queue
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"queue": "test_queue2", "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"queue": "test_queue2"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert alert.queue.value == "test_queue2"
     assert alert.version != initial_alert_version
@@ -215,9 +200,7 @@ def test_update_valid_node_directives(client_valid_access_token, db, values):
         helpers.create_node_directive(value=value, db=db)
 
     # Update the alert
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"directives": values, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"directives": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(alert.directives) == len(set(values))
     assert alert.version != initial_alert_version
@@ -237,9 +220,7 @@ def test_update_valid_node_tags(client_valid_access_token, db, values):
         helpers.create_node_tag(value=value, db=db)
 
     # Update the alert
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"tags": values, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"tags": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(alert.tags) == len(set(values))
     assert alert.version != initial_alert_version
@@ -259,9 +240,7 @@ def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
         helpers.create_node_threat_actor(value=value, db=db)
 
     # Update the alert
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"threat_actor": value, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"threat_actor": value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     if value:
@@ -286,9 +265,7 @@ def test_update_valid_node_threats(client_valid_access_token, db, values):
         helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Update the alert
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"threats": values, "version": str(alert.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={"threats": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(alert.threats) == len(set(values))
     assert alert.version != initial_alert_version
@@ -320,9 +297,7 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
     assert getattr(alert, key) == initial_value
 
     # Update it
-    update = client_valid_access_token.patch(
-        f"/api/alert/{alert.uuid}", json={"version": str(alert.version), key: updated_value}
-    )
+    update = client_valid_access_token.patch(f"/api/alert/{alert.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     if key == "event_time":

--- a/backend/app/tests/api/analysis/test_update.py
+++ b/backend/app/tests/api/analysis/test_update.py
@@ -39,9 +39,7 @@ from tests import helpers
     ],
 )
 def test_update_invalid_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{uuid.uuid4()}", json={key: value, "version": str(uuid.uuid4())}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(update.json()["detail"]) == 1
     assert key in update.json()["detail"][0]["loc"]
@@ -52,16 +50,14 @@ def test_update_invalid_fields(client_valid_access_token, key, value):
     INVALID_UPDATE_FIELDS,
 )
 def test_update_invalid_node_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{uuid.uuid4()}", json={"version": str(uuid.uuid4()), key: value}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert len(update.json()["detail"]) == 1
     assert key in update.json()["detail"][0]["loc"]
 
 
 def test_update_invalid_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch("/api/analysis/1", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch("/api/analysis/1", json={})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -69,7 +65,8 @@ def test_update_invalid_version(client_valid_access_token, db):
     # Create an analysis
     analysis = helpers.create_analysis(db=db)
 
-    # Make sure you cannot update it using an invalid version
+    # Make sure you cannot update it using an invalid version. The version is
+    # optional, but if given, it must match.
     update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={"version": str(uuid.uuid4())})
     assert update.status_code == status.HTTP_409_CONFLICT
 
@@ -81,7 +78,7 @@ def test_update_nonexistent_analysis_module_type(client_valid_access_token, db):
     # Make sure you cannot update it to use a nonexistent analysis module type
     update = client_valid_access_token.patch(
         f"/api/analysis/{analysis.uuid}",
-        json={"analysis_module_type": str(uuid.uuid4()), "version": str(analysis.version)},
+        json={"analysis_module_type": str(uuid.uuid4())},
     )
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
@@ -95,14 +92,12 @@ def test_update_nonexistent_node_fields(client_valid_access_token, db, key, valu
     analysis = helpers.create_analysis(db=db)
 
     # Make sure you cannot update it to use a nonexistent node field value
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={key: value, "version": str(analysis.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={key: value})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_nonexistent_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch(f"/api/analysis/{uuid.uuid4()}", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch(f"/api/analysis/{uuid.uuid4()}", json={})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -122,7 +117,7 @@ def test_update_analysis_module_type(client_valid_access_token, db):
     # Update the analysis module type
     update = client_valid_access_token.patch(
         f"/api/analysis/{analysis.uuid}",
-        json={"analysis_module_type": str(analysis_module_type.uuid), "version": str(analysis.version)},
+        json={"analysis_module_type": str(analysis_module_type.uuid)},
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert analysis.analysis_module_type == analysis_module_type
@@ -143,9 +138,7 @@ def test_update_valid_node_directives(client_valid_access_token, db, values):
         helpers.create_node_directive(value=value, db=db)
 
     # Update the analysis
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={"directives": values, "version": str(analysis.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={"directives": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(analysis.directives) == len(set(values))
     assert analysis.version != initial_analysis_version
@@ -165,9 +158,7 @@ def test_update_valid_node_tags(client_valid_access_token, db, values):
         helpers.create_node_tag(value=value, db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={"tags": values, "version": str(analysis.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={"tags": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(analysis.tags) == len(set(values))
     assert analysis.version != initial_analysis_version
@@ -187,9 +178,7 @@ def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
         helpers.create_node_threat_actor(value=value, db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={"threat_actor": value, "version": str(analysis.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={"threat_actor": value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     if value:
@@ -214,9 +203,7 @@ def test_update_valid_node_threats(client_valid_access_token, db, values):
         helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={"threats": values, "version": str(analysis.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={"threats": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(analysis.threats) == len(set(values))
     assert analysis.version != initial_analysis_version
@@ -244,9 +231,7 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
     setattr(analysis, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(
-        f"/api/analysis/{analysis.uuid}", json={"version": str(analysis.version), key: updated_value}
-    )
+    update = client_valid_access_token.patch(f"/api/analysis/{analysis.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     if key == "details":

--- a/backend/app/tests/api/event/test_update.py
+++ b/backend/app/tests/api/event/test_update.py
@@ -76,9 +76,7 @@ from tests import helpers
     ],
 )
 def test_update_invalid_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/event/{uuid.uuid4()}", json={key: value, "version": str(uuid.uuid4())}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert key in update.text
 
@@ -88,15 +86,13 @@ def test_update_invalid_fields(client_valid_access_token, key, value):
     INVALID_UPDATE_FIELDS,
 )
 def test_update_invalid_node_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(
-        f"/api/event/{uuid.uuid4()}", json={"version": str(uuid.uuid4()), key: value}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert key in update.text
 
 
 def test_update_invalid_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch("/api/event/1", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch("/api/event/1", json={})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -104,7 +100,8 @@ def test_update_invalid_version(client_valid_access_token, db):
     # create an event
     event = helpers.create_event(name="test", db=db)
 
-    # Make sure you cannot update it using an invalid version
+    ## Make sure you cannot update it using an invalid version. The version is
+    # optional, but if given, it must match.
     update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"version": str(uuid.uuid4())})
     assert update.status_code == status.HTTP_409_CONFLICT
 
@@ -127,9 +124,7 @@ def test_update_nonexistent_fields(client_valid_access_token, db, key, value):
     event = helpers.create_event(name="test", db=db)
 
     # Make sure you cannot update it to use a nonexistent field value
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={key: value, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={key: value})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -142,14 +137,12 @@ def test_update_nonexistent_node_fields(client_valid_access_token, db, key, valu
     event = helpers.create_event(name="test", db=db)
 
     # Make sure you cannot update it to use a nonexistent node field value
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={key: value, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={key: value})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_nonexistent_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch(f"/api/event/{uuid.uuid4()}", json={"version": str(uuid.uuid4())})
+    update = client_valid_access_token.patch(f"/api/event/{uuid.uuid4()}", json={})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -167,9 +160,7 @@ def test_update_owner(client_valid_access_token, db):
     helpers.create_user(username="johndoe", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"owner": "johndoe", "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"owner": "johndoe"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.owner.username == "johndoe"
     assert event.version != initial_event_version
@@ -184,9 +175,7 @@ def test_update_prevention_tools(client_valid_access_token, db):
     helpers.create_event_prevention_tool(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"prevention_tools": ["test"], "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"prevention_tools": ["test"]})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(event.prevention_tools) == 1
     assert event.prevention_tools[0].value == "test"
@@ -202,9 +191,7 @@ def test_update_remediations(client_valid_access_token, db):
     helpers.create_event_remediation(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"remediations": ["test"], "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"remediations": ["test"]})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(event.remediations) == 1
     assert event.remediations[0].value == "test"
@@ -220,9 +207,7 @@ def test_update_risk_level(client_valid_access_token, db):
     helpers.create_event_risk_level(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"risk_level": "test", "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"risk_level": "test"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.risk_level.value == "test"
     assert event.version != initial_event_version
@@ -237,9 +222,7 @@ def test_update_source(client_valid_access_token, db):
     helpers.create_event_source(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"source": "test", "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"source": "test"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.source.value == "test"
     assert event.version != initial_event_version
@@ -254,9 +237,7 @@ def test_update_status(client_valid_access_token, db):
     helpers.create_event_status(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"status": "test", "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"status": "test"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.status.value == "test"
     assert event.version != initial_event_version
@@ -271,9 +252,7 @@ def test_update_type(client_valid_access_token, db):
     helpers.create_event_type(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"type": "test", "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"type": "test"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.type.value == "test"
     assert event.version != initial_event_version
@@ -288,9 +267,7 @@ def test_update_vectors(client_valid_access_token, db):
     helpers.create_event_vector(value="test", db=db)
 
     # Update the event
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"vectors": ["test"], "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"vectors": ["test"]})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(event.vectors) == 1
     assert event.vectors[0].value == "test"
@@ -311,9 +288,7 @@ def test_update_valid_node_directives(client_valid_access_token, db, values):
         helpers.create_node_directive(value=value, db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"directives": values, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"directives": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(event.directives) == len(set(values))
     assert event.version != initial_event_version
@@ -333,9 +308,7 @@ def test_update_valid_node_tags(client_valid_access_token, db, values):
         helpers.create_node_tag(value=value, db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"tags": values, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"tags": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert len(event.tags) == len(set(values))
     assert event.version != initial_event_version
@@ -355,9 +328,7 @@ def test_update_valid_node_threat_actor(client_valid_access_token, db, value):
         helpers.create_node_threat_actor(value=value, db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"threat_actor": value, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"threat_actor": value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     if value:
@@ -382,9 +353,7 @@ def test_update_valid_node_threats(client_valid_access_token, db, values):
         helpers.create_node_threat(value=value, types=["test_type"], db=db)
 
     # Update the node
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"threats": values, "version": str(event.version)}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"threats": values})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # Read it back
@@ -444,9 +413,7 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
     setattr(event, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(
-        f"/api/event/{event.uuid}", json={"version": str(event.version), key: updated_value}
-    )
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
 
     # If the test is for one of the times, make sure that the retrieved value matches the proper UTC timestamp


### PR DESCRIPTION
The database has a "version" field for the various Node subclass tables. Originally, you had to pass in the current version of the Node object you were updating in order for the update to succeed.

However, this requirement broke certain things in the GUI, such as taking ownership of an alert... A user would not be able to take ownership of an alert (which would require updating it) unless nothing else (the Core or another analyst) had modified the alert since the last time the user loaded the list of alerts in their browser.

This PR makes the version field optional for this reason... if it is given as part of an update request, it must match the current version stored in the database.