### PR TITLE
Get Nodes of a specific type from a list of NodeTrees

### DIFF
--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -26,6 +26,7 @@ from api.routes.node_tag import router as node_tag_router
 from api.routes.node_threat import router as node_threat_router
 from api.routes.node_threat_actor import router as node_threat_actor_router
 from api.routes.node_threat_type import router as node_threat_type_router
+from api.routes.node_tree import router as node_tree_router
 from api.routes.observable import router as observable_router
 from api.routes.observable_type import router as observable_type_router
 from api.routes.ping import router as ping_router
@@ -61,6 +62,7 @@ router.include_router(node_tag_router)
 router.include_router(node_threat_router)
 router.include_router(node_threat_actor_router)
 router.include_router(node_threat_type_router)
+router.include_router(node_tree_router)
 router.include_router(observable_router)
 router.include_router(observable_type_router)
 router.include_router(ping_router)

--- a/backend/app/api/routes/helpers.py
+++ b/backend/app/api/routes/helpers.py
@@ -81,12 +81,16 @@ def api_route_read(
     endpoint: Callable,
     response_model: BaseModel = BaseModel,
     path: str = "/{uuid}",
+    methods: list[str] = None,
 ):
+    if not methods:
+        methods = ["GET"]
+
     router.add_api_route(
         dependencies=[Depends(validate_access_token)],
         path=path,
         endpoint=endpoint,
-        methods=["GET"],
+        methods=methods,
         response_model=response_model,
         responses={
             status.HTTP_404_NOT_FOUND: {"description": "The UUID was not found"},

--- a/backend/app/api/routes/node_tree.py
+++ b/backend/app/api/routes/node_tree.py
@@ -1,0 +1,25 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from api.routes import helpers
+from db import crud
+from db.database import get_db
+
+
+router = APIRouter(
+    prefix="/node/tree",
+    tags=["Node Tree"],
+)
+
+
+#
+# READ
+#
+
+
+def get_node_tree_nodes(node_type: str, root_node_uuids: list[UUID], db: Session = Depends(get_db)):
+    return crud.read_node_tree_nodes(node_type=node_type, root_node_uuids=root_node_uuids, db=db)
+
+
+helpers.api_route_read(router, get_node_tree_nodes, list[dict], methods=["POST"], path="/{node_type}")

--- a/backend/app/tests/api/node_tree/test_read.py
+++ b/backend/app/tests/api/node_tree/test_read.py
@@ -1,0 +1,61 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_node_tree_nodes_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.post("/api/node/tree/observable", json=["1"])
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_node_tree_nodes_nonexistent_type(client_valid_access_token, db):
+    alert_tree = helpers.create_alert(db=db)
+
+    get = client_valid_access_token.post("/api/node/tree/abc", json=[str(alert_tree.node_uuid)])
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_node_tree_nodes_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.post("/api/node/tree/observable", json=[str(uuid.uuid4())])
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_node_tree_nodes(client_valid_access_token, db):
+    # Create an alert tree where the same observable type+value appears twice
+    alert_tree = helpers.create_alert(db=db)
+    observable1_tree = helpers.create_observable(type="fqdn", value="bad.com", parent_tree=alert_tree, db=db)
+    helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree, db=db)
+    analysis_tree = helpers.create_analysis(parent_tree=observable1_tree, db=db)
+    helpers.create_observable(type="fqdn", value="bad.com", parent_tree=analysis_tree, db=db)
+
+    # Create a second alert tree with a duplicate observable from the first alert
+    alert_tree2 = helpers.create_alert(db=db)
+    helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree2, db=db)
+    helpers.create_observable(type="email_address", value="badguy@bad.com", parent_tree=alert_tree2, db=db)
+
+    # Fetching the list of observables in the NodeTrees should only show three observables since
+    # there were duplicates:
+    #
+    # email_address: badguy@bad.com
+    # fqdn: bad.com
+    # ipv4: 127.0.0.1
+    get = client_valid_access_token.post(
+        "/api/node/tree/observable", json=[str(alert_tree.node_uuid), str(alert_tree2.node_uuid)]
+    )
+    assert get.status_code == status.HTTP_200_OK
+    assert len(get.json()) == 3
+    assert any(o["type"]["value"] == "email_address" and o["value"] == "badguy@bad.com" for o in get.json())
+    assert any(o["type"]["value"] == "fqdn" and o["value"] == "bad.com" for o in get.json())
+    assert any(o["type"]["value"] == "ipv4" and o["value"] == "127.0.0.1" for o in get.json())


### PR DESCRIPTION
Despite the awkward sounding PR title, this adds functionality (in a generic way) to accomplish something very common in the application - getting a list of observables inside of an alert. But because this was written generically, you could use it to get a list of analyses in an alert (or any other Node type that might be added in the future).

Also, because this new API endpoint uses a POST request (which does buck the trend of only using GET requests to read data), you can specify multiple alert UUIDs in the request if you want a list of observables across multiple alerts. This was done with events in mind since we will eventually want an easy way to say "give me all the observables in events A, B, and C".

### Example

To fetch all observables inside of alert `2dcdb780-059a-4531-b580-f65c356c8db6`:

```
POST /node/tree/observable
[
  "2dcdb780-059a-4531-b580-f65c356c8db6"
]
```