### PR TITLE
Event Queues

### DIFF
--- a/backend/app/api/models/event.py
+++ b/backend/app/api/models/event.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from api.models import type_str, validators
 from api.models.node import NodeBase, NodeCreate, NodeRead, NodeUpdate
 from api.models.event_prevention_tool import EventPreventionToolRead
+from api.models.event_queue import EventQueueRead
 from api.models.event_remediation import EventRemediationRead
 from api.models.event_risk_level import EventRiskLevelRead
 from api.models.event_source import EventSourceRead
@@ -45,6 +46,8 @@ class EventBase(NodeBase):
     prevention_tools: List[type_str] = Field(
         default_factory=list, description="A list of prevention tools involved in the event"
     )
+
+    queue: type_str = Field(description="The event queue containing this event")
 
     remediation_time: Optional[datetime] = Field(
         description="The earliest time that any remediation was performed on the attack represented by the event"
@@ -91,6 +94,8 @@ class EventRead(NodeRead, EventBase):
         description="A list of prevention tools involved in the event"
     )
 
+    queue: EventQueueRead = Field(description="The event queue containing this event")
+
     remediations: List[EventRemediationRead] = Field(
         description="A list of remediations performed to clean up the attack represented by the event"
     )
@@ -122,6 +127,8 @@ class EventRead(NodeRead, EventBase):
 class EventUpdate(NodeUpdate, EventBase):
     name: Optional[type_str] = Field(description="The name of the event")
 
+    queue: Optional[type_str] = Field(description="The event queue containing this event")
+
     status: Optional[type_str] = Field(description="The status assigned to the event")
 
     tags: Optional[List[type_str]] = Field(description="A list of tags to add to the event")
@@ -130,4 +137,4 @@ class EventUpdate(NodeUpdate, EventBase):
 
     threats: Optional[List[type_str]] = Field(description="A list of threats to add to the event")
 
-    _prevent_none: classmethod = validators.prevent_none("name", "status", "tags", "threat_actors", "threats")
+    _prevent_none: classmethod = validators.prevent_none("name", "queue", "status", "tags", "threat_actors", "threats")

--- a/backend/app/api/models/event_queue.py
+++ b/backend/app/api/models/event_queue.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api.models import type_str, validators
+
+
+class EventQueueBase(BaseModel):
+    """Represents an event queue used to filter events."""
+
+    description: Optional[type_str] = Field(description="An optional human-readable description of the event queue")
+
+    value: type_str = Field(description="The value of the event queue")
+
+
+class EventQueueCreate(EventQueueBase):
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the event queue")
+
+
+class EventQueueRead(EventQueueBase):
+    uuid: UUID4 = Field(description="The UUID of the event queue")
+
+    class Config:
+        orm_mode = True
+
+
+class EventQueueUpdate(EventQueueBase):
+    value: Optional[type_str] = Field(description="The value of the event queue")
+
+    _prevent_none: classmethod = validators.prevent_none("value")

--- a/backend/app/api/models/user.py
+++ b/backend/app/api/models/user.py
@@ -4,6 +4,7 @@ from uuid import uuid4
 
 from api.models import type_list_str, type_str, validators
 from api.models.alert_queue import AlertQueueRead
+from api.models.event_queue import EventQueueRead
 from api.models.user_role import UserRoleRead
 
 
@@ -12,6 +13,10 @@ class UserBase(BaseModel):
 
     default_alert_queue: type_str = Field(
         description="The default alert queue the user will see on the alert management page"
+    )
+
+    default_event_queue: type_str = Field(
+        description="The default event queue the user will see on the event management page"
     )
 
     display_name: type_str = Field(description="The user's full name")
@@ -44,6 +49,10 @@ class UserRead(UserBase):
         description="The default alert queue the user will see on the alert management page"
     )
 
+    default_event_queue: EventQueueRead = Field(
+        description="The default event queue the user will see on the event management page"
+    )
+
     roles: List[UserRoleRead] = Field(description="A list of roles assigned to the user")
 
     uuid: UUID4 = Field(description="The UUID of the user")
@@ -55,6 +64,10 @@ class UserRead(UserBase):
 class UserUpdate(UserBase):
     default_alert_queue: Optional[type_str] = Field(
         description="The default alert queue the user will see on the alert management page"
+    )
+
+    default_event_queue: Optional[type_str] = Field(
+        description="The default event queue the user will see on the event management page"
     )
 
     display_name: Optional[type_str] = Field(description="The user's full name")
@@ -77,6 +90,7 @@ class UserUpdate(UserBase):
 
     _prevent_none: classmethod = validators.prevent_none(
         "default_alert_queue",
+        "default_event_queue",
         "display_name",
         "email",
         "enabled",

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -11,6 +11,7 @@ from api.routes.analysis_module_type import router as analysis_module_type_route
 from api.routes.auth import router as auth_router
 from api.routes.event import router as event_router
 from api.routes.event_prevention_tool import router as event_prevention_tool_router
+from api.routes.event_queue import router as event_queue_router
 from api.routes.event_remediation import router as event_remediation_router
 from api.routes.event_risk_level import router as event_risk_level_router
 from api.routes.event_source import router as event_source_router
@@ -45,6 +46,7 @@ router.include_router(analysis_module_type_router)
 router.include_router(auth_router)
 router.include_router(event_router)
 router.include_router(event_prevention_tool_router)
+router.include_router(event_queue_router)
 router.include_router(event_remediation_router)
 router.include_router(event_risk_level_router)
 router.include_router(event_source_router)

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -9,6 +9,7 @@ from db import crud
 from db.database import get_db
 from db.schemas.event import Event
 from db.schemas.event_prevention_tool import EventPreventionTool
+from db.schemas.event_queue import EventQueue
 from db.schemas.event_remediation import EventRemediation
 from db.schemas.event_risk_level import EventRiskLevel
 from db.schemas.event_source import EventSource
@@ -38,6 +39,7 @@ def create_event(
     new_event: Event = create_node(node_create=event, db_node_type=Event, db=db, exclude={"alert_uuids"})
 
     # Set the required event properties
+    new_event.queue = crud.read_by_value(value=event.queue, db_table=EventQueue, db=db)
     new_event.status = crud.read_by_value(value=event.status, db_table=EventStatus, db=db)
 
     # Set the various optional event properties if they were given in the request.
@@ -139,6 +141,9 @@ def update_event(
             db_table=EventPreventionTool,
             db=db,
         )
+
+    if "queue" in update_data:
+        db_event.queue = crud.read_by_value(value=update_data["queue"], db_table=EventQueue, db=db)
 
     if "remediation_time" in update_data:
         db_event.remediation_time = update_data["remediation_time"]

--- a/backend/app/api/routes/event_queue.py
+++ b/backend/app/api/routes/event_queue.py
@@ -1,0 +1,85 @@
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import select
+from uuid import UUID
+
+from api.models.event_queue import EventQueueCreate, EventQueueRead, EventQueueUpdate
+from api.routes import helpers
+from db import crud
+from db.database import get_db
+from db.schemas.event_queue import EventQueue
+
+
+router = APIRouter(
+    prefix="/event/queue",
+    tags=["Event Queue"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_event_queue(
+    event_queue: EventQueueCreate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    uuid = crud.create(obj=event_queue, db_table=EventQueue, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_event_queue", uuid=uuid)
+
+
+helpers.api_route_create(router, create_event_queue)
+
+
+#
+# READ
+#
+
+
+def get_all_event_queues(db: Session = Depends(get_db)):
+    return paginate(db, select(EventQueue).order_by(EventQueue.value))
+
+
+def get_event_queue(uuid: UUID, db: Session = Depends(get_db)):
+    return crud.read(uuid=uuid, db_table=EventQueue, db=db)
+
+
+helpers.api_route_read_all(router, get_all_event_queues, EventQueueRead)
+helpers.api_route_read(router, get_event_queue, EventQueueRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_event_queue(
+    uuid: UUID,
+    event_queue: EventQueueUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    crud.update(uuid=uuid, obj=event_queue, db_table=EventQueue, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_event_queue", uuid=uuid)
+
+
+helpers.api_route_update(router, update_event_queue)
+
+
+#
+# DELETE
+#
+
+
+def delete_event_queue(uuid: UUID, db: Session = Depends(get_db)):
+    crud.delete(uuid=uuid, db_table=EventQueue, db=db)
+
+
+helpers.api_route_delete(router, delete_event_queue)

--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -14,6 +14,7 @@ from core.auth import hash_password
 from db import crud
 from db.database import get_db
 from db.schemas.alert_queue import AlertQueue
+from db.schemas.event_queue import EventQueue
 from db.schemas.user import User
 from db.schemas.user_role import UserRole
 
@@ -38,8 +39,9 @@ def create_user(
     # Create the new user using the data from the request
     new_user = User(**user.dict())
 
-    # Get the alert queue from the database to associate with the new user
+    # Get the queues from the database to associate with the new user
     new_user.default_alert_queue = crud.read_by_value(user.default_alert_queue, db_table=AlertQueue, db=db)
+    new_user.default_event_queue = crud.read_by_value(user.default_event_queue, db_table=EventQueue, db=db)
 
     # Get the user roles from the database to associate with the new user
     new_user.roles = crud.read_by_values(user.roles, db_table=UserRole, db=db)
@@ -96,6 +98,11 @@ def update_user(
     if "default_alert_queue" in update_data:
         db_user.default_alert_queue = crud.read_by_value(
             value=update_data["default_alert_queue"], db_table=AlertQueue, db=db
+        )
+
+    if "default_event_queue" in update_data:
+        db_user.default_event_queue = crud.read_by_value(
+            value=update_data["default_event_queue"], db_table=EventQueue, db=db
         )
 
     if "display_name" in update_data:

--- a/backend/app/db/schemas/__init__.py
+++ b/backend/app/db/schemas/__init__.py
@@ -12,6 +12,7 @@ from db.schemas.analysis_module_type import AnalysisModuleType
 from db.schemas.event import Event
 from db.schemas.event_prevention_tool import EventPreventionTool
 from db.schemas.event_prevention_tool_mapping import event_prevention_tool_mapping
+from db.schemas.event_queue import EventQueue
 from db.schemas.event_remediation import EventRemediation
 from db.schemas.event_remediation_mapping import event_remediation_mapping
 from db.schemas.event_risk_level import EventRiskLevel

--- a/backend/app/db/schemas/event.py
+++ b/backend/app/db/schemas/event.py
@@ -18,7 +18,7 @@ class Event(Node):
 
     alert_time = Column(DateTime(timezone=True))
 
-    alerts = relationship("Alert", primaryjoin="Alert.event_uuid == Event.uuid")
+    alerts = relationship("Alert", primaryjoin="Alert.event_uuid == Event.uuid", lazy="selectin")
 
     alert_uuids = association_proxy("alerts", "uuid")
 
@@ -34,33 +34,37 @@ class Event(Node):
 
     owner_uuid = Column(UUID(as_uuid=True), ForeignKey("user.uuid"), nullable=True)
 
-    owner = relationship("User", foreign_keys=[owner_uuid])
+    owner = relationship("User", foreign_keys=[owner_uuid], lazy="selectin")
 
     ownership_time = Column(DateTime(timezone=True))
 
-    prevention_tools = relationship("EventPreventionTool", secondary=event_prevention_tool_mapping)
+    prevention_tools = relationship("EventPreventionTool", secondary=event_prevention_tool_mapping, lazy="selectin")
+
+    queue = relationship("EventQueue", lazy="selectin")
+
+    queue_uuid = Column(UUID(as_uuid=True), ForeignKey("event_queue.uuid"), nullable=False, index=True)
 
     remediation_time = Column(DateTime(timezone=True))
 
-    remediations = relationship("EventRemediation", secondary=event_remediation_mapping)
+    remediations = relationship("EventRemediation", secondary=event_remediation_mapping, lazy="selectin")
 
-    risk_level = relationship("EventRiskLevel")
+    risk_level = relationship("EventRiskLevel", lazy="selectin")
 
     risk_level_uuid = Column(UUID(as_uuid=True), ForeignKey("event_risk_level.uuid"))
 
-    source = relationship("EventSource")
+    source = relationship("EventSource", lazy="selectin")
 
     source_uuid = Column(UUID(as_uuid=True), ForeignKey("event_source.uuid"))
 
-    status = relationship("EventStatus")
+    status = relationship("EventStatus", lazy="selectin")
 
     status_uuid = Column(UUID(as_uuid=True), ForeignKey("event_status.uuid"), nullable=False)
 
-    type = relationship("EventType")
+    type = relationship("EventType", lazy="selectin")
 
     type_uuid = Column(UUID(as_uuid=True), ForeignKey("event_type.uuid"))
 
-    vectors = relationship("EventVector", secondary=event_vector_mapping)
+    vectors = relationship("EventVector", secondary=event_vector_mapping, lazy="selectin")
 
     __mapper_args__ = {"polymorphic_identity": "event", "polymorphic_load": "inline"}
 

--- a/backend/app/db/schemas/event_queue.py
+++ b/backend/app/db/schemas/event_queue.py
@@ -1,0 +1,14 @@
+from sqlalchemy import func, Column, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from db.database import Base
+
+
+class EventQueue(Base):
+    __tablename__ = "event_queue"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    description = Column(String)
+
+    value = Column(String, nullable=False, unique=True, index=True)

--- a/backend/app/db/schemas/user.py
+++ b/backend/app/db/schemas/user.py
@@ -11,9 +11,13 @@ class User(Base):
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
 
-    default_alert_queue = relationship("AlertQueue")
+    default_alert_queue = relationship("AlertQueue", lazy="selectin")
 
     default_alert_queue_uuid = Column(UUID(as_uuid=True), ForeignKey("alert_queue.uuid"), nullable=False)
+
+    default_event_queue = relationship("EventQueue", lazy="selectin")
+
+    default_event_queue_uuid = Column(UUID(as_uuid=True), ForeignKey("event_queue.uuid"), nullable=False)
 
     display_name = Column(String, nullable=False)
 
@@ -23,7 +27,7 @@ class User(Base):
 
     password = Column(String, nullable=False)
 
-    roles = relationship("UserRole", secondary=user_role_mapping, passive_deletes=True)
+    roles = relationship("UserRole", secondary=user_role_mapping, passive_deletes=True, lazy="selectin")
 
     timezone = Column(String, default="UTC", nullable=False)
 

--- a/backend/app/etc/defaults.yml
+++ b/backend/app/etc/defaults.yml
@@ -31,6 +31,8 @@ event_prevention_tool:
   - proxy
   - response team
   - user
+event_queue:
+  - default
 event_remediation:
   - cleaned manually
   - cleaned with antivirus

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -11,6 +11,7 @@ from db.schemas.alert_disposition import AlertDisposition
 from db.schemas.alert_queue import AlertQueue
 from db.schemas.alert_type import AlertType
 from db.schemas.event_prevention_tool import EventPreventionTool
+from db.schemas.event_queue import EventQueue
 from db.schemas.event_remediation import EventRemediation
 from db.schemas.event_risk_level import EventRiskLevel
 from db.schemas.event_source import EventSource
@@ -63,6 +64,20 @@ if not crud.read_all(db_table=AlertQueue, db=db):
         # Make sure there is always a "default" queue
         db.add(AlertQueue(value="default"))
         print("Adding alert queue: default")
+
+if not crud.read_all(db_table=EventQueue, db=db):
+    if "event_queue" in data:
+        # Make sure there is always a "default" queue
+        if "default" not in data["event_queue"]:
+            data["event_queue"].append("default")
+
+        for value in data["event_queue"]:
+            db.add(EventQueue(value=value))
+            print(f"Adding event queue: {value}")
+    else:
+        # Make sure there is always a "default" queue
+        db.add(EventQueue(value="default"))
+        print("Adding event queue: default")
 
 if "alert_type" in data and not crud.read_all(db_table=AlertType, db=db):
     for value in data["alert_type"]:
@@ -136,6 +151,7 @@ if not crud.read_all(db_table=User, db=db):
     db.add(
         User(
             default_alert_queue=crud.read_by_value(value="default", db_table=AlertQueue, db=db),
+            default_event_queue=crud.read_by_value(value="default", db_table=EventQueue, db=db),
             display_name="Analyst",
             email="analyst@fake.com",
             password=hash_password("analyst"),
@@ -146,6 +162,7 @@ if not crud.read_all(db_table=User, db=db):
     db.add(
         User(
             default_alert_queue=crud.read_by_value(value="default", db_table=AlertQueue, db=db),
+            default_event_queue=crud.read_by_value(value="default", db_table=EventQueue, db=db),
             display_name="Analyst Alice",
             email="alice@alice.com",
             password=hash_password("analyst"),
@@ -156,6 +173,7 @@ if not crud.read_all(db_table=User, db=db):
     db.add(
         User(
             default_alert_queue=crud.read_by_value(value="default", db_table=AlertQueue, db=db),
+            default_event_queue=crud.read_by_value(value="default", db_table=EventQueue, db=db),
             display_name="Analyst Bob",
             email="bob@bob.com",
             password=hash_password("analyst"),

--- a/backend/app/tests/api/event/test_update.py
+++ b/backend/app/tests/api/event/test_update.py
@@ -42,6 +42,9 @@ from tests import helpers
         ("prevention_tools", [None]),
         ("prevention_tools", [""]),
         ("prevention_tools", ["abc", 123]),
+        ("queue", 123),
+        ("queue", None),
+        ("queue", ""),
         ("remediation_time", ""),
         ("remediation_time", "Monday"),
         ("remediation_time", "2022-01-01"),
@@ -109,6 +112,7 @@ def test_update_invalid_version(client_valid_access_token, db):
     [
         ("owner", "johndoe"),
         ("prevention_tools", ["abc"]),
+        ("queue", "abc"),
         ("remediations", ["abc"]),
         ("risk_level", "abc"),
         ("source", "abc"),
@@ -189,6 +193,22 @@ def test_update_prevention_tools(client_valid_access_token, db):
     update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"prevention_tools": []})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert event.prevention_tools == []
+
+
+def test_update_queue(client_valid_access_token, db):
+    # Create an event
+    event = helpers.create_event(name="test", db=db)
+    initial_event_version = event.version
+    assert event.queue.value == "default"
+
+    # Create an event queue
+    helpers.create_event_queue(value="updated_queue", db=db)
+
+    # Update the event
+    update = client_valid_access_token.patch(f"/api/event/{event.uuid}", json={"queue": "updated_queue"})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert event.queue.value == "updated_queue"
+    assert event.version != initial_event_version
 
 
 def test_update_remediations(client_valid_access_token, db):

--- a/backend/app/tests/api/event_queue/test_create.py
+++ b/backend/app/tests/api/event_queue/test_create.py
@@ -1,0 +1,91 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client_valid_access_token, key, value):
+    create_json = {"value": "test"}
+    create_json[key] = value
+    create = client_valid_access_token.post("/api/event/queue/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("uuid"),
+        ("value"),
+    ],
+)
+def test_create_duplicate_unique_fields(client_valid_access_token, key):
+    # Create an object
+    create1_json = {"uuid": str(uuid.uuid4()), "value": "test"}
+    client_valid_access_token.post("/api/event/queue/", json=create1_json)
+
+    # Ensure you cannot create another object with the same unique field value
+    create2_json = {"value": "test2"}
+    create2_json[key] = create1_json[key]
+    create2 = client_valid_access_token.post("/api/event/queue/", json=create2_json)
+    assert create2.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_create_missing_required_fields(client_valid_access_token, key):
+    create_json = {"value": "test"}
+    del create_json[key]
+    create = client_valid_access_token.post("/api/event/queue/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("description", None), ("description", "test"), ("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client_valid_access_token, key, value):
+    # Create the object
+    create = client_valid_access_token.post("/api/event/queue/", json={key: value, "value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client_valid_access_token):
+    # Create the object
+    create = client_valid_access_token.post("/api/event/queue/", json={"value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()["value"] == "test"

--- a/backend/app/tests/api/event_queue/test_delete.py
+++ b/backend/app/tests/api/event_queue/test_delete.py
@@ -1,0 +1,44 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+"""
+NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
+are in place in order to account for this.
+"""
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete("/api/event/queue/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete(f"/api/event/queue/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete(client_valid_access_token, db):
+    # Create the object
+    obj = helpers.create_event_queue(value="test", db=db)
+
+    # Delete it
+    delete = client_valid_access_token.delete(f"/api/event/queue/{obj.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Make sure it is gone
+    get = client_valid_access_token.get(f"/api/event/queue/{obj.uuid}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/event_queue/test_read.py
+++ b/backend/app/tests/api/event_queue/test_read.py
@@ -1,0 +1,42 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.get("/api/event/queue/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.get(f"/api/event/queue/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_all(client_valid_access_token, db):
+    # Create some objects
+    helpers.create_event_queue(value="test", db=db)
+    helpers.create_event_queue(value="test2", db=db)
+
+    # Read them back
+    get = client_valid_access_token.get("/api/event/queue/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 2
+
+
+def test_get_all_empty(client_valid_access_token):
+    get = client_valid_access_token.get("/api/event/queue/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/event_queue/test_update.py
+++ b/backend/app/tests/api/event_queue/test_update.py
@@ -1,0 +1,79 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_update_invalid_fields(client_valid_access_token, key, value):
+    update = client_valid_access_token.patch(f"/api/event/queue/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_invalid_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch("/api/event/queue/1", json={"value": "test"})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
+    # Create some objects
+    obj1 = helpers.create_event_queue(value="test", db=db)
+    obj2 = helpers.create_event_queue(value="test2", db=db)
+
+    # Ensure you cannot update a unique field to a value that already exists
+    update = client_valid_access_token.patch(f"/api/event/queue/{obj2.uuid}", json={key: getattr(obj1, key)})
+    assert update.status_code == status.HTTP_409_CONFLICT
+
+
+def test_update_nonexistent_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch(f"/api/event/queue/{uuid.uuid4()}", json={"value": "test"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,initial_value,updated_value",
+    [
+        ("description", None, "test"),
+        ("description", "test", "test"),
+        ("value", "test", "test2"),
+        ("value", "test", "test"),
+    ],
+)
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
+    # Create the object
+    obj = helpers.create_event_queue(value="test", db=db)
+
+    # Set the initial value
+    setattr(obj, key, initial_value)
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/event/queue/{obj.uuid}", json={key: updated_value})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/user/test_create.py
+++ b/backend/app/tests/api/user/test_create.py
@@ -17,6 +17,9 @@ from tests import helpers
         ("default_alert_queue", 123),
         ("default_alert_queue", None),
         ("default_alert_queue", ""),
+        ("default_event_queue", 123),
+        ("default_event_queue", None),
+        ("default_event_queue", ""),
         ("display_name", 123),
         ("display_name", None),
         ("display_name", ""),
@@ -55,6 +58,7 @@ from tests import helpers
 def test_create_invalid_fields(client_valid_access_token, key, value):
     create_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "John Doe",
         "email": "johndoe@test.com",
         "password": "abcd1234",
@@ -75,15 +79,14 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
     ],
 )
 def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
-    # Create an alert queue
     helpers.create_alert_queue(value="test_queue", db=db)
-
-    # Create a user role
+    helpers.create_event_queue(value="test_queue", db=db)
     helpers.create_user_role(value="test_role", db=db)
 
     # Create an object
     create1_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "John Doe",
         "email": "john@test.com",
         "password": "abcd1234",
@@ -96,6 +99,7 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     # Ensure you cannot create another object with the same unique field value
     create2_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "Jane Doe",
         "email": "jane@test.com",
         "password": "wxyz6789",
@@ -112,6 +116,7 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     "key",
     [
         ("default_alert_queue"),
+        ("default_event_queue"),
         ("display_name"),
         ("email"),
         ("password"),
@@ -122,6 +127,7 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
 def test_create_missing_required_fields(client_valid_access_token, key):
     create_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "John Doe",
         "email": "john@test.com",
         "password": "abcd1234",
@@ -143,15 +149,14 @@ def test_create_missing_required_fields(client_valid_access_token, key):
     [("enabled", False), ("timezone", "America/New_York"), ("uuid", str(uuid.uuid4()))],
 )
 def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
-    # Create an alert queue
     helpers.create_alert_queue(value="test_queue", db=db)
-
-    # Create a user role
+    helpers.create_event_queue(value="test_queue", db=db)
     helpers.create_user_role(value="test_role", db=db)
 
     # Create the object
     create_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "John Doe",
         "email": "john@test.com",
         "password": "abcd1234",
@@ -168,15 +173,14 @@ def test_create_valid_optional_fields(client_valid_access_token, db, key, value)
 
 
 def test_create_valid_required_fields(client_valid_access_token, db):
-    # Create an alert queue
     helpers.create_alert_queue(value="test_queue", db=db)
-
-    # Create a user role
+    helpers.create_event_queue(value="test_queue", db=db)
     helpers.create_user_role(value="test_role", db=db)
 
     # Create the object
     create_json = {
         "default_alert_queue": "test_queue",
+        "default_event_queue": "test_queue",
         "display_name": "John Doe",
         "email": "john@test.com",
         "password": "abcd1234",
@@ -189,6 +193,7 @@ def test_create_valid_required_fields(client_valid_access_token, db):
     # Read it back
     get = client_valid_access_token.get(create.headers["Content-Location"])
     assert get.json()["default_alert_queue"]["value"] == "test_queue"
+    assert get.json()["default_event_queue"]["value"] == "test_queue"
     assert get.json()["display_name"] == "John Doe"
     assert get.json()["email"] == "john@test.com"
     assert get.json()["enabled"] is True

--- a/backend/app/tests/api/user/test_update.py
+++ b/backend/app/tests/api/user/test_update.py
@@ -20,6 +20,9 @@ from tests import helpers
         ("default_alert_queue", 123),
         ("default_alert_queue", None),
         ("default_alert_queue", ""),
+        ("default_event_queue", 123),
+        ("default_event_queue", None),
+        ("default_event_queue", ""),
         ("display_name", 123),
         ("display_name", None),
         ("display_name", ""),
@@ -100,6 +103,20 @@ def test_update_valid_alert_queue(client_valid_access_token, db):
     update = client_valid_access_token.patch(f"/api/user/{obj.uuid}", json={"default_alert_queue": "test_queue2"})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert obj.default_alert_queue.value == "test_queue2"
+
+
+def test_update_valid_event_queue(client_valid_access_token, db):
+    # Create a user
+    obj = helpers.create_user(username="johndoe", event_queue="test_queue", db=db)
+    assert obj.default_event_queue.value == "test_queue"
+
+    # Create the new event queue
+    helpers.create_event_queue(value="test_queue2", db=db)
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/user/{obj.uuid}", json={"default_event_queue": "test_queue2"})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert obj.default_event_queue.value == "test_queue2"
 
 
 @pytest.mark.parametrize(

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -20,6 +20,7 @@ from db.schemas.analysis import Analysis
 from db.schemas.analysis_module_type import AnalysisModuleType
 from db.schemas.event import Event
 from db.schemas.event_prevention_tool import EventPreventionTool
+from db.schemas.event_queue import EventQueue
 from db.schemas.event_remediation import EventRemediation
 from db.schemas.event_risk_level import EventRiskLevel
 from db.schemas.event_source import EventSource
@@ -273,8 +274,14 @@ def create_analysis_module_type(
     return obj
 
 
-def create_event(name: str, db: Session, status: str = "OPEN") -> Event:
-    obj = Event(name=name, status=create_event_status(value=status, db=db), uuid=uuid.uuid4(), version=uuid.uuid4())
+def create_event(name: str, db: Session, queue: str = "default", status: str = "OPEN") -> Event:
+    obj = Event(
+        name=name,
+        queue=create_event_queue(value=queue, db=db),
+        status=create_event_status(value=status, db=db),
+        uuid=uuid.uuid4(),
+        version=uuid.uuid4(),
+    )
     db.add(obj)
     crud.commit(db)
     return obj
@@ -282,6 +289,10 @@ def create_event(name: str, db: Session, status: str = "OPEN") -> Event:
 
 def create_event_prevention_tool(value: str, db: Session) -> EventPreventionTool:
     return _create_basic_object(db_table=EventPreventionTool, value=value, db=db)
+
+
+def create_event_queue(value: str, db: Session) -> EventQueue:
+    return _create_basic_object(db_table=EventQueue, value=value, db=db)
 
 
 def create_event_remediation(value: str, db: Session) -> EventRemediation:
@@ -417,6 +428,7 @@ def create_user(
     alert_queue: str = "test_queue",
     display_name: str = "Analyst",
     email: Optional[str] = None,
+    event_queue: str = "test_queue",
     password: str = "asdfasdf",
     roles: List[str] = None,
 ) -> User:
@@ -434,6 +446,7 @@ def create_user(
 
     obj = User(
         default_alert_queue=create_alert_queue(value=alert_queue, db=db),
+        default_event_queue=create_event_queue(value=event_queue, db=db),
         display_name=display_name,
         email=email,
         password=hash_password(password),

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,5 +1,6 @@
 import { UUID } from "./base";
 import { eventPreventionToolRead } from "./eventPreventionTool";
+import { eventQueueRead } from "./eventQueue";
 import { eventRemediationRead } from "./eventRemediation";
 import { eventRiskLevelRead } from "./eventRiskLevel";
 import { eventSourceRead } from "./eventSource";
@@ -22,6 +23,7 @@ export interface eventCreate extends nodeCreate {
   owner?: string;
   ownershipTime?: Date;
   preventionTools?: string[];
+  queue: string;
   remediationTime?: Date;
   riskLevel?: string;
   source?: string;
@@ -46,6 +48,7 @@ export interface eventRead extends nodeRead {
   owner: userRead | null;
   ownershipTime: Date | null;
   preventionTools: eventPreventionToolRead[];
+  queue: eventQueueRead;
   remediations: eventRemediationRead[];
   remediationTime: Date | null;
   riskLevel: eventRiskLevelRead | null;
@@ -71,6 +74,7 @@ export interface eventUpdate extends nodeUpdate {
   owner?: string | null;
   ownershipTime?: Date | null;
   preventionTools?: string[];
+  queue?: string;
   remediationTime?: Date | null;
   riskLevel?: string | null;
   source?: string | null;

--- a/frontend/src/models/eventQueue.ts
+++ b/frontend/src/models/eventQueue.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type eventQueueCreate = genericObjectCreate;
+
+export type eventQueueRead = genericObjectRead;
+
+export interface eventQueueReadPage extends genericObjectReadPage {
+  items: eventQueueRead[];
+}
+
+export type eventQueueUpdate = genericObjectUpdate;

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -1,9 +1,11 @@
 import { UUID } from "./base";
 import { alertQueueRead } from "./alertQueue";
+import { eventQueueRead } from "./eventQueue";
 import { userRoleRead } from "./userRole";
 
 export interface userCreate {
   defaultAlertQueue: string;
+  defaultEventQueue: string;
   displayName: string;
   email: string;
   enabled?: boolean;
@@ -17,6 +19,7 @@ export interface userCreate {
 
 export interface userRead {
   defaultAlertQueue: alertQueueRead;
+  defaultEventQueue: eventQueueRead;
   displayName: string;
   email: string;
   enabled: boolean;
@@ -36,6 +39,7 @@ export interface userReadPage {
 
 export interface userUpdate {
   defaultAlertQueue?: string;
+  defaultEventQueue?: string;
   displayName?: string;
   email?: string;
   enabled?: boolean;

--- a/frontend/tests/mockData/alert.ts
+++ b/frontend/tests/mockData/alert.ts
@@ -445,6 +445,11 @@ export const mockAlert: alertTreeRead = {
       value: "test_queue",
       uuid: "a7adcd83-5c0e-4185-874a-c548fe8116e9",
     },
+    defaultEventQueue: {
+      description: null,
+      value: "test_queue",
+      uuid: "167b7210-f7d2-46eb-8c7a-61ce6c7e9ece",
+    },
     displayName: "Analyst",
     email: "bob@bob.com",
     enabled: true,
@@ -469,6 +474,11 @@ export const mockAlert: alertTreeRead = {
       description: null,
       value: "test_queue",
       uuid: "a7adcd83-5c0e-4185-874a-c548fe8116e9",
+    },
+    defaultEventQueue: {
+      description: null,
+      value: "test_queue",
+      uuid: "167b7210-f7d2-46eb-8c7a-61ce6c7e9ece",
     },
     displayName: "Analyst",
     email: "alice@alice.com",

--- a/frontend/tests/unit/src/components/UserInterface/FilterInput.spec.ts
+++ b/frontend/tests/unit/src/components/UserInterface/FilterInput.spec.ts
@@ -48,6 +48,7 @@ const FILTERS_STUB = [
 const USERS_STUB: userRead[] = [
   {
     defaultAlertQueue: { description: null, uuid: "1", value: "default" },
+    defaultEventQueue: { description: null, uuid: "1", value: "default" },
     displayName: "Test Analyst",
     email: "analyst@test.com",
     enabled: true,
@@ -58,6 +59,7 @@ const USERS_STUB: userRead[] = [
   },
   {
     defaultAlertQueue: { description: null, uuid: "1", value: "default" },
+    defaultEventQueue: { description: null, uuid: "1", value: "default" },
     displayName: "Test Analyst2",
     email: "analyst2@test.com",
     enabled: true,

--- a/frontend/tests/unit/src/store/auth.spec.ts
+++ b/frontend/tests/unit/src/store/auth.spec.ts
@@ -8,6 +8,7 @@ const store = useAuthStore();
 
 const mockUser: userRead = {
   defaultAlertQueue: { description: null, uuid: "1", value: "default" },
+  defaultEventQueue: { description: null, uuid: "1", value: "default" },
   displayName: "Test Analyst",
   email: "analyst@test.com",
   enabled: true,


### PR DESCRIPTION
This PR adds the concept of "event queues", which is the same functionality as alert queues. This is used so that users will be able to filter events based on the queue. Some example use cases:

* Separate event queues for external vs. internal threat analysts so that they reduce clutter and do not see each other's events
* An intel event queue used when an event is "handed over" to the intel team for further investigation