### PR TITLE
Sets user in auth store upon authenticating and refreshing tokens

### DIFF
--- a/backend/app/api/models/auth.py
+++ b/backend/app/api/models/auth.py
@@ -2,6 +2,7 @@ from pydantic import BaseModel
 from typing import Optional
 
 from api.models import type_str
+from api.models.user import UserRead
 
 
 class Auth(BaseModel):
@@ -12,3 +13,5 @@ class Auth(BaseModel):
     refresh_token: Optional[type_str]
 
     token_type: type_str
+
+    user: UserRead

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -140,6 +140,7 @@ def auth_refresh(response: Response, new_tokens: dict = Depends(refresh_token)):
         "access_token": access_token,
         "refresh_token": refresh_token,
         "token_type": "bearer",
+        "user": new_tokens["user"],
     }
 
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -80,11 +80,7 @@ def auth(response: Response, form_data: OAuth2PasswordRequestForm = Depends(), d
     user.refresh_token = refresh_token
     crud.commit(db)
 
-    return {
-        "access_token": access_token,
-        "refresh_token": refresh_token,
-        "token_type": "bearer",
-    }
+    return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer", "user": user}
 
 
 helpers.api_route_auth(

--- a/backend/app/core/auth.py
+++ b/backend/app/core/auth.py
@@ -187,7 +187,11 @@ def refresh_token(db: Session = Depends(get_db), refresh_token: str = Depends(oa
             user.refresh_token = new_refresh_token
             db.commit()
 
-            return {"access_token": create_access_token(claims["sub"]), "refresh_token": new_refresh_token}
+            return {
+                "access_token": create_access_token(claims["sub"]),
+                "refresh_token": new_refresh_token,
+                "user": user,
+            }
 
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,

--- a/backend/app/tests/api/test_auth.py
+++ b/backend/app/tests/api/test_auth.py
@@ -178,6 +178,7 @@ def test_auth_success(client, db):
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK
     assert auth.json()["token_type"] == "bearer"
+    assert auth.json()["user"]["username"] == "johndoe"
     assert access_token
     assert refresh_token
     assert auth.cookies.get("access_token")

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -5,7 +5,7 @@ import PrimeVue from "primevue/config";
 import Tooltip from "primevue/tooltip";
 
 import router from "@/router";
-import { useAuthStore } from "./stores/auth";
+import { axiosRefresh } from "@/services/api/axios";
 
 import "primeflex/primeflex.css";
 import "primeicons/primeicons.css";
@@ -18,8 +18,9 @@ import "snakecase-keys";
 (async () => {
   const app = createApp(App).use(createPinia());
 
-  const authStore = useAuthStore();
-  await authStore.refreshTokens();
+  await axiosRefresh().catch(() => {
+    console.error("Must reauthenticate");
+  });
 
   app.use(router).use(PrimeVue);
 

--- a/frontend/src/services/api/auth.ts
+++ b/frontend/src/services/api/auth.ts
@@ -1,5 +1,7 @@
 import { AxiosRequestConfig } from "axios";
+import camelcaseKeys from "camelcase-keys";
 
+import { useAuthStore } from "@/stores/auth";
 import instance, { axiosRefresh } from "@/services/api/axios";
 
 export default {
@@ -8,6 +10,8 @@ export default {
     username: string;
     password: string;
   }): Promise<void> {
+    const authStore = useAuthStore();
+
     const config: AxiosRequestConfig = {
       url: "/auth",
       method: "POST",
@@ -22,9 +26,12 @@ export default {
       "content-type": "application/x-www-form-urlencoded",
     };
 
-    await instance.request(config).catch((error) => {
+    const response = await instance.request(config).catch((error) => {
+      authStore.$reset();
       throw error;
     });
+
+    authStore.user = camelcaseKeys(response.data.user, { deep: true });
   },
 
   // REFRESH AUTH
@@ -35,6 +42,8 @@ export default {
 
   // VALIDATE
   async validate(): Promise<void> {
+    const authStore = useAuthStore();
+
     const config: AxiosRequestConfig = {
       url: "/auth/validate",
       method: "GET",
@@ -43,17 +52,22 @@ export default {
 
     await instance.request(config).catch((error) => {
       console.debug("refresh token not present or expired");
+      authStore.$reset();
       throw error;
     });
   },
 
   // LOGOUT
   async logout(): Promise<void> {
+    const authStore = useAuthStore();
+
     const config: AxiosRequestConfig = {
       url: "/auth/logout",
       method: "GET",
       withCredentials: true,
     };
+
+    authStore.$reset();
 
     await instance.request(config).catch((error) => {
       throw error;

--- a/frontend/src/services/api/axios.ts
+++ b/frontend/src/services/api/axios.ts
@@ -1,5 +1,8 @@
 // create instance
 import axios, { AxiosRequestConfig } from "axios";
+import camelcaseKeys from "camelcase-keys";
+
+import { useAuthStore } from "@/stores/auth";
 
 const instance = axios.create({
   baseURL: `${process.env.VUE_APP_BACKEND_URL}`,
@@ -52,17 +55,21 @@ instance.interceptors.response.use(
 );
 
 export async function axiosRefresh(): Promise<void> {
+  const authStore = useAuthStore();
+
   const config: AxiosRequestConfig = {
     url: "/auth/refresh",
     method: "GET",
     withCredentials: true,
   };
 
-  await instance.request(config).catch((error) => {
+  const response = await instance.request(config).catch((error) => {
     console.debug("need to authenticate");
+    authStore.$reset();
     throw error;
   });
 
+  authStore.user = camelcaseKeys(response.data.user, { deep: true });
   console.debug("successfully refreshed tokens");
 }
 

--- a/frontend/src/stores/alert.ts
+++ b/frontend/src/stores/alert.ts
@@ -15,7 +15,7 @@ export const useAlertStore = defineStore({
     async create(newAlert: alertCreate) {
       await Alert.createAndRead(newAlert)
         .then((alert) => {
-          this.$state.openAlert = alert;
+          this.openAlert = alert;
         })
         .catch((error) => {
           throw error;
@@ -25,7 +25,7 @@ export const useAlertStore = defineStore({
     async read(uuid: UUID) {
       await Alert.read(uuid)
         .then((alert) => {
-          this.$state.openAlert = alert;
+          this.openAlert = alert;
         })
         .catch((error) => {
           throw error;

--- a/frontend/src/stores/alertTable.ts
+++ b/frontend/src/stores/alertTable.ts
@@ -54,8 +54,8 @@ export const useAlertTableStore = defineStore({
     async readPage(params: alertFilterParams) {
       await Alert.readPage(params)
         .then((page) => {
-          this.$state.visibleQueriedAlerts = page.items;
-          this.$state.totalAlerts = page.total;
+          this.visibleQueriedAlerts = page.items;
+          this.totalAlerts = page.total;
         })
         .catch((error) => {
           throw error;

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -1,43 +1,16 @@
 import { defineStore } from "pinia";
 import { userRead } from "@/models/user";
-import authApi from "@/services/api/auth";
 
 export const useAuthStore = defineStore({
   id: "authStore",
 
   state: () => ({
-    authenticated: false,
     user: null as unknown as userRead,
   }),
 
   getters: {
-    displayName(): string {
-      if (this.authenticated && this.user) {
-        return this.user.displayName;
-      }
-
-      return "Unauthenticated User";
-    },
-
     isAuthenticated(): boolean {
-      return this.authenticated;
-    },
-  },
-
-  actions: {
-    async refreshTokens() {
-      await authApi
-        .refresh()
-        .then(() => {
-          this.authenticated = true;
-        })
-        .catch(() => {
-          this.authenticated = false;
-        });
-    },
-
-    setAuthenticated(value: boolean) {
-      this.authenticated = value;
+      return !!this.user;
     },
   },
 });

--- a/frontend/tests/unit/src/services/api/auth.spec.ts
+++ b/frontend/tests/unit/src/services/api/auth.spec.ts
@@ -1,5 +1,9 @@
+import { createTestingPinia } from "@pinia/testing";
+
 import auth from "@/services/api/auth";
 import myNock from "@unit/services/api/nock";
+
+createTestingPinia();
 
 const mockLoginData = {
   username: "user",

--- a/frontend/tests/unit/src/services/api/axios.spec.ts
+++ b/frontend/tests/unit/src/services/api/axios.spec.ts
@@ -1,6 +1,10 @@
+import { createTestingPinia } from "@pinia/testing";
+
 import auth from "@/services/api/auth";
 import { User } from "@/services/api/user";
 import myNock from "@unit/services/api/nock";
+
+createTestingPinia();
 
 describe("Axios interceptor functionality", () => {
   it("will reject the request if it the response was not a 401", async () => {

--- a/frontend/tests/unit/src/store/auth.spec.ts
+++ b/frontend/tests/unit/src/store/auth.spec.ts
@@ -1,7 +1,6 @@
 import { createTestingPinia } from "@pinia/testing";
 import { useAuthStore } from "@/stores/auth";
 import { userRead } from "@/models/user";
-import myNock from "@unit/services/api/nock";
 
 createTestingPinia();
 
@@ -28,49 +27,8 @@ describe("auth Getters", () => {
   });
 
   it("will return isAuthenticated state when logged in", () => {
-    store.authenticated = true;
-
-    expect(store.isAuthenticated).toStrictEqual(true);
-  });
-
-  it("will return displayName when not logged in", () => {
-    expect(store.displayName).toStrictEqual("Unauthenticated User");
-  });
-
-  it("will return displayName when logged in", () => {
-    store.authenticated = true;
     store.user = mockUser;
 
-    expect(store.displayName).toStrictEqual("Test Analyst");
-  });
-});
-
-describe("auth Actions", () => {
-  beforeEach(() => {
-    store.$reset();
-  });
-
-  it("will set authenticated state when the refreshTokens call fails", async () => {
-    myNock.get("/auth/refresh").reply(403);
-
-    await store.refreshTokens();
-    expect(store.authenticated).toStrictEqual(false);
-  });
-
-  it("will set authenticated state when the refreshTokens call succeeds", async () => {
-    myNock.get("/auth/refresh").reply(200);
-
-    await store.refreshTokens();
-    expect(store.authenticated).toStrictEqual(true);
-  });
-
-  it("will set authenticated state when setAuthenticated is called with false", () => {
-    store.setAuthenticated(false);
-    expect(store.authenticated).toStrictEqual(false);
-  });
-
-  it("will set authenticated state when setAuthenticated is called with true", () => {
-    store.setAuthenticated(true);
-    expect(store.authenticated).toStrictEqual(true);
+    expect(store.isAuthenticated).toStrictEqual(true);
   });
 });


### PR DESCRIPTION
Several of the things in the GUI require the currently logged in user's information (like taking ownership of an alert, adding a comment, etc).

This PR makes the API return the user information when authenticating as well as when refreshing the tokens. The frontend then stores the user inside of the auth store so that it can be used across the application.