### PR TITLE
Fixes bug when sorting alerts by nullable columns

### DIFF
--- a/backend/app/api/routes/alert.py
+++ b/backend/app/api/routes/alert.py
@@ -293,9 +293,9 @@ def get_all_alerts(
         # Only sort by disposition if we are not also filtering by disposition
         if sort_by.lower() == "disposition" and not disposition:
             if order == "asc":
-                query = query.join(AlertDisposition).order_by(AlertDisposition.value.asc())
+                query = query.outerjoin(AlertDisposition).order_by(AlertDisposition.value.asc())
             else:
-                query = query.join(AlertDisposition).order_by(AlertDisposition.value.desc())
+                query = query.outerjoin(AlertDisposition).order_by(AlertDisposition.value.desc())
 
         elif sort_by.lower() == "disposition_time":
             if order == "asc":
@@ -305,7 +305,7 @@ def get_all_alerts(
 
         # Only sort by disposition_user if we are not also filtering by disposition_user
         elif sort_by.lower() == "disposition_user" and not disposition_user:
-            query = query.join(User, onclause=Alert.disposition_user_uuid == User.uuid).group_by(
+            query = query.outerjoin(User, onclause=Alert.disposition_user_uuid == User.uuid).group_by(
                 Alert.uuid, Node.uuid, User.username
             )
             if order == "asc":
@@ -333,7 +333,7 @@ def get_all_alerts(
 
         # Only sort by owner if we are not also filtering by owner
         elif sort_by.lower() == "owner" and not owner:
-            query = query.join(User, onclause=Alert.owner_uuid == User.uuid).group_by(
+            query = query.outerjoin(User, onclause=Alert.owner_uuid == User.uuid).group_by(
                 Alert.uuid, Node.uuid, User.username
             )
             if order == "asc":

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -527,18 +527,21 @@ def test_get_multiple_filters(client_valid_access_token, db):
 def test_get_sort_by_disposition(client_valid_access_token, db):
     alert_tree1 = helpers.create_alert(db, disposition="DELIVERY")
     alert_tree2 = helpers.create_alert(db, disposition="FALSE_POSITIVE")
+    alert_tree3 = helpers.create_alert(db)
 
-    # If you sort descending, the FALSE_POSITIVE alert (alert2) should appear first
+    # If you sort descending: null disposition, FALSE_POSITIVE, DELIVERY
     get = client_valid_access_token.get("/api/alert/?sort=disposition|desc")
-    assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["total"] == 3
+    assert get.json()["items"][0]["uuid"] == str(alert_tree3.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree1.node_uuid)
 
-    # If you sort ascending, the DELIVERY alert (alert1) should appear first
+    # If you sort ascending: DELIVERY, FALSE_POSITIVE, null disposition
     get = client_valid_access_token.get("/api/alert/?sort=disposition|asc")
-    assert get.json()["total"] == 2
+    assert get.json()["total"] == 3
     assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
     assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree3.node_uuid)
 
 
 def test_get_sort_by_disposition_time(client_valid_access_token, db):
@@ -561,18 +564,21 @@ def test_get_sort_by_disposition_time(client_valid_access_token, db):
 def test_get_sort_by_disposition_user(client_valid_access_token, db):
     alert_tree1 = helpers.create_alert(db, disposition_user="alice")
     alert_tree2 = helpers.create_alert(db, disposition_user="bob")
+    alert_tree3 = helpers.create_alert(db)
 
-    # If you sort descending, bob's alert (alert2) should appear first
+    # If you sort descending: null user, bob, alice
     get = client_valid_access_token.get("/api/alert/?sort=disposition_user|desc")
-    assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["total"] == 3
+    assert get.json()["items"][0]["uuid"] == str(alert_tree3.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree1.node_uuid)
 
-    # If you sort ascending, alice's alert (alert1) should appear first
+    # If you sort ascending: alice, bob, null user
     get = client_valid_access_token.get("/api/alert/?sort=disposition_user|asc")
-    assert get.json()["total"] == 2
+    assert get.json()["total"] == 3
     assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
     assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree3.node_uuid)
 
 
 def test_get_sort_by_event_time(client_valid_access_token, db):
@@ -629,18 +635,21 @@ def test_get_sort_by_name(client_valid_access_token, db):
 def test_get_sort_by_owner(client_valid_access_token, db):
     alert_tree1 = helpers.create_alert(db, owner="alice")
     alert_tree2 = helpers.create_alert(db, owner="bob")
+    alert_tree3 = helpers.create_alert(db)
 
-    # If you sort descending, bob's alert (alert2) should appear first
+    # If you sort descending: null owner, bob, alice
     get = client_valid_access_token.get("/api/alert/?sort=owner|desc")
-    assert get.json()["total"] == 2
-    assert get.json()["items"][0]["uuid"] == str(alert_tree2.node_uuid)
-    assert get.json()["items"][1]["uuid"] == str(alert_tree1.node_uuid)
+    assert get.json()["total"] == 3
+    assert get.json()["items"][0]["uuid"] == str(alert_tree3.node_uuid)
+    assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree1.node_uuid)
 
-    # If you sort ascending, alice's alert (alert1) should appear first
+    # If you sort ascending: alice, bob, null owner
     get = client_valid_access_token.get("/api/alert/?sort=owner|asc")
-    assert get.json()["total"] == 2
+    assert get.json()["total"] == 3
     assert get.json()["items"][0]["uuid"] == str(alert_tree1.node_uuid)
     assert get.json()["items"][1]["uuid"] == str(alert_tree2.node_uuid)
+    assert get.json()["items"][2]["uuid"] == str(alert_tree3.node_uuid)
 
 
 def test_get_sort_by_queue(client_valid_access_token, db):


### PR DESCRIPTION
This fixes an issue with the SQL JOINs being used when sorting alerts by columns that can be nullable. Using an inner join caused the alerts with NULL in the column to be removed from the result.