### PR TITLE
Update multiple alerts with a single API call

### DIFF
--- a/backend/app/api/models/alert.py
+++ b/backend/app/api/models/alert.py
@@ -36,7 +36,6 @@ class AlertBase(NodeBase):
 
     queue: type_str = Field(description="The alert queue containing this alert")
 
-    # TODO: When we have authentication, creating a manual alert will infer the owner from the token.
     owner: Optional[type_str] = Field(description="The username of the user who has taken ownership of this alert")
 
 
@@ -104,11 +103,6 @@ class AlertRead(NodeRead, AlertBase):
 class AlertUpdate(NodeUpdate, AlertBase):
     disposition: Optional[type_str] = Field(description="The disposition assigned to this alert")
 
-    # TODO: This should not be editable. When we have authentication in place, the user will be inferred from the token.
-    # disposition_user: Optional[type_str] = Field(
-    #     description="The username of the user who most recently dispositioned this alert"
-    # )
-
     event_uuid: Optional[UUID4] = Field(description="The UUID of the event containing this alert")
 
     queue: Optional[type_str] = Field(description="The alert queue containing this alert")
@@ -120,6 +114,10 @@ class AlertUpdate(NodeUpdate, AlertBase):
     threats: Optional[List[type_str]] = Field(description="A list of threats to add to the alert")
 
     _prevent_none: classmethod = validators.prevent_none("queue", "tags", "threat_actors", "threats")
+
+
+class AlertUpdateMultiple(AlertUpdate):
+    uuid: UUID4 = Field(description="The UUID of the alert")
 
 
 class AlertTreeRead(AlertRead, NodeTreeItemRead):

--- a/frontend/src/components/Alerts/TheAlertActionToolbar.vue
+++ b/frontend/src/components/Alerts/TheAlertActionToolbar.vue
@@ -106,11 +106,12 @@
 
   async function takeOwnership() {
     try {
-      for (const uuid of selectedAlertStore.selected) {
-        await alertStore.update(uuid, {
-          owner: authStore.user.username,
-        });
-      }
+      const updateData = selectedAlertStore.selected.map((uuid) => ({
+        uuid: uuid,
+        owner: authStore.user.username,
+      }));
+
+      await alertStore.update(updateData);
     } catch (err) {
       error.value = err.message;
     }

--- a/frontend/src/components/Modals/AssignModal.vue
+++ b/frontend/src/components/Modals/AssignModal.vue
@@ -72,11 +72,12 @@
     isLoading.value = true;
 
     try {
-      for (const uuid of selectedAlertStore.selected) {
-        await alertStore.update(uuid, {
-          owner: selectedUser.value.username,
-        });
-      }
+      const updateData = selectedAlertStore.selected.map((uuid) => ({
+        uuid: uuid,
+        owner: selectedUser.value.username,
+      }));
+
+      await alertStore.update(updateData);
     } catch (err) {
       error.value = err.message;
     }

--- a/frontend/src/components/Modals/DispositionModal.vue
+++ b/frontend/src/components/Modals/DispositionModal.vue
@@ -91,10 +91,14 @@
     isLoading.value = true;
 
     try {
+      const updateData = selectedAlertStore.selected.map((uuid) => ({
+        uuid: uuid,
+        disposition: newDisposition.value.value,
+      }));
+
+      await alertStore.update(updateData);
+
       for (const uuid of selectedAlertStore.selected) {
-        await alertStore.update(uuid, {
-          disposition: newDisposition.value.value,
-        });
         if (dispositionComment.value) {
           await NodeComment.create({ ...commentData.value, nodeUuid: uuid });
         }

--- a/frontend/src/components/Modals/TagModal.vue
+++ b/frontend/src/components/Modals/TagModal.vue
@@ -84,11 +84,13 @@
     isLoading.value = true;
     try {
       await createTags(newTags.value);
-      for (const uuid of selectedAlertStore.selected) {
-        await alertStore.update(uuid, {
-          tags: newAlertTags(uuid, newTags.value),
-        });
-      }
+
+      const updateData = selectedAlertStore.selected.map((uuid) => ({
+        uuid: uuid,
+        tags: newAlertTags(uuid, newTags.value),
+      }));
+
+      await alertStore.update(updateData);
     } catch (err) {
       error.value = err.message;
     }

--- a/frontend/src/models/alert.ts
+++ b/frontend/src/models/alert.ts
@@ -94,6 +94,7 @@ export interface alertUpdate extends nodeUpdate {
   tags?: string[];
   threatActors?: string[];
   threats?: string[];
+  uuid: UUID;
   [key: string]: unknown;
 }
 

--- a/frontend/src/services/api/alert.ts
+++ b/frontend/src/services/api/alert.ts
@@ -41,6 +41,6 @@ export const Alert = {
     return api.read(`${endpoint}`, params);
   },
 
-  update: (uuid: UUID, data: alertUpdate): Promise<void> =>
-    api.update(`${endpoint}${uuid}`, data),
+  update: (data: alertUpdate[]): Promise<void> =>
+    api.update(`${endpoint}`, data),
 };

--- a/frontend/src/services/api/base.ts
+++ b/frontend/src/services/api/base.ts
@@ -28,7 +28,7 @@ export class BaseApi {
     url: string,
     method: Method,
     options?: {
-      data?: Record<string, unknown>;
+      data?: Record<string, unknown> | Record<string, unknown>[];
       params?: Record<string, unknown>;
     },
     getAfterCreate = false,
@@ -41,7 +41,11 @@ export class BaseApi {
 
     if (options) {
       if (options.data) {
-        config["data"] = this.formatOutgoingData(options.data);
+        if (Array.isArray(options.data)) {
+          config["data"] = options.data.map((x) => this.formatOutgoingData(x));
+        } else {
+          config["data"] = this.formatOutgoingData(options.data);
+        }
       }
 
       if (options.params) {
@@ -106,7 +110,10 @@ export class BaseApi {
     return results;
   }
 
-  async update(url: string, data?: Record<string, unknown>): Promise<any> {
+  async update(
+    url: string,
+    data?: Record<string, unknown> | Record<string, unknown>[],
+  ): Promise<any> {
     return await this.baseRequest(url, "PATCH", { data: data });
   }
 }

--- a/frontend/src/stores/alert.ts
+++ b/frontend/src/stores/alert.ts
@@ -35,20 +35,11 @@ export const useAlertStore = defineStore({
         });
     },
 
-    async update(uuid: UUID, data: alertUpdate) {
+    async update(data: alertUpdate[]) {
       // once we get around to updating alerts, we will need to update the base api service to have a
       // 'getAfterUpdate' option like there is for 'create'
       // then we can reset the open/queried alert(s)
-      await Alert.update(uuid, data).catch((error) => {
-        throw error;
-      });
-    },
-
-    // reason enough to have an updateMultiple in api?
-    async updateMultiple(uuids: UUID[], data: alertUpdate) {
-      const promises = uuids.map((u) => Alert.update(u, data));
-
-      await Promise.all(promises).catch((error) => {
+      await Alert.update(data).catch((error) => {
         throw error;
       });
     },

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -134,9 +134,7 @@ describe("ViewAlert.vue", () => {
 
   // Disposition
   it.only("should make a request to update and get updated alert when disposition is set", () => {
-    cy.intercept("PATCH", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
-      "updateAlert",
-    );
+    cy.intercept("PATCH", "/api/alert/").as("updateAlert");
     cy.intercept("POST", "/api/node/comment").as("createComment");
     cy.intercept("GET", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
       "getAlert",
@@ -153,9 +151,7 @@ describe("ViewAlert.vue", () => {
     cy.get(".p-dialog-footer > .p-button").click();
     cy.get(".p-dialog-content").should("not.exist");
 
-    cy.intercept("PATCH", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
-      "updateAlert",
-    );
+    cy.intercept("PATCH", "/api/alert/").as("updateAlert");
 
     cy.wait("@updateAlert").its("state").should("eq", "Complete");
     cy.wait("@createComment").its("state").should("eq", "Complete");
@@ -187,9 +183,7 @@ describe("ViewAlert.vue", () => {
 
   // Take Ownership
   it("should make a request to update and get updated alert take ownership is clicked", () => {
-    cy.intercept("PATCH", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
-      "updateAlert",
-    );
+    cy.intercept("PATCH", "/api/alert/").as("updateAlert");
     cy.intercept("GET", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
       "getAlert",
     );
@@ -203,9 +197,7 @@ describe("ViewAlert.vue", () => {
 
   // Assign
   it("should make a request to update owner and get updated alert when owner is set", () => {
-    cy.intercept("PATCH", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
-      "updateAlert",
-    );
+    cy.intercept("PATCH", "/api/alert/").as("updateAlert");
     cy.intercept("GET", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
       "getAlert",
     );
@@ -225,9 +217,7 @@ describe("ViewAlert.vue", () => {
 
   // Tag
   it("should make a request to update tags and get updated alert when owner is set", () => {
-    cy.intercept("PATCH", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
-      "updateAlert",
-    );
+    cy.intercept("PATCH", "/api/alert/").as("updateAlert");
     cy.intercept("GET", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
       "getAlert",
     );

--- a/frontend/tests/unit/src/components/Alerts/TheAlertActionToolbar.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertActionToolbar.spec.ts
@@ -98,14 +98,12 @@ describe("TheAlertActionToolbar.vue", () => {
   it("updates ownership of alert to current user and requests alertTable reload when Take Ownership clicked", async () => {
     await wrapper.setProps({ page: "Manage Alerts" });
     myNock
-      .options("/alert/uuid1")
+      .options("/alert/")
       .reply(200)
-      .patch("/alert/uuid1", { owner: "testingUser" })
-      .reply(204);
-    myNock
-      .options("/alert/uuid2")
-      .reply(200)
-      .patch("/alert/uuid2", { owner: "testingUser" })
+      .patch("/alert/", [
+        { uuid: "uuid1", owner: "testingUser" },
+        { uuid: "uuid2", owner: "testingUser" },
+      ])
       .reply(204);
     wrapper.vm.authStore.user = { username: "testingUser" };
     wrapper.vm.selectedAlertStore.selected = ["uuid1", "uuid2"];
@@ -118,11 +116,7 @@ describe("TheAlertActionToolbar.vue", () => {
     wrapper.vm.alertTableStore.$reset();
     wrapper.vm.alertStore.$reset();
     await wrapper.setProps({ page: "Manage Alerts" });
-    myNock
-      .options("/alert/uuid1")
-      .reply(200)
-      .patch("/alert/uuid1", { owner: "testingUser" })
-      .reply(403);
+    myNock.options("/alert/").reply(200).patch("/alert/").reply(403);
     wrapper.vm.authStore.user = { username: "testingUser" };
     wrapper.vm.selectedAlertStore.selected = ["uuid1", "uuid2"];
     await wrapper.vm.takeOwnership();

--- a/frontend/tests/unit/src/components/Modals/AssignModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/AssignModal.spec.ts
@@ -95,10 +95,13 @@ describe("AssignModal.vue", () => {
     wrapper.vm.selectedUser = { username: "Alice" };
 
     // Mock the update alert API call
-    myNock.options("/alert/1").reply(200, "Success");
-    myNock.patch("/alert/1", '{"owner":"Alice"}').reply(200, "Success");
-    myNock.options("/alert/2").reply(200, "Success");
-    myNock.patch("/alert/2", '{"owner":"Alice"}').reply(200, "Success");
+    myNock.options("/alert/").reply(200, "Success");
+    myNock
+      .patch("/alert/", [
+        { uuid: "1", owner: "Alice" },
+        { uuid: "2", owner: "Alice" },
+      ])
+      .reply(200, "Success");
 
     expect(wrapper.vm.modalStore.openModals).toStrictEqual([]);
     wrapper.vm.modalStore.open("AssignModal");
@@ -120,9 +123,9 @@ describe("AssignModal.vue", () => {
 
     // Mock the update alert API call
     const updateAlert = myNock
-      .options("/alert/1")
+      .options("/alert/")
       .reply(200, "Success")
-      .patch("/alert/1", '{"owner":"Alice"}')
+      .patch("/alert/")
       .reply(403, "Unauthorized");
 
     expect(wrapper.vm.modalStore.openModals).toStrictEqual([]);

--- a/frontend/tests/unit/src/components/Modals/DispositionModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/DispositionModal.spec.ts
@@ -71,21 +71,21 @@ describe("DispositionModal.vue", () => {
     expect(wrapper.vm.allowSubmit).toBeFalsy();
     // No alerts selected and value set
     wrapper.vm.selectedAlertStore.selected = [];
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     expect(wrapper.vm.allowSubmit).toBeFalsy();
     // Alerts selected and value set
     wrapper.vm.selectedAlertStore.selected = ["1", "2"];
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     expect(wrapper.vm.allowSubmit).toBeTruthy();
   });
 
   it("correctly computes showAddToEventButton", () => {
     const { wrapper } = factory();
 
-    wrapper.vm.newDisposition = { value: "high dispostion", rank: 2 };
+    wrapper.vm.newDisposition = { value: "high disposition", rank: 2 };
     expect(wrapper.vm.showAddToEventButton).toBeTruthy();
 
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     expect(wrapper.vm.showAddToEventButton).toBeFalsy();
   });
   it("has the correctly assigned name 'DispositionModal'", () => {
@@ -122,7 +122,7 @@ describe("DispositionModal.vue", () => {
   it("will remove the DispositionModal from open modals store and clear newDisposition and dispositionComment on close", async () => {
     const { wrapper } = factory({ stubActions: false });
 
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     wrapper.vm.dispositionComment = "test comment";
     wrapper.vm.modalStore.open("DispositionModal");
 
@@ -143,17 +143,16 @@ describe("DispositionModal.vue", () => {
     wrapper.vm.authStore.user = { username: "Alice" };
 
     // Set the new disposition / comment values
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     wrapper.vm.dispositionComment = "test comment";
 
     // Mock the update alert API calls
-    myNock.options("/alert/1").reply(200, "Success");
+    myNock.options("/alert/").reply(200, "Success");
     myNock
-      .patch("/alert/1", '{"disposition":"low dispostion"}')
-      .reply(200, "Success");
-    myNock.options("/alert/2").reply(200, "Success");
-    myNock
-      .patch("/alert/2", '{"disposition":"low dispostion"}')
+      .patch("/alert/", [
+        { uuid: "1", disposition: "low disposition" },
+        { uuid: "2", disposition: "low disposition" },
+      ])
       .reply(200, "Success");
     myNock
       .post("/node/comment/", {
@@ -192,16 +191,15 @@ describe("DispositionModal.vue", () => {
     wrapper.vm.authStore.user = { username: "Alice" };
 
     // Set the new disposition / comment values
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
 
     // Mock the update alert API calls
-    myNock.options("/alert/1").reply(200, "Success");
+    myNock.options("/alert/").reply(200, "Success");
     myNock
-      .patch("/alert/1", '{"disposition":"low dispostion"}')
-      .reply(200, "Success");
-    myNock.options("/alert/2").reply(200, "Success");
-    myNock
-      .patch("/alert/2", '{"disposition":"low dispostion"}')
+      .patch("/alert/", [
+        { uuid: "1", disposition: "low disposition" },
+        { uuid: "2", disposition: "low disposition" },
+      ])
       .reply(200, "Success");
 
     expect(wrapper.vm.modalStore.openModals).toStrictEqual([]);
@@ -226,14 +224,12 @@ describe("DispositionModal.vue", () => {
     wrapper.vm.authStore.user = { username: "Alice" };
 
     // Set the new disposition / comment values
-    wrapper.vm.newDisposition = { value: "low dispostion", rank: 1 };
+    wrapper.vm.newDisposition = { value: "low disposition", rank: 1 };
     wrapper.vm.dispositionComment = "test comment";
 
     // Mock the update alert API call
-    myNock.options("/alert/1").reply(200, "Success");
-    const updateAlert = myNock
-      .patch("/alert/1", '{"disposition":"low dispostion"}')
-      .reply(403, "Failure");
+    myNock.options("/alert/").reply(200, "Success");
+    const updateAlert = myNock.patch("/alert/").reply(403, "Failure");
 
     expect(wrapper.vm.modalStore.openModals).toStrictEqual([]);
     wrapper.vm.modalStore.open("DispositionModal");
@@ -244,7 +240,7 @@ describe("DispositionModal.vue", () => {
     expect(updateAlert.isDone()).toBe(true);
     expect(wrapper.vm.error).toEqual("Request failed with status code 403");
     expect(wrapper.vm.newDisposition).toEqual({
-      value: "low dispostion",
+      value: "low disposition",
       rank: 1,
     });
     expect(wrapper.vm.dispositionComment).toEqual("test comment");

--- a/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
@@ -176,13 +176,12 @@ describe("TagModal.vue", () => {
         items: [{ value: "tag1" }, { value: "tag2" }, { value: "tag3" }],
       });
     myNock.post("/node/tag/", { value: "tag2" }).reply(200);
-    myNock.options("/alert/uuid1").reply(200, "Success");
+    myNock.options("/alert/").reply(200, "Success");
     myNock
-      .patch("/alert/uuid1", '{"tags":["tag1","tag2"]}')
-      .reply(200, "Success");
-    myNock.options("/alert/uuid2").reply(200, "Success");
-    myNock
-      .patch("/alert/uuid2", '{"tags":["tag1","tag1","tag2"]}')
+      .patch("/alert/", [
+        { uuid: "uuid1", tags: ["tag1", "tag2"] },
+        { uuid: "uuid2", tags: ["tag1", "tag1", "tag2"] },
+      ])
       .reply(200, "Success");
 
     const { wrapper } = factory({ stubActions: false });
@@ -207,7 +206,7 @@ describe("TagModal.vue", () => {
     expect(wrapper.emitted("requestReload")).toBeTruthy();
   });
 
-  it("will not close the modal and will set the 'error' property when assignUser fails", async () => {
+  it("will not close the modal and will set the 'error' property when addTags fails", async () => {
     myNock
       .get("/node/tag/?offset=0")
       .once()
@@ -220,9 +219,9 @@ describe("TagModal.vue", () => {
       });
     myNock.post("/node/tag/", { value: "tag2" }).reply(200);
     const updateAlert = myNock
-      .options("/alert/uuid1")
+      .options("/alert/")
       .reply(200, "Success")
-      .patch("/alert/uuid1")
+      .patch("/alert/")
       .reply(403, "Unauthorized");
 
     const { wrapper } = factory({ stubActions: false });

--- a/frontend/tests/unit/src/services/api/alerts.spec.ts
+++ b/frontend/tests/unit/src/services/api/alerts.spec.ts
@@ -12,7 +12,7 @@ const MOCK_ALERT_CREATE: alertCreate = {
   type: "test",
   observables: [],
 };
-const MOCK_ALERT_UPDATE: alertUpdate = { version: "test" };
+const MOCK_ALERT_UPDATE: alertUpdate = { uuid: "uuid" };
 const MOCK_PARAMS: alertFilterParams = {
   limit: 10,
   offset: 10,
@@ -66,9 +66,9 @@ describe("Alert calls", () => {
     expect(res).toEqual("Read successful");
   });
 
-  it("will make a patch request to the /alert/{uuid} endpoint when 'update' is called with a given UUID and update data", async () => {
-    myNock.patch("/alert/uuid").reply(200, "Update successful");
-    const res = await api.update("uuid", MOCK_ALERT_UPDATE);
+  it("will make a patch request to the /alert/ endpoint when 'update' is called with an array of update data", async () => {
+    myNock.patch("/alert/").reply(200, "Update successful");
+    const res = await api.update([MOCK_ALERT_UPDATE]);
     expect(res).toEqual("Update successful");
   });
 });

--- a/frontend/tests/unit/src/store/alert.spec.ts
+++ b/frontend/tests/unit/src/store/alert.spec.ts
@@ -64,23 +64,8 @@ describe("alert Actions", () => {
   });
 
   it("will make a request to update an alert given the UUID and update data upon the updateAlert action", async () => {
-    const mockRequest = myNock.patch("/alert/uuid1").reply(200);
-    await store.update("uuid1", { disposition: "test", version: "1" });
-
-    expect(mockRequest.isDone()).toEqual(true);
-    // None of these should be changed
-    expect(store.openAlert).toBeNull();
-  });
-
-  it("will make multiple reqs to update multiple alerts given a list of UUIDS and update data upon the updateAlerts action", async () => {
-    const mockRequest = myNock
-      .patch(/\/alert\/uuid\d/)
-      .twice()
-      .reply(200);
-    await store.updateMultiple(["uuid1", "uuid2"], {
-      disposition: "test",
-      version: "1",
-    });
+    const mockRequest = myNock.patch("/alert/").reply(200);
+    await store.update([{ uuid: "uuid1", disposition: "test" }]);
 
     expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
@@ -106,14 +91,7 @@ describe("alert Actions", () => {
     );
 
     await expect(
-      store.update("uuid1", { disposition: "test", version: "1" }),
-    ).rejects.toEqual(new Error("Request failed with status code 403"));
-
-    await expect(
-      store.updateMultiple(["uuid1", "uuid2"], {
-        disposition: "test",
-        version: "1",
-      }),
+      store.update([{ uuid: "uuid1", disposition: "test" }]),
     ).rejects.toEqual(new Error("Request failed with status code 403"));
 
     mockRequest.persist(false); // cleanup persisted nock request


### PR DESCRIPTION
This allows you to update multiple alerts in a single API call. For example, it's common to want to disposition or take ownership of multiple alerts at a time. Instead of that needing to fire off API calls for each alert, it is now performed in one go.

Due to how this is implemented in the API, you could update different fields with different values for multiple alerts... For example, you could take ownership of one alert and disposition a second alert in the same API call. However, the GUI does not currently allow for this functionality (though the flexibility is there should it ever be needed).