### PR TITLE
Adds get_node_version API endpoint

### DIFF
--- a/backend/app/api/models/node.py
+++ b/backend/app/api/models/node.py
@@ -104,3 +104,10 @@ class NodeTreeUpdate(NodeTreeBase):
     )
 
     node_uuid: Optional[UUID4] = Field(description="The UUID of the Node represented by the leaf")
+
+
+class NodeVersion(BaseModel):
+    version: UUID4 = Field(description="The current version of the Node")
+
+    class Config:
+        orm_mode = True

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -17,6 +17,7 @@ from api.routes.event_source import router as event_source_router
 from api.routes.event_status import router as event_status_router
 from api.routes.event_type import router as event_type_router
 from api.routes.event_vector import router as event_vector_router
+from api.routes.node import router as node_router
 from api.routes.node_comment import router as node_comment_router
 from api.routes.node_directive import router as node_directive_router
 from api.routes.node_history_action import router as node_history_action_router
@@ -50,6 +51,7 @@ router.include_router(event_source_router)
 router.include_router(event_status_router)
 router.include_router(event_type_router)
 router.include_router(event_vector_router)
+router.include_router(node_router)
 router.include_router(node_comment_router)
 router.include_router(node_directive_router)
 router.include_router(node_history_action_router)

--- a/backend/app/api/routes/node.py
+++ b/backend/app/api/routes/node.py
@@ -1,16 +1,24 @@
-from fastapi import status
+from fastapi import APIRouter, Depends, status
 from fastapi.exceptions import HTTPException
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 from uuid import UUID, uuid4
 
-from api.models.node import NodeCreate, NodeUpdate
+from api.models.node import NodeCreate, NodeUpdate, NodeVersion
+from api.routes import helpers
 from db import crud
+from db.database import get_db
 from db.schemas.node import Node
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
 from db.schemas.node_threat_actor import NodeThreatActor
+
+
+router = APIRouter(
+    prefix="/node",
+    tags=["Node"],
+)
 
 
 def create_node(
@@ -75,3 +83,15 @@ def update_node(node_update: NodeUpdate, uuid: UUID, db_table: DeclarativeMeta, 
     db_node.version = uuid4()
 
     return db_node
+
+
+#
+# READ
+#
+
+
+def get_node_version(uuid: UUID, db: Session = Depends(get_db)):
+    return crud.read(uuid=uuid, db_table=Node, db=db)
+
+
+helpers.api_route_read(router, get_node_version, NodeVersion, path="/{uuid}/version")

--- a/backend/app/tests/api/node/test_read.py
+++ b/backend/app/tests/api/node/test_read.py
@@ -1,0 +1,34 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_version_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/1/version")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_version_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.get(f"/api/node/{uuid.uuid4()}/version")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_version(client_valid_access_token, db):
+    # Create a Node
+    analysis = helpers.create_analysis(db=db)
+
+    get = client_valid_access_token.get(f"/api/node/{analysis.uuid}/version")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json() == {"version": str(analysis.version)}


### PR DESCRIPTION
This PR adds a `/node/{uuid}/version` API endpoint that returns the version of the given Node. This will be particularly useful for the GUI so that it can periodically poll the version when someone is viewing an alert. If the version from the API does not match the version of the alert in the data store, then the GUI knows that there are updates for the alert and can either pull them down automatically (and flash a message) or somehow alert the analyst so they can click a button to refresh.