### PR TITLE
Node Tree metadata

### DIFF
--- a/backend/app/api/models/node.py
+++ b/backend/app/api/models/node.py
@@ -67,7 +67,23 @@ class NodeTreeBase(BaseModel):
         orm_mode = True
 
 
+class NodeTreeMetadataDisplay(BaseModel):
+    type: Optional[type_str] = Field(description="An optional type override to use when displaying the Node in the GUI")
+
+    value: Optional[type_str] = Field(
+        description="An optional value override to use when displaying the Node in the GUI"
+    )
+
+
+class NodeTreeMetadata(BaseModel):
+    display: Optional[NodeTreeMetadataDisplay] = Field(
+        description="Optional attributes to include that will override how the Node is displayed in the GUI"
+    )
+
+
 class NodeTreeCreateWithNode(BaseModel):
+    node_metadata: Optional[NodeTreeMetadata] = Field(description="Optional metadata included with the Node")
+
     root_node_uuid: UUID4 = Field(
         description="""The node UUID that contains the tree.
             For example, an alert UUID that contains a tree of analyses and observables."""
@@ -81,29 +97,13 @@ class NodeTreeItemRead(NodeRead):
 
     first_appearance: bool = Field("Whether or not this is the first time the Node appears in the tree")
 
+    node_metadata: Optional[NodeTreeMetadata] = Field(description="Optional metadata included with the Node")
+
     parent_tree_uuid: Optional[UUID4] = Field(
         description="The node's parent leaf UUID if the node is inside a NodeTree"
     )
 
     tree_uuid: UUID4 = Field(description="The UUID of the leaf if this Node is inside a NodeTree")
-
-
-class NodeTreeRead(BaseModel):
-    root_node: NodeRead = Field(description="The root node of the tree. For example, this will often be an Alert.")
-
-    leaves: List[NodeTreeBase] = Field(description="A list of the leaves that make up the tree")
-
-    class Config:
-        orm_mode = True
-
-
-class NodeTreeUpdate(NodeTreeBase):
-    root_node_uuid: Optional[UUID4] = Field(
-        description="""The node UUID that contains the tree.
-            For example, an alert UUID that contains a tree of analyses and observables."""
-    )
-
-    node_uuid: Optional[UUID4] = Field(description="The UUID of the Node represented by the leaf")
 
 
 class NodeVersion(BaseModel):

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -48,6 +48,7 @@ def create_analysis(
 
     # Link the analysis to a Node Tree
     crud.create_node_tree_leaf(
+        node_metadata=analysis.node_tree.node_metadata,
         root_node_uuid=analysis.node_tree.root_node_uuid,
         parent_tree_uuid=analysis.node_tree.parent_tree_uuid,
         node_uuid=new_analysis.uuid,

--- a/backend/app/api/routes/observable.py
+++ b/backend/app/api/routes/observable.py
@@ -78,6 +78,7 @@ def create_observables(
     # Then link them to a Node Tree
     for observable in observables:
         crud.create_node_tree_leaf(
+            node_metadata=observable.node_tree.node_metadata,
             root_node_uuid=observable.node_tree.root_node_uuid,
             parent_tree_uuid=observable.node_tree.parent_tree_uuid,
             node_uuid=observable.uuid,

--- a/backend/app/db/migrations/versions/3144a1826e24_initial.py
+++ b/backend/app/db/migrations/versions/3144a1826e24_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: 7811ddacebd9
+Revision ID: 3144a1826e24
 Revises: 
-Create Date: 2022-01-04 14:23:58.299293
+Create Date: 2022-01-04 19:17:21.526530
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = '7811ddacebd9'
+revision = '3144a1826e24'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -262,6 +262,7 @@ def upgrade() -> None:
     op.create_index(op.f('ix_node_threat_node_threat_type_mapping_node_threat_uuid'), 'node_threat_node_threat_type_mapping', ['node_threat_uuid'], unique=False)
     op.create_table('node_tree',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('node_metadata', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
     sa.Column('root_node_uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('node_uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('parent_tree_uuid', postgresql.UUID(as_uuid=True), nullable=True),

--- a/backend/app/db/schemas/node_tree.py
+++ b/backend/app/db/schemas/node_tree.py
@@ -1,5 +1,5 @@
 from sqlalchemy import Column, ForeignKey, func, Index
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
 from db.database import Base
@@ -9,6 +9,8 @@ class NodeTree(Base):
     __tablename__ = "node_tree"
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    node_metadata = Column(JSONB)
 
     root_node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), nullable=False, index=True)
 

--- a/backend/app/tests/alerts/small.json
+++ b/backend/app/tests/alerts/small.json
@@ -17,16 +17,29 @@
             {
               "type": "email_address",
               "value": "badguy@evil.com",
+              "node_metadata": {
+                "display": {
+                  "type": "sender"
+                }
+              },
               "tags": ["from_address"],
               "analyses": [
                 {
                   "type": "Email Address Analysis",
-                  "observables": [{ "type": "fqdn", "value": "evil.com", "analyses": [
+                  "observables": [
                     {
-                      "type": "Test Analysis",
-                      "observables": [{ "type": "test_type", "value": "test_value" }]
+                      "type": "fqdn",
+                      "value": "evil.com",
+                      "analyses": [
+                        {
+                          "type": "Test Analysis",
+                          "observables": [
+                            { "type": "test_type", "value": "test_value" }
+                          ]
+                        }
+                      ]
                     }
-                  ] }]
+                  ]
                 }
               ]
             },
@@ -48,6 +61,11 @@
             {
               "type": "file",
               "value": "email.rfc822.unknown_plain_text_000",
+              "node_metadata": {
+                "display": {
+                  "value": "email plaintext body"
+                }
+              },
               "analyses": [
                 {
                   "type": "URL Extraction Analysis",
@@ -61,10 +79,16 @@
                           "observables": [
                             {
                               "type": "fqdn",
-                              "value": "evil.com", "analyses": [
+                              "value": "evil.com",
+                              "analyses": [
                                 {
                                   "type": "Test Analysis",
-                                  "observables": [{ "type": "test_type", "value": "test_value" }]
+                                  "observables": [
+                                    {
+                                      "type": "test_type",
+                                      "value": "test_value"
+                                    }
+                                  ]
                                 }
                               ]
                             },
@@ -96,7 +120,13 @@
     {
       "type": "ipv4",
       "value": "127.0.0.1",
-      "tags": ["c2", "contacted_host"]
+      "tags": ["c2", "contacted_host"],
+      "node_metadata": {
+        "display": {
+          "type": "private ip address",
+          "value": "localhost"
+        }
+      }
     }
   ]
 }

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -66,7 +66,6 @@ def test_get_all_empty(client_valid_access_token):
 
 
 def test_get_filter_disposition(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, disposition="FALSE_POSITIVE")
 
@@ -81,7 +80,6 @@ def test_get_filter_disposition(client_valid_access_token, db):
 
 
 def test_get_filter_disposition_user(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, disposition_user="analyst")
 
@@ -96,9 +94,8 @@ def test_get_filter_disposition_user(client_valid_access_token, db):
 
 
 def test_get_filter_dispositioned_after(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
-    alert = helpers.create_alert(db, disposition_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(db, disposition_time=datetime.utcnow())
     helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
 
     # There should be 3 total alerts
@@ -108,16 +105,15 @@ def test_get_filter_dispositioned_after(client_valid_access_token, db):
     # There should only be 1 alert when we filter by dispositioned_after. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"dispositioned_after": alert.disposition_time}
+    params = {"dispositioned_after": alert_tree2.node.disposition_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_dispositioned_before(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, disposition_time=datetime.utcnow() - timedelta(seconds=5))
-    alert = helpers.create_alert(db, disposition_time=datetime.utcnow())
+    alert_tree3 = helpers.create_alert(db, disposition_time=datetime.utcnow())
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -126,16 +122,15 @@ def test_get_filter_dispositioned_before(client_valid_access_token, db):
     # There should only be 1 alert when we filter by dispositioned_before. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"dispositioned_before": alert.disposition_time}
+    params = {"dispositioned_before": alert_tree3.node.disposition_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_dispositioned_after_and_before(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, disposition_time=datetime.utcnow() - timedelta(days=1))
+    alert_tree1 = helpers.create_alert(db, disposition_time=datetime.utcnow() - timedelta(days=1))
     helpers.create_alert(db, disposition_time=datetime.utcnow())
-    alert3 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(days=1))
+    alert_tree3 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(days=1))
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -144,14 +139,16 @@ def test_get_filter_dispositioned_after_and_before(client_valid_access_token, db
     # There should only be 1 alert when we filter by dispositioned_after and dispositioned_before.
     # But the timestamp has a timezone specified, which uses the + symbol that needs to be
     # urlencoded since it is a reserved URL character.
-    params = {"dispositioned_after": alert1.disposition_time, "dispositioned_before": alert3.disposition_time}
+    params = {
+        "dispositioned_after": alert_tree1.node.disposition_time,
+        "dispositioned_before": alert_tree3.node.disposition_time,
+    }
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_event_time_after(client_valid_access_token, db):
-    # Create some alerts
-    alert = helpers.create_alert(db, event_time=datetime.utcnow())
+    alert_tree1 = helpers.create_alert(db, event_time=datetime.utcnow())
     helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
 
     # There should be 2 total alerts
@@ -161,15 +158,14 @@ def test_get_filter_event_time_after(client_valid_access_token, db):
     # There should only be 1 alert when we filter by event_time_after. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"event_time_after": alert.event_time}
+    params = {"event_time_after": alert_tree1.node.event_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_event_time_before(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, event_time=datetime.utcnow())
-    alert = helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
+    alert_tree2 = helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
 
     # There should be 2 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -178,7 +174,7 @@ def test_get_filter_event_time_before(client_valid_access_token, db):
     # There should only be 1 alert when we filter by event_time_before. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"event_time_before": alert.event_time}
+    params = {"event_time_before": alert_tree2.node.event_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
@@ -189,10 +185,10 @@ def test_get_filter_event_uuid(client_valid_access_token, db):
 
     # Create some alerts
     helpers.create_alert(db)
-    alert = helpers.create_alert(db)
+    alert_tree2 = helpers.create_alert(db)
 
     # Add one alert to the event
-    alert.event_uuid = event.uuid
+    alert_tree2.node.event_uuid = event.uuid
 
     # There should be 2 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -205,8 +201,7 @@ def test_get_filter_event_uuid(client_valid_access_token, db):
 
 
 def test_get_filter_insert_time_after(client_valid_access_token, db):
-    # Create some alerts
-    alert = helpers.create_alert(db, insert_time=datetime.utcnow())
+    alert_tree1 = helpers.create_alert(db, insert_time=datetime.utcnow())
     helpers.create_alert(db, insert_time=datetime.utcnow() + timedelta(seconds=5))
 
     # There should be 2 total alerts
@@ -216,15 +211,14 @@ def test_get_filter_insert_time_after(client_valid_access_token, db):
     # There should only be 1 alert when we filter by insert_time_after. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"insert_time_after": alert.insert_time}
+    params = {"insert_time_after": alert_tree1.node.insert_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_insert_time_before(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, insert_time=datetime.utcnow() - timedelta(seconds=5))
-    alert = helpers.create_alert(db, insert_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(db, insert_time=datetime.utcnow())
 
     # There should be 2 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -233,13 +227,12 @@ def test_get_filter_insert_time_before(client_valid_access_token, db):
     # There should only be 1 alert when we filter by insert_time_before. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"insert_time_before": alert.insert_time}
+    params = {"insert_time_before": alert_tree2.node.insert_time}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_name(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, name="Test Alert")
     helpers.create_alert(db, name="Some Other Alert")
 
@@ -258,17 +251,17 @@ def test_get_filter_observable(client_valid_access_token, db):
     helpers.create_alert(db=db)
 
     # Create some alerts with one observable
-    alert1 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert1, type="test_type1", value="test_value1", db=db)
+    alert_tree1 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree1, type="test_type1", value="test_value1", db=db)
 
-    alert2 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type2", value="test_value2", db=db)
+    alert_tree2 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type2", value="test_value2", db=db)
 
     # Create an alert with multiple observables
-    alert3 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type1", value="test_value_asdf", db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type2", value="test_value1", db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type2", value="test_value2", db=db)
+    alert_tree3 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value2", db=db)
 
     # There should be 4 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -277,28 +270,28 @@ def test_get_filter_observable(client_valid_access_token, db):
     # There should only be 1 alert when we filter by the test_type1/test_value1 observable
     get = client_valid_access_token.get("/api/alert/?observable=test_type1|test_value1")
     assert get.json()["total"] == 1
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
 
     # There should be 2 alerts when we filter by the test_type2/test_value2 observable
     get = client_valid_access_token.get("/api/alert/?observable=test_type2|test_value2")
     assert get.json()["total"] == 2
-    assert any(a["uuid"] == str(alert2.uuid) for a in get.json()["items"])
-    assert any(a["uuid"] == str(alert3.uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree2.node_uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree3.node_uuid) for a in get.json()["items"])
 
 
 def test_get_filter_observable_types(client_valid_access_token, db):
     # Create an empty alert
     helpers.create_alert(db=db)
 
-    # Create some alerts with one observable
-    alert1 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert1, type="test_type1", value="test_value1", db=db)
+    # Create an alert with one observable
+    alert_tree1 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree1, type="test_type1", value="test_value1", db=db)
 
     # Create an alert with multiple observables
-    alert2 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type1", value="test_value_asdf", db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type2", value="test_value1", db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type2", value="test_value2", db=db)
+    alert_tree2 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type2", value="test_value2", db=db)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -307,13 +300,13 @@ def test_get_filter_observable_types(client_valid_access_token, db):
     # There should be 2 alerts when we filter by just test_type1
     get = client_valid_access_token.get("/api/alert/?observable_types=test_type1")
     assert get.json()["total"] == 2
-    assert any(a["uuid"] == str(alert1.uuid) for a in get.json()["items"])
-    assert any(a["uuid"] == str(alert2.uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree1.node_uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree2.node_uuid) for a in get.json()["items"])
 
     # There should only be 1 alert when we filter by the test_type1 and test_type2
     get = client_valid_access_token.get("/api/alert/?observable_types=test_type1,test_type2")
     assert get.json()["total"] == 1
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_filter_observable_value(client_valid_access_token, db):
@@ -321,17 +314,17 @@ def test_get_filter_observable_value(client_valid_access_token, db):
     helpers.create_alert(db=db)
 
     # Create some alerts with one observable
-    alert1 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert1, type="test_type1", value="test_value1", db=db)
+    alert_tree1 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree1, type="test_type1", value="test_value1", db=db)
 
-    alert2 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type2", value="test_value2", db=db)
+    alert_tree2 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type2", value="test_value2", db=db)
 
     # Create an alert with multiple observables
-    alert3 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type1", value="test_value_asdf", db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type2", value="test_value1", db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type2", value="test_value2", db=db)
+    alert_tree3 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value2", db=db)
 
     # There should be 4 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -340,13 +333,13 @@ def test_get_filter_observable_value(client_valid_access_token, db):
     # There should only be 1 alert when we filter by the test_value_asdf observable value
     get = client_valid_access_token.get("/api/alert/?observable_value=test_value_asdf")
     assert get.json()["total"] == 1
-    assert get.json()["items"][0]["uuid"] == str(alert3.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree3.node_uuid)
 
     # There should be 2 alerts when we filter by the test_value1 observable value
     get = client_valid_access_token.get("/api/alert/?observable_value=test_value1")
     assert get.json()["total"] == 2
-    assert any(a["uuid"] == str(alert1.uuid) for a in get.json()["items"])
-    assert any(a["uuid"] == str(alert3.uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree1.node_uuid) for a in get.json()["items"])
+    assert any(a["uuid"] == str(alert_tree3.node_uuid) for a in get.json()["items"])
 
 
 def test_get_filter_observable_and_observable_types(client_valid_access_token, db):
@@ -354,13 +347,13 @@ def test_get_filter_observable_and_observable_types(client_valid_access_token, d
     helpers.create_alert(db=db)
 
     # Create an alert with multiple observables
-    alert2 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type1", value="test_value1", db=db)
-    helpers.create_observable_in_tree(root_node=alert2, type="test_type2", value="test_value2", db=db)
+    alert_tree2 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type1", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type2", value="test_value2", db=db)
 
     # Create an alert with one observable
-    alert3 = helpers.create_alert(db=db)
-    helpers.create_observable_in_tree(root_node=alert3, type="test_type1", value="test_value1", db=db)
+    alert_tree3 = helpers.create_alert(db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type1", value="test_value1", db=db)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -369,14 +362,11 @@ def test_get_filter_observable_and_observable_types(client_valid_access_token, d
     # There should only be 1 alert when we filter by observable and observable_types
     get = client_valid_access_token.get("/api/alert/?observable_types=test_type1&observable=test_type2|test_value2")
     assert get.json()["total"] == 1
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_filter_owner(client_valid_access_token, db):
-    # Create an analyst user
     helpers.create_user(username="analyst", db=db)
-
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, owner="analyst")
 
@@ -391,7 +381,6 @@ def test_get_filter_owner(client_valid_access_token, db):
 
 
 def test_get_filter_queue(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, alert_queue="test_queue1")
     helpers.create_alert(db, alert_queue="test_queue2")
 
@@ -406,7 +395,6 @@ def test_get_filter_queue(client_valid_access_token, db):
 
 
 def test_get_filter_tags(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, tags=["tag1"])
     helpers.create_alert(db, tags=["tag2", "tag3", "tag4"])
@@ -434,7 +422,6 @@ def test_get_filter_tags(client_valid_access_token, db):
 
 
 def test_get_filter_threat_actors(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, threat_actors=["test_actor"])
 
@@ -453,7 +440,6 @@ def test_get_filter_threat_actors(client_valid_access_token, db):
 
 
 def test_get_filter_threats(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db)
     helpers.create_alert(db, threats=["threat1"])
     helpers.create_alert(db, threats=["threat2", "threat3", "threat4"])
@@ -481,7 +467,6 @@ def test_get_filter_threats(client_valid_access_token, db):
 
 
 def test_get_filter_tool(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, tool="test_tool1")
     helpers.create_alert(db, tool="test_tool2")
 
@@ -496,7 +481,6 @@ def test_get_filter_tool(client_valid_access_token, db):
 
 
 def test_get_filter_tool_instance(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, tool_instance="test_tool_instance1")
     helpers.create_alert(db, tool_instance="test_tool_instance2")
 
@@ -511,7 +495,6 @@ def test_get_filter_tool_instance(client_valid_access_token, db):
 
 
 def test_get_filter_type(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, alert_type="test_type")
     helpers.create_alert(db, alert_type="test_type2")
 
@@ -526,7 +509,6 @@ def test_get_filter_type(client_valid_access_token, db):
 
 
 def test_get_multiple_filters(client_valid_access_token, db):
-    # Create some alerts
     helpers.create_alert(db, alert_type="test_type1")
     helpers.create_alert(db, alert_type="test_type1", disposition="FALSE_POSITIVE")
     helpers.create_alert(db, alert_type="test_type2", disposition="FALSE_POSITIVE")
@@ -543,173 +525,163 @@ def test_get_multiple_filters(client_valid_access_token, db):
 
 
 def test_get_sort_by_disposition(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, disposition="DELIVERY")
-    alert2 = helpers.create_alert(db, disposition="FALSE_POSITIVE")
+    alert_tree1 = helpers.create_alert(db, disposition="DELIVERY")
+    alert_tree2 = helpers.create_alert(db, disposition="FALSE_POSITIVE")
 
     # If you sort descending, the FALSE_POSITIVE alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, the DELIVERY alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_disposition_time(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, disposition_time=datetime.utcnow())
-    alert2 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
+    alert_tree1 = helpers.create_alert(db, disposition_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
 
     # If you sort descending, the newest alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition_time|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, the oldest alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition_time|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_disposition_user(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, disposition_user="alice")
-    alert2 = helpers.create_alert(db, disposition_user="bob")
+    alert_tree1 = helpers.create_alert(db, disposition_user="alice")
+    alert_tree2 = helpers.create_alert(db, disposition_user="bob")
 
     # If you sort descending, bob's alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition_user|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, alice's alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition_user|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_event_time(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, event_time=datetime.utcnow())
-    alert2 = helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
+    alert_tree1 = helpers.create_alert(db, event_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(db, event_time=datetime.utcnow() + timedelta(seconds=5))
 
     # If you sort descending, the newest alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=event_time|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, the oldest alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=event_time|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_insert_time(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, insert_time=datetime.utcnow())
-    alert2 = helpers.create_alert(db, insert_time=datetime.utcnow() + timedelta(seconds=5))
+    alert_tree1 = helpers.create_alert(db, insert_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(db, insert_time=datetime.utcnow() + timedelta(seconds=5))
 
     # If you sort descending, the newest alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=insert_time|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, the oldest alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=insert_time|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_name(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, name="alert1")
-    alert2 = helpers.create_alert(db, name="alert2")
+    alert_tree1 = helpers.create_alert(db, name="alert1")
+    alert_tree2 = helpers.create_alert(db, name="alert2")
 
     # If you sort descending, alert2 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=name|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, alert1 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=name|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_owner(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, owner="alice")
-    alert2 = helpers.create_alert(db, owner="bob")
+    alert_tree1 = helpers.create_alert(db, owner="alice")
+    alert_tree2 = helpers.create_alert(db, owner="bob")
 
     # If you sort descending, bob's alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=owner|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, alice's alert (alert1) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=owner|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_queue(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, alert_queue="detect")
-    alert2 = helpers.create_alert(db, alert_queue="intel")
+    alert_tree1 = helpers.create_alert(db, alert_queue="detect")
+    alert_tree2 = helpers.create_alert(db, alert_queue="intel")
 
     # If you sort descending, alert2 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=queue|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, alert1 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=queue|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_sort_by_type(client_valid_access_token, db):
-    # Create some alerts
-    alert1 = helpers.create_alert(db, alert_type="type1")
-    alert2 = helpers.create_alert(db, alert_type="type2")
+    alert_tree1 = helpers.create_alert(db, alert_type="type1")
+    alert_tree2 = helpers.create_alert(db, alert_type="type2")
 
     # If you sort descending, alert2 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=type|desc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert2.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert1.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
 
     # If you sort ascending, alert1 should appear first
     get = client_valid_access_token.get("/api/alert/?sort=type|asc")
     assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert1.uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert2.uuid)
+    assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
 
 
 def test_get_alert_tree(client_valid_access_token, db):
-    # Create an alert with a tree of analyses and observable instances
-    alert = helpers.create_alert_from_json_file(db=db, json_path="/app/tests/alerts/small.json")
+    alert_tree = helpers.create_alert_from_json_file(db=db, json_path="/app/tests/alerts/small.json")
 
     # The small.json alert has 14 observables and 8 analyses. However, it only has two root observables.
-    get = client_valid_access_token.get(f"/api/alert/{alert.uuid}")
+    get = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}")
     assert str(get.json()["children"]).count("'observable'") == 14
     assert str(get.json()["children"]).count("'analysis'") == 8
     assert len(get.json()["children"]) == 2

--- a/backend/app/tests/api/analysis/test_read.py
+++ b/backend/app/tests/api/analysis/test_read.py
@@ -26,8 +26,9 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 
 
 def test_get(client_valid_access_token, db):
-    analysis = helpers.create_analysis(db=db)
+    alert_tree = helpers.create_alert(db=db)
+    analysis_tree = helpers.create_analysis(parent_tree=alert_tree, db=db)
 
-    get = client_valid_access_token.get(f"/api/analysis/{analysis.uuid}")
+    get = client_valid_access_token.get(f"/api/analysis/{analysis_tree.node.uuid}")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["node_type"] == "analysis"

--- a/backend/app/tests/api/node/test_read.py
+++ b/backend/app/tests/api/node/test_read.py
@@ -26,9 +26,9 @@ def test_get_version_nonexistent_uuid(client_valid_access_token):
 
 
 def test_get_version(client_valid_access_token, db):
-    # Create a Node
-    analysis = helpers.create_analysis(db=db)
+    alert_tree = helpers.create_alert(db=db)
+    analysis_tree = helpers.create_analysis(parent_tree=alert_tree, db=db)
 
-    get = client_valid_access_token.get(f"/api/node/{analysis.uuid}/version")
+    get = client_valid_access_token.get(f"/api/node/{analysis_tree.node_uuid}/version")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json() == {"version": str(analysis.version)}
+    assert get.json() == {"version": str(analysis_tree.node.version)}

--- a/backend/app/tests/api/node_comment/test_create.py
+++ b/backend/app/tests/api/node_comment/test_create.py
@@ -36,15 +36,12 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
 
 
 def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
-    # Create a node
-    node = helpers.create_alert(db=db)
-
-    # Create a user
+    alert_tree = helpers.create_alert(db=db)
     helpers.create_user(username="johndoe", db=db)
 
     # Create a comment
     create_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test",
@@ -54,7 +51,7 @@ def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
 
     # Make sure you cannot add the same comment value to a node
     create_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test",
@@ -70,15 +67,12 @@ def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
     ],
 )
 def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
-    # Create a node
-    node = helpers.create_alert(db=db)
-
-    # Create a user
+    alert_tree = helpers.create_alert(db=db)
     helpers.create_user(username="johndoe", db=db)
 
     # Create a comment
     create1_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test",
@@ -87,7 +81,7 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
 
     # Ensure you cannot create another comment with the same unique field value
     create2_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test2",
@@ -98,7 +92,6 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
 
 
 def test_create_nonexistent_node_uuid(client_valid_access_token, db):
-    # Create a user
     helpers.create_user(username="johndoe", db=db)
 
     # Create a comment
@@ -113,12 +106,11 @@ def test_create_nonexistent_node_uuid(client_valid_access_token, db):
 
 
 def test_create_nonexistent_user(client_valid_access_token, db):
-    # Create a node
-    node = helpers.create_alert(db=db)
+    alert_tree = helpers.create_alert(db=db)
 
     # Create a comment
     create_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test",
@@ -133,22 +125,19 @@ def test_create_nonexistent_user(client_valid_access_token, db):
 
 
 def test_create_valid_required_fields(client_valid_access_token, db):
-    # Create a node
-    node = helpers.create_alert(db=db)
-    initial_node_version = node.version
-
-    # Create a user
+    alert_tree = helpers.create_alert(db=db)
+    initial_node_version = alert_tree.node.version
     helpers.create_user(username="johndoe", db=db)
 
     # Create a comment
     create_json = {
-        "node_uuid": str(node.uuid),
+        "node_uuid": str(alert_tree.node_uuid),
         "user": "johndoe",
         "uuid": str(uuid.uuid4()),
         "value": "test",
     }
     create = client_valid_access_token.post("/api/node/comment/", json=create_json)
     assert create.status_code == status.HTTP_201_CREATED
-    assert len(node.comments) == 1
-    assert node.comments[0].value == "test"
-    assert node.version != initial_node_version
+    assert len(alert_tree.node.comments) == 1
+    assert alert_tree.node.comments[0].value == "test"
+    assert alert_tree.node.version != initial_node_version

--- a/backend/app/tests/api/node_comment/test_delete.py
+++ b/backend/app/tests/api/node_comment/test_delete.py
@@ -33,11 +33,11 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 
 def test_delete(client_valid_access_token, db):
     # Create a node
-    node = helpers.create_alert(db=db)
+    node_tree = helpers.create_alert(db=db)
 
     # Create a comment
-    comment = helpers.create_node_comment(node=node, username="johndoe", value="test", db=db)
-    assert len(node.comments) == 1
+    comment = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test", db=db)
+    assert len(node_tree.node.comments) == 1
 
     # Delete it
     delete = client_valid_access_token.delete(f"/api/node/comment/{comment.uuid}")
@@ -48,4 +48,4 @@ def test_delete(client_valid_access_token, db):
     assert get.status_code == status.HTTP_404_NOT_FOUND
 
     # And make sure the node no longer shows the comment
-    assert len(node.comments) == 0
+    assert len(node_tree.node.comments) == 0

--- a/backend/app/tests/api/node_comment/test_update.py
+++ b/backend/app/tests/api/node_comment/test_update.py
@@ -37,11 +37,11 @@ def test_update_nonexistent_uuid(client_valid_access_token):
 
 def test_update_duplicate_node_uuid_value(client_valid_access_token, db):
     # Create a node
-    node = helpers.create_alert(db=db)
+    node_tree = helpers.create_alert(db=db)
 
     # Create some comments
-    comment1 = helpers.create_node_comment(node=node, username="johndoe", value="test", db=db)
-    comment2 = helpers.create_node_comment(node=node, username="johndoe", value="test2", db=db)
+    comment1 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test", db=db)
+    comment2 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test2", db=db)
 
     # Make sure you cannot update a comment on a node to one that already exists
     update = client_valid_access_token.patch(f"/api/node/comment/{comment2.uuid}", json={"value": comment1.value})
@@ -55,13 +55,13 @@ def test_update_duplicate_node_uuid_value(client_valid_access_token, db):
 
 def test_update(client_valid_access_token, db):
     # Create a node
-    node = helpers.create_alert(db=db)
+    node_tree = helpers.create_alert(db=db)
 
     # Create a comment
-    comment = helpers.create_node_comment(node=node, username="johndoe", value="test", db=db)
-    assert node.comments[0].value == "test"
+    comment = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test", db=db)
+    assert node_tree.node.comments[0].value == "test"
 
     # Update it
     update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
-    assert node.comments[0].value == "updated"
+    assert node_tree.node.comments[0].value == "updated"

--- a/backend/app/tests/api/observable/test_read.py
+++ b/backend/app/tests/api/observable/test_read.py
@@ -26,17 +26,22 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 
 
 def test_get(client_valid_access_token, db):
-    observable = helpers.create_observable(type="test_type", value="test_value", db=db)
+    alert_tree = helpers.create_alert(db=db)
+    observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
 
-    get = client_valid_access_token.get(f"/api/observable/{observable.uuid}")
+    get = client_valid_access_token.get(f"/api/observable/{observable_tree.node.uuid}")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["node_type"] == "observable"
 
 
 def test_get_all(client_valid_access_token, db):
-    # Create some objects
-    helpers.create_observable(type="test_type", value="test", db=db)
-    helpers.create_observable(type="test_type", value="test2", db=db)
+    alert_tree = helpers.create_alert(db=db)
+    observable_tree = helpers.create_observable(type="test_type", value="test", parent_tree=alert_tree, db=db)
+    helpers.create_observable(type="test_type", value="test2", parent_tree=alert_tree, db=db)
+
+    # Adding a third observable somewhere in the alert tree with the same type+value combination is allowed,
+    # but it will not result in a third entry in the observable table.
+    helpers.create_observable(type="test_type", value="test2", parent_tree=observable_tree, db=db)
 
     # Read them back
     get = client_valid_access_token.get("/api/observable/")

--- a/frontend/src/components/Alerts/AlertTree.vue
+++ b/frontend/src/components/Alerts/AlertTree.vue
@@ -104,7 +104,30 @@
     if (isAnalysis(item)) {
       return item.analysisModuleType.value;
     } else {
-      return item.type.value + ": " + item.value;
+      let type = null;
+      let value = null;
+
+      try {
+        if (item.nodeMetadata.display) {
+          if (item.nodeMetadata.display.type) {
+            type =
+              item.nodeMetadata.display.type + " (" + item.type.value + ")";
+          } else {
+            type = item.type.value;
+          }
+
+          if (item.nodeMetadata.display.value) {
+            value = item.nodeMetadata.display.value;
+          } else {
+            value = item.value;
+          }
+        }
+      } catch (error) {
+        type = item.type.value;
+        value = item.value;
+      }
+
+      return type + ": " + value;
     }
   }
   function isAnalysis(item) {

--- a/frontend/src/models/analysis.ts
+++ b/frontend/src/models/analysis.ts
@@ -1,5 +1,11 @@
 import { UUID } from "./base";
-import { nodeCreate, nodeRead, nodeTreeCreate, nodeUpdate } from "./node";
+import {
+  nodeCreate,
+  nodeMetadata,
+  nodeRead,
+  nodeTreeCreate,
+  nodeUpdate,
+} from "./node";
 import {
   analysisModuleTypeNodeTreeRead,
   analysisModuleTypeRead,
@@ -28,6 +34,7 @@ export interface analysisTreeRead extends nodeRead {
   analysisModuleType: analysisModuleTypeNodeTreeRead;
   children: observableTreeRead[];
   firstAppearance?: boolean;
+  nodeMetadata?: nodeMetadata;
   parentTreeUuid: UUID | null;
   treeUuid: UUID;
 }

--- a/frontend/src/models/node.ts
+++ b/frontend/src/models/node.ts
@@ -5,6 +5,15 @@ export interface nodeCreate {
   version?: UUID;
 }
 
+interface nodeMetadataDisplay {
+  type?: string;
+  value?: string;
+}
+
+export interface nodeMetadata {
+  display?: nodeMetadataDisplay;
+}
+
 export interface nodeRead {
   nodeType: string;
   uuid: UUID;

--- a/frontend/src/models/observable.ts
+++ b/frontend/src/models/observable.ts
@@ -1,6 +1,12 @@
 import { analysisTreeRead } from "./analysis";
 import { UUID } from "./base";
-import { nodeCreate, nodeRead, nodeTreeCreate, nodeUpdate } from "./node";
+import {
+  nodeCreate,
+  nodeMetadata,
+  nodeRead,
+  nodeTreeCreate,
+  nodeUpdate,
+} from "./node";
 import { nodeCommentRead } from "./nodeComment";
 import { nodeDirectiveRead } from "./nodeDirective";
 import { nodeTagRead } from "./nodeTag";
@@ -49,6 +55,7 @@ export interface observableReadPage {
 export interface observableTreeRead extends observableRead {
   children: analysisTreeRead[];
   firstAppearance?: boolean;
+  nodeMetadata?: nodeMetadata;
   parentTreeUuid: UUID | null;
   treeUuid: UUID;
 }


### PR DESCRIPTION
ACE 1.0 recently added a feature that allows analysis modules to override an observable's type or value when it is displayed in the GUI. This PR adds similar functionality. The original use case was for email-based alerts so that instead of using tags to denote the sender/recipient `email_address` observables you could just override the `email_address` observable type to be something like `sender` and `recipient` instead.

This makes it much clearer when looking at an alert where observables might have several tags to more immediately gain that context of what the observable is. An example is shown below:

![Screenshot 2022-01-06 091119](https://user-images.githubusercontent.com/22526682/148447190-c876352c-ea2f-4a53-9e47-41452f763463.png)

1. The first circled item is an example of overriding the observable's type. The original type is still shown in the parentheses.
2. The second circled item is an example of overriding an observable's value. The original value is not shown.
3. The final circled item is an example of overriding both the type and value.

**NOTE:** This does not change the observable's type, nor does it add new types. This is purely a nicety for looking at an alert tree. You also cannot filter alerts by the overridden observable types or values. Using the screenshot example above, this means that you cannot filter alerts by the `sender` observable type, as that does not actually exist.