### PR TITLE
Observable Dropdown

### DIFF
--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -94,11 +94,7 @@
           >
           <br />
           <span>
-            <NodeTagVue
-              v-for="tag in data.tags"
-              :key="tag.uuid"
-              :tag="tag"
-            ></NodeTagVue>
+            <NodeTagVue v-for="tag in data.tags" :key="tag.uuid" :tag="tag" />
           </span>
           <span v-if="data.comments">
             <pre
@@ -119,13 +115,16 @@
 
     <!--      ALERT ROW DROPDOWN -->
     <template #expansion="slotProps">
-      <h5>Observables:</h5>
       <ul>
         <li
           v-for="obs of expandedRowsData[slotProps.data.uuid]"
           :key="obs.value"
         >
-          {{ obs.type.value }} : {{ obs.value}}
+          <span class="link-text" @click="filterByObservable(obs)"
+            >{{ obs.type.value }} : {{ obs.value }}</span
+          >
+
+          <NodeTagVue v-for="tag of obs.tags" :key="tag.value" :tag="tag" />
         </li>
       </ul>
     </template>
@@ -162,6 +161,7 @@
   import { useAlertTableStore } from "@/stores/alertTable";
   import { useFilterStore } from "@/stores/filter";
   import { useSelectedAlertStore } from "@/stores/selectedAlert";
+  import NodeTag from "../Node/NodeTag.vue";
 
   const alertTableStore = useAlertTableStore();
   const filterStore = useFilterStore();
@@ -237,11 +237,26 @@
       [uuid],
       "observable",
     );
-    expandedRowsData.value[uuid] = observables;
+    expandedRowsData.value[uuid] = observables.sort((a, b) =>
+      a.type.value < b.type.value ? -1 : a.type.value > b.type.value ? 1 : 0,
+    );
   };
 
-  const rowCollapse = async (uuid) => {
+  const rowCollapse = (uuid) => {
     delete expandedRowsData.value[uuid];
+  };
+
+  const filterByObservable = (observable) => {
+    expandedRows.value = [];
+    filterStore.bulkSetFilters({
+      filterType: "alerts",
+      filters: {
+        observable: {
+          category: observable.type,
+          value: observable.value,
+        },
+      },
+    });
   };
 
   onMounted(async () => {
@@ -321,3 +336,11 @@
     }
   };
 </script>
+
+<style>
+  .link-text:hover {
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
+  }
+</style>

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -161,7 +161,6 @@
   import { useAlertTableStore } from "@/stores/alertTable";
   import { useFilterStore } from "@/stores/filter";
   import { useSelectedAlertStore } from "@/stores/selectedAlert";
-  import NodeTag from "../Node/NodeTag.vue";
 
   const alertTableStore = useAlertTableStore();
   const filterStore = useFilterStore();

--- a/frontend/src/services/api/base.ts
+++ b/frontend/src/services/api/base.ts
@@ -24,11 +24,11 @@ export class BaseApi {
     DELETE: "delete",
   };
 
-  protected async baseRequest(
+  async baseRequest(
     url: string,
     method: Method,
     options?: {
-      data?: Record<string, unknown> | Record<string, unknown>[];
+      data?: Record<string, unknown> | Record<string, unknown>[] | string[];
       params?: Record<string, unknown>;
     },
     getAfterCreate = false,
@@ -42,7 +42,13 @@ export class BaseApi {
     if (options) {
       if (options.data) {
         if (Array.isArray(options.data)) {
-          config["data"] = options.data.map((x) => this.formatOutgoingData(x));
+          config["data"] = options.data.map((x) => {
+            if (typeof x === "string") {
+              return x;
+            } else {
+              return this.formatOutgoingData(x);
+            }
+          });
         } else {
           config["data"] = this.formatOutgoingData(options.data);
         }

--- a/frontend/src/services/api/nodeTree.ts
+++ b/frontend/src/services/api/nodeTree.ts
@@ -1,0 +1,14 @@
+import { nodeRead } from "@/models/node";
+import { UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/node/tree/";
+
+export const NodeTree = {
+  readNodesOfNodeTree: (
+    uuids: Array<UUID>,
+    nodeType: string,
+  ): Promise<Array<nodeRead>> =>
+    api.baseRequest(`${endpoint}${nodeType}`, "POST", { data: uuids }),
+};

--- a/frontend/src/services/api/nodeTree.ts
+++ b/frontend/src/services/api/nodeTree.ts
@@ -1,4 +1,3 @@
-import { nodeRead } from "@/models/node";
 import { UUID } from "@/models/base";
 import { BaseApi } from "./base";
 
@@ -9,6 +8,6 @@ export const NodeTree = {
   readNodesOfNodeTree: (
     uuids: Array<UUID>,
     nodeType: string,
-  ): Promise<Array<nodeRead>> =>
+  ): Promise<Record<string, unknown>[]> =>
     api.baseRequest(`${endpoint}${nodeType}`, "POST", { data: uuids }),
 };

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -1,10 +1,9 @@
 import TheAlertsTable from "@/components/Alerts/TheAlertsTable.vue";
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import PrimeVue from "primevue/config";
 import myNock from "@unit/services/api/nock";
-import router from "@/router";
 import { FilterMatchMode } from "primevue/api";
-import { createTestingPinia } from "@pinia/testing";
+import { createTestingPinia, TestingOptions } from "@pinia/testing";
 
 import InputText from "primevue/inputtext";
 import MultiSelect from "primevue/multiselect";
@@ -13,8 +12,9 @@ import DataTable from "primevue/datatable";
 import Button from "primevue/button";
 import Column from "primevue/column";
 import Paginator from "primevue/paginator";
-import nock from "nock";
 import { alertRead } from "@/models/alert";
+import { useFilterStore } from "@/stores/filter";
+import { createRouterMock, injectRouterMock } from "vue-router-mock";
 
 const mockAPIAlert: alertRead = {
   comments: [],
@@ -40,39 +40,31 @@ const mockAPIAlert: alertRead = {
   version: "uuid2",
 };
 
-// DATA/CREATION
-describe("TheAlertsTable data/creation", () => {
+function factory(options?: TestingOptions) {
+  const router = createRouterMock();
+  injectRouterMock(router);
+
   const wrapper: VueWrapper<any> = mount(TheAlertsTable, {
     global: {
-      plugins: [createTestingPinia({ stubActions: false }), PrimeVue, router],
+      plugins: [createTestingPinia(options), PrimeVue],
     },
   });
 
-  beforeAll(async () => {
-    nock.cleanAll();
-    myNock
-      .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
-      .reply(200, {
-        items: [mockAPIAlert, mockAPIAlert],
-        total: 2,
-      })
-      .persist();
-  });
+  const filterStore = useFilterStore();
 
-  beforeEach(async () => {
-    await wrapper.vm.reset();
-    await wrapper.vm.loadAlerts();
-  });
+  return { wrapper, filterStore };
+}
 
-  afterAll(() => {
-    nock.cleanAll();
-  });
-
+// DATA/CREATION
+describe.only("TheAlertsTable data/creation", () => {
   it("renders", async () => {
+    const { wrapper } = factory();
     expect(wrapper.exists()).toBe(true);
   });
 
-  it("contains expected components upon creation", async () => {
+  it("contains expected components upon creation", () => {
+    const { wrapper } = factory();
+
     expect(wrapper.findComponent(Button).exists()).toBe(true);
     expect(wrapper.findComponent(Column).exists()).toBe(true);
     expect(wrapper.findComponent(DataTable).exists()).toBe(true);
@@ -82,7 +74,9 @@ describe("TheAlertsTable data/creation", () => {
     expect(wrapper.findComponent(Paginator).exists()).toBe(true);
   });
 
-  it("initializes data as expected", async () => {
+  it("initializes data as expected", () => {
+    const { wrapper } = factory();
+
     expect(wrapper.vm.alertTableFilter).toStrictEqual({
       global: { matchMode: "contains", value: null },
     });
@@ -111,18 +105,21 @@ describe("TheAlertsTable data/creation", () => {
       "owner",
       "disposition",
     ]);
-    expect(wrapper.vm.isLoading).toEqual(false);
+    expect(wrapper.vm.isLoading).toEqual(true);
     expect(wrapper.vm.error).toBeNull();
     expect(
       wrapper.vm.alertTableStore.visibleQueriedAlertSummaries,
-    ).toHaveLength(2);
-    expect(wrapper.vm.alertTableStore.totalAlerts).toEqual(2);
+    ).toHaveLength(0);
+    expect(wrapper.vm.alertTableStore.totalAlerts).toEqual(0);
     expect(wrapper.vm.sortField).toEqual("eventTime");
     expect(wrapper.vm.sortOrder).toEqual("desc");
     expect(wrapper.vm.numRows).toEqual(10);
     expect(wrapper.vm.page).toEqual(0);
   });
-  it("computes computed properties correctly", async () => {
+
+  it("computes computed properties correctly", () => {
+    const { wrapper } = factory();
+
     expect(wrapper.vm.pageOptions).toStrictEqual({
       limit: 10,
       offset: 0,
@@ -131,37 +128,66 @@ describe("TheAlertsTable data/creation", () => {
     wrapper.vm.sortField = null;
     expect(wrapper.vm.sortFilter).toBeNull();
   });
-});
 
-// METHODS (SUCCESS)
-describe("TheAlertsTable methods success", () => {
-  const wrapper: VueWrapper<any> = mount(TheAlertsTable, {
-    global: {
-      plugins: [createTestingPinia({ stubActions: false }), PrimeVue, router],
-    },
+  it("will fetch an alert's observables and set the sorted array in expandedRowsData on rowExpand", async () => {
+    const { wrapper } = factory();
+
+    myNock.post("/node/tree/observable", '["uuid1"]').reply(200, [
+      { type: { value: "type_B" }, value: "value_B" },
+      { type: { value: "type_A" }, value: "value_A" },
+    ]);
+    await wrapper.vm.rowExpand("uuid1");
+    expect(wrapper.vm.expandedRowsData).toStrictEqual({
+      uuid1: [
+        { type: { value: "type_A" }, value: "value_A" },
+        { type: { value: "type_B" }, value: "value_B" },
+      ],
+    });
   });
 
-  beforeAll(async () => {
-    nock.cleanAll();
+  it("will remove the given property (an alert UUID) from expandedRowsData on rowCollapse", () => {
+    const { wrapper } = factory();
+
+    wrapper.vm.expandedRowsData = {
+      uuid1: [
+        { type: { value: "type_A" }, value: "value_A" },
+        { type: { value: "type_B" }, value: "value_B" },
+      ],
+    };
+    wrapper.vm.rowCollapse("uuid1");
+    expect(wrapper.vm.expandedRowsData).toStrictEqual({});
+  });
+
+  it("will set filters to the given observable and clear expandedRows on filterByObservable", async () => {
+    myNock.get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0").reply(200, {
+      items: [mockAPIAlert, mockAPIAlert],
+      total: 2,
+    });
     myNock
-      .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
+      .get(
+        "/alert/?sort=event_time%7Cdesc&limit=10&offset=0&observable=type_A%7Cvalue_A",
+      )
       .reply(200, {
-        items: [mockAPIAlert, mockAPIAlert],
-        total: 2,
-      })
-      .persist();
-  });
+        items: [],
+        total: 0,
+      });
+    const { wrapper, filterStore } = factory({ stubActions: false });
 
-  beforeEach(async () => {
-    await wrapper.vm.reset();
-    await wrapper.vm.loadAlerts();
-  });
+    wrapper.vm.expandedRows = ["uuid1"];
+    wrapper.vm.filterByObservable({
+      type: { value: "type_A" },
+      value: "value_A",
+    });
 
-  afterAll(() => {
-    nock.cleanAll();
+    expect(wrapper.vm.expandedRows).toEqual([]);
+    expect(filterStore.alerts).toStrictEqual({
+      observable: { category: { value: "type_A" }, value: "value_A" },
+    });
   });
 
   it("will reset Alert table to defaults upon reset()", async () => {
+    const { wrapper } = factory();
+
     wrapper.vm.alertTableFilter = [];
     wrapper.vm.selectedColumns = [];
     wrapper.vm.reset();
@@ -177,6 +203,8 @@ describe("TheAlertsTable methods success", () => {
   });
 
   it("will init Alert table to defaults upon initAlertTable()", async () => {
+    const { wrapper } = factory();
+
     wrapper.vm.alertTableFilter = [];
     wrapper.vm.initAlertTable();
     expect(wrapper.vm.alertTableFilter).toStrictEqual({
@@ -184,12 +212,16 @@ describe("TheAlertsTable methods success", () => {
     });
   });
   it("will export the alerts table to CSV on exportCSV", async () => {
+    const { wrapper } = factory();
+
     // we cant actually export the CSV in test so mock one of the dependency functions
     window.URL.createObjectURL = jest.fn().mockReturnValueOnce("fakeURL");
     wrapper.vm.exportCSV();
   });
 
   it("will correctly set selectedColumns when onColumnToggle", async () => {
+    const { wrapper } = factory();
+
     expect(wrapper.vm.selectedColumns).toStrictEqual([
       { field: "eventTime", header: "Event Time" },
       { field: "name", header: "Name" },
@@ -202,9 +234,14 @@ describe("TheAlertsTable methods success", () => {
     ]);
   });
   it("will reload the alerts with new pagination settings on 'onPage'", async () => {
+    myNock.get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0").reply(200, {
+      items: [mockAPIAlert, mockAPIAlert],
+      total: 2,
+    });
+    const { wrapper } = factory({ stubActions: false });
+
     const mockRequest = myNock
       .get("/alert/?sort=event_time%7Cdesc&limit=1&offset=1")
-      .thrice()
       .reply(200, {
         items: [mockAPIAlert],
         total: 2,
@@ -215,8 +252,14 @@ describe("TheAlertsTable methods success", () => {
     expect(mockRequest.isDone()).toEqual(true);
   });
   it("will reload the alerts with new sort settings on 'sort'", async () => {
+    myNock.get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0").reply(200, {
+      items: [mockAPIAlert, mockAPIAlert],
+      total: 2,
+    });
+    const { wrapper } = factory({ stubActions: false });
+
     const mockRequestSort = myNock
-      .get("/alert/?sort=name%7Casc&limit=1&offset=1")
+      .get("/alert/?sort=name%7Casc&limit=10&offset=0")
       .reply(200, {
         items: [mockAPIAlert],
         total: 2,
@@ -227,11 +270,15 @@ describe("TheAlertsTable methods success", () => {
     expect(mockRequestSort.isDone()).toEqual(true);
   });
   it("will reset sort settings if sort called without sortField", async () => {
+    const { wrapper } = factory();
+
     await wrapper.vm.sort({});
     expect(wrapper.vm.sortField).toBeNull();
     expect(wrapper.vm.sortOrder).toBeNull();
   });
   it("will reload and clear selected alerts, and clear requestReload on reloadTable", async () => {
+    const { wrapper } = factory();
+
     wrapper.vm.selectedAlertStore.selectAll(["uuid1", "uuid2", "uuid3"]);
     wrapper.vm.selectedRows = ["uuid1", "uuid2", "uuid3"];
     wrapper.vm.alertTableStore.requestReload = true;
@@ -240,28 +287,16 @@ describe("TheAlertsTable methods success", () => {
     expect(wrapper.vm.selectedAlertStore.selected).toEqual([]);
     expect(wrapper.vm.alertTableStore.requestReload).toBeFalsy();
   });
-});
-
-// METHODS (FAILED)
-describe("TheAlertsTable methods failed", () => {
-  const wrapper: VueWrapper<any> = mount(TheAlertsTable, {
-    global: {
-      plugins: [createTestingPinia({ stubActions: false }), PrimeVue, router],
-    },
-  });
-
-  beforeAll(() => {
-    nock.cleanAll();
-  });
-
-  afterAll(() => {
-    nock.cleanAll();
-  });
 
   it("will set the error data property to the given error if getAllAlerts fails within loadAlerts", async () => {
+    myNock.get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0").reply(200, {
+      items: [mockAPIAlert, mockAPIAlert],
+      total: 2,
+    });
+    const { wrapper } = factory({ stubActions: false });
+
     const mockRequest = myNock
       .get("/alert/?sort=event_time%7Cdesc&limit=10&offset=0")
-      .twice()
       .reply(403, "Request Failed");
 
     expect(wrapper.vm.error).toBeNull();

--- a/frontend/tests/unit/src/services/api/base.spec.ts
+++ b/frontend/tests/unit/src/services/api/base.spec.ts
@@ -67,6 +67,17 @@ describe("BaseAPI calls", () => {
     expect(res).toEqual("Create successful");
   });
 
+  it("will not change format of outgoing data if its an array of strings", async () => {
+    myNock.post("/create", ["A", "B"]).reply(200, "Create successful");
+    const res = await api.baseRequest(
+      "/create",
+      "POST",
+      { data: ["A", "B"] },
+      false,
+    );
+    expect(res).toEqual("Create successful");
+  });
+
   it("will format incoming data into camelCase keys", async () => {
     myNock.post("/create").reply(200, { first_key: "A", second_key: 2 });
     const res = await api.create("/create", {}, false);

--- a/frontend/tests/unit/src/services/api/nodeTree.spec.ts
+++ b/frontend/tests/unit/src/services/api/nodeTree.spec.ts
@@ -1,0 +1,28 @@
+/**
+ * @jest-environment node
+ */
+
+import { NodeTree } from "@/services/api/nodeTree";
+import myNock from "./nock";
+
+describe("nodeTree API calls", () => {
+  const mockObjectReadArray: Record<string, unknown>[] = [
+    {
+      uuid: "1",
+      value: "Test",
+    },
+    {
+      uuid: "1",
+      value: "Test",
+    },
+  ];
+
+  it("will make a post request to the correct endpoint when readNodesOfNodeTree is called", async () => {
+    myNock
+      .post("/node/tree/observable", JSON.stringify(["1", "2"]))
+      .reply(200, mockObjectReadArray);
+
+    const res = await NodeTree.readNodesOfNodeTree(["1", "2"], "observable");
+    expect(res).toEqual(mockObjectReadArray);
+  });
+});


### PR DESCRIPTION
This PR adds functionality to fetch and display a given alert's observables in the alert table when a row is expanded.

Within the dropdown, the observables are displayed in a list, alphabetically by type. Clicking on an observable will refresh the table and filter on that observable. Observable tags are also displayed, and can be clicked on to filter by each given tag.

Detailed file changelist:
* frontend/src/components/Alerts/TheAlertsTable.vue
  * Add functionality for row/expand collapse
  * Add observable & observable tag display
  * Add functionality for filter links on observable or observable tag
* frontend/src/services/api/base.ts
  * Un-protect baseRequest to make it easier to do complex requests
  * Add the ability to send a list of strings as data (as opposed to only objects or list of objects) 
* frontend/src/services/api/nodeTree.ts
  * Add new service for 'nodeTree,' which allows for fetching all observables for a given alert (or list of alerts). Can be extended for any node type 
