### PR TITLE
Observable Filter Links

### DIFF
--- a/frontend/src/components/Alerts/AlertTree.vue
+++ b/frontend/src/components/Alerts/AlertTree.vue
@@ -22,11 +22,16 @@
               <span :class="toggleIcon(index)"></span>
             </button>
           </span>
-          <span v-if="isObservable(i)">{{ treeItemName(i) }}</span>
+          <span
+            v-if="isObservable(i)"
+            class="treenode-text"
+            @click="filterByObservable(i)"
+            >{{ treeItemName(i) }}</span
+          >
 
           <span
             v-else
-            style="cursor: pointer"
+            class="treenode-text"
             @click="router.push(viewAnalysisRoute(i))"
             >{{ treeItemName(i) }}</span
           >
@@ -100,6 +105,13 @@
     };
   }
 
+  function filterByObservable(obs) {
+    router.replace({
+      path: "/manage_alerts",
+      query: { observable: `${obs.type.value}|${obs.value}` },
+    });
+  }
+
   function treeItemName(item) {
     if (isAnalysis(item)) {
       return item.analysisModuleType.value;
@@ -170,5 +182,10 @@
   .p-treenode-content {
     display: flex;
     align-items: center;
+  }
+  .treenode-text:hover {
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
   }
 </style>

--- a/frontend/src/components/Alerts/AlertTree.vue
+++ b/frontend/src/components/Alerts/AlertTree.vue
@@ -133,6 +133,8 @@
           } else {
             value = item.value;
           }
+        } else {
+          throw new Error("No observable display metadata given");
         }
       } catch (error) {
         type = item.type.value;

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -239,7 +239,7 @@ describe("ViewAlert.vue", () => {
     cy.wait("@getAlert").its("state").should("eq", "Complete");
   });
 
-  it("will reroute to the Manage Alerts page with tag filter applied when filter clicked", () => {
+  it("will reroute to the Manage Alerts page with tag filter applied when tag clicked", () => {
     // Find the recipient tag and click
     cy.get(".p-chip-text").contains("recipient").click();
 
@@ -257,6 +257,35 @@ describe("ViewAlert.vue", () => {
     );
     cy.get(".p-chips-token").should("exist");
     cy.get(".p-chips-token").should("have.text", "recipient");
+
+    // Close the modal to finish
+    cy.get(".p-dialog-header-icon").click();
+  });
+
+  it("will reroute to the Manage Alerts page with observable filter applied when observable clicked", () => {
+    // Find the email subject observable and click
+    cy.get(
+      '[data-cy="email_subject: Hello"] > .p-treenode-content > .treenode-text',
+    ).click();
+
+    // Should have been rerouted
+    cy.url().should("contain", "/manage_alerts");
+
+    // Check which alerts are visible (should be none (1 checkbox visible for the header row))
+    cy.get(".p-checkbox-box").should("have.length", 1);
+
+    // Verify in the filter modal that the correct filter is set
+    cy.get("#FilterToolbar > .p-toolbar-group-left > .p-m-1").click();
+    cy.get(
+      ".formgrid > :nth-child(1) > .p-dropdown > .p-dropdown-label",
+    ).should("have.text", "Observable");
+    cy.get(
+      ".col > :nth-child(1) > :nth-child(1) > .p-dropdown > .p-dropdown-label",
+    ).should("have.text", "email_subject");
+    cy.get(".col > :nth-child(1) > :nth-child(2) > input").should(
+      "have.value",
+      "Hello",
+    );
 
     // Close the modal to finish
     cy.get(".p-dialog-header-icon").click();

--- a/frontend/tests/unit/src/components/Alerts/AlertTree.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AlertTree.spec.ts
@@ -1,30 +1,41 @@
 import AlertTree from "../../../../../src/components/Alerts/AlertTree.vue";
 import { mount, VueWrapper } from "@vue/test-utils";
-import { createTestingPinia } from "@pinia/testing";
+import { createTestingPinia, TestingOptions } from "@pinia/testing";
 import { mockAlert, mockAnalysisRead } from "../../../../mockData/alert";
+import { createRouterMock, injectRouterMock } from "vue-router-mock";
 import { useAlertStore } from "@/stores/alert";
-import router from "@/router";
 
 describe("AlertTree.vue", () => {
-  const pinia = createTestingPinia({ stubActions: false });
-  const alertStore = useAlertStore();
-  alertStore.openAlert = mockAlert;
+  function factory(options?: TestingOptions) {
+    const router = createRouterMock();
+    injectRouterMock(router);
 
-  const wrapper: VueWrapper<any> = mount(AlertTree, {
-    props: {
-      items: mockAlert.children,
-    },
-    global: {
-      plugins: [router, pinia],
-      stubs: { NodeTagVue: true },
-    },
-  });
+    const pinia = createTestingPinia(options);
+    const alertStore = useAlertStore();
+    alertStore.openAlert = mockAlert;
+
+    const wrapper: VueWrapper<any> = mount(AlertTree, {
+      props: {
+        items: mockAlert.children,
+      },
+      global: {
+        plugins: [pinia],
+        stubs: { NodeTagVue: true },
+      },
+    });
+
+    return { wrapper, alertStore, router };
+  }
 
   it("renders", () => {
+    const { wrapper } = factory();
+
     expect(wrapper.exists()).toBe(true);
   });
 
   it("will correctly populate array of expanded status on generateExpandedStatus", () => {
+    const { wrapper } = factory();
+
     const itemsStub = [
       { firstAppearance: true },
       { firstAppearance: false },
@@ -35,10 +46,14 @@ describe("AlertTree.vue", () => {
   });
 
   it("will correctly return the expanded status for a given item index", () => {
+    const { wrapper } = factory();
+
     expect(wrapper.vm.nodeExpanded(0)).toEqual(true);
   });
 
   it("will correctly toggle the expanded status for a given item index", () => {
+    const { wrapper } = factory();
+
     wrapper.vm.toggleNodeExpanded(0);
     expect(wrapper.vm.itemsExpandedStatus).toEqual([false, true]);
     wrapper.vm.toggleNodeExpanded(1);
@@ -50,6 +65,8 @@ describe("AlertTree.vue", () => {
   });
 
   it("will correctly return the toggle icon class for a given item index", () => {
+    const { wrapper } = factory();
+
     wrapper.vm.toggleNodeExpanded(0);
     expect(wrapper.vm.toggleIcon(0)).toEqual([
       "p-tree-toggler-icon pi pi-fw",
@@ -63,6 +80,8 @@ describe("AlertTree.vue", () => {
   });
 
   it("will correctly generate route for a given analysis item", () => {
+    const { wrapper } = factory();
+
     wrapper.vm.openAlertId = "alertUuid";
     const route = wrapper.vm.viewAnalysisRoute({ uuid: "itemUuid" });
     expect(route).toStrictEqual({
@@ -72,17 +91,51 @@ describe("AlertTree.vue", () => {
   });
 
   it("will correctly return a given item's 'Name' on treeItemName", () => {
+    const { wrapper } = factory();
+
+    // Analysis
     let name = wrapper.vm.treeItemName(mockAnalysisRead);
     expect(name).toEqual("File Analysis");
+
+    // Basic observable
     name = wrapper.vm.treeItemName({
       nodeType: "observable",
       type: { value: "test_type" },
       value: "test",
     });
     expect(name).toEqual("test_type: test");
+
+    // 'Styled' observable type
+    name = wrapper.vm.treeItemName({
+      nodeType: "observable",
+      type: { value: "test_type" },
+      value: "test",
+      nodeMetadata: { display: { type: "Special Type" } },
+    });
+    expect(name).toEqual("Special Type (test_type): test");
+
+    // 'Styled' observable value
+    name = wrapper.vm.treeItemName({
+      nodeType: "observable",
+      type: { value: "test_type" },
+      value: "test",
+      nodeMetadata: { display: { value: "Special Value" } },
+    });
+    expect(name).toEqual("test_type: Special Value");
+
+    // nodeMetadata field but no 'display' field
+    name = wrapper.vm.treeItemName({
+      nodeType: "observable",
+      type: { value: "test_type" },
+      value: "test",
+      nodeMetadata: {},
+    });
+    expect(name).toEqual("test_type: test");
   });
 
   it("will correctly return whether a given item is 'analysis' on isAnalysis", () => {
+    const { wrapper } = factory();
+
     let isAnalysis = wrapper.vm.isAnalysis(mockAnalysisRead);
     expect(isAnalysis).toEqual(true);
     isAnalysis = wrapper.vm.isAnalysis({
@@ -93,6 +146,8 @@ describe("AlertTree.vue", () => {
     expect(isAnalysis).toEqual(false);
   });
   it("will correctly return whether a given item is an 'observable' on isObservable", () => {
+    const { wrapper } = factory();
+
     let isObservable = wrapper.vm.isObservable(mockAnalysisRead);
     expect(isObservable).toEqual(false);
     isObservable = wrapper.vm.isObservable({
@@ -103,6 +158,8 @@ describe("AlertTree.vue", () => {
     expect(isObservable).toEqual(true);
   });
   it("will correctly generate a given item's style classes", () => {
+    const { wrapper } = factory();
+
     let containerClass = wrapper.vm.containerClass({ children: ["not_empty"] });
     expect(containerClass).toEqual([
       "p-treenode",
@@ -112,11 +169,26 @@ describe("AlertTree.vue", () => {
     expect(containerClass).toEqual(["p-treenode", { "p-treenode-leaf": true }]);
   });
   it("will correctly return whether a given item has tags", () => {
+    const { wrapper } = factory();
+
     let hasTags = wrapper.vm.hasTags({});
     expect(hasTags).toEqual(false);
     hasTags = wrapper.vm.hasTags({ tags: [] });
     expect(hasTags).toBeFalsy();
     hasTags = wrapper.vm.hasTags({ tags: ["not_empty"] });
     expect(hasTags).toBeTruthy();
+  });
+  it("will route the manage alerts page with correctly observable query when filterByObservable is called with a given observable", async () => {
+    const { wrapper, router } = factory();
+
+    const observable = {
+      nodeType: "observable",
+      type: { value: "test_type" },
+      value: "test",
+    };
+    wrapper.vm.filterByObservable(observable);
+    expect(router.currentRoute.value.fullPath).toEqual(
+      "/manage_alerts?observable=test_type|test",
+    );
   });
 });


### PR DESCRIPTION
This adds functionality to click on an observable in the alert tree and be linked to the Manage Alerts page with the observable filter applied for the clicked observable.

Also, this PR adds an underline & bold effect on hover for alert tree nodes.