### PR TITLE
Child tags

### DIFF
--- a/backend/app/api/models/alert.py
+++ b/backend/app/api/models/alert.py
@@ -64,6 +64,8 @@ class AlertCreate(NodeCreate, AlertBase):
 
 
 class AlertRead(NodeRead, AlertBase):
+    child_tags: List[NodeTagRead] = Field(description="A list of tags added to child Nodes in the alert's tree")
+
     comments: List[NodeCommentRead] = Field(description="A list of comments added to the alert")
 
     disposition: Optional[AlertDispositionRead] = Field(description="The disposition assigned to this alert")

--- a/backend/app/api/routes/alert.py
+++ b/backend/app/api/routes/alert.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from fastapi import APIRouter, Depends, Query, Request, Response
 from fastapi_pagination.ext.sqlalchemy_future import paginate
-from sqlalchemy import and_, func, select
+from sqlalchemy import and_, func, or_, select
 from sqlalchemy.orm import Session
 from typing import List, Optional
 from uuid import UUID, uuid4
@@ -252,9 +252,9 @@ def get_all_alerts(
     if tags:
         tag_filters = []
         for tag in tags.split(","):
-            tag_filters.append(Alert.tags.any(NodeTag.value == tag))
-        tags_query = select(Alert).where(and_(*tag_filters))
+            tag_filters.append(or_(Alert.tags.any(NodeTag.value == tag), Alert.child_tags.any(NodeTag.value == tag)))
 
+        tags_query = select(Alert).where(and_(*tag_filters))
         query = _join_as_subquery(query, tags_query)
 
     if threat_actors:

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -256,7 +256,7 @@ def read_node_tree(root_node_uuid: UUID, db: Session) -> dict:
 
 def read_node_tree_nodes(node_type: str, root_node_uuids: list[UUID], db: Session) -> list[dict]:
     """Returns a list of Node objects of the given type that are in the given NodeTrees.
-    The returned objectsare manually serialized into their Pydantic models since Pydantic
+    The returned objects are manually serialized into their Pydantic models since Pydantic
     cannot handle returning a list of multiple types of objects in this case."""
 
     nodes: List[Node] = (

--- a/backend/app/db/schemas/node.py
+++ b/backend/app/db/schemas/node.py
@@ -15,6 +15,38 @@ class Node(Base):
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
 
+    # The child_tags field uses a composite join relationship to get a list of the tags that
+    # are applied to any Nodes that exist in this Node's tree structure. For example, this is
+    # used on the Manage Alerts page so that we can display ALL of the tags for an alert and
+    # its child Nodes. Below is an example of a raw SQL query that gets a list of the tags
+    # on child Nodes:
+    #
+    # SELECT * from node_tag
+    # JOIN node_tag_mapping ON node_tag_mapping.tag_uuid = node_tag.uuid
+    # JOIN node_tree ON node_tree.node_uuid = node_tag_mapping.node_uuid
+    # WHERE node_tree.root_node_uuid = '02f8299b-2a24-400f-9751-7dd9164daf6a'
+    #
+    # While there is nothing complicated about this SQL query, SQLAlchemy does not have a
+    # straightforward way to handle these types of relationships with intermediate tables.
+    # To solve this, you have to use the composite join relationship, which is described here:
+    # https://docs.sqlalchemy.org/en/14/orm/join_conditions.html#composite-secondary-joins
+    #
+    # The overall goal is that you use the "secondary" parameter in the relationship to construct
+    # the intermediate table that you need. You then use the "primaryjoin" and, if needed, the
+    # "secondaryjoin" parameters to tell SQLAlchemy how to join the child object against the
+    # parent object (where in this case Node is the parent, and NodeTag is the child).
+    #
+    # Finally, "viewonly" is used on the relationship to prevent attempts to add tags to this list.
+
+    child_tags = relationship(
+        "NodeTag",
+        secondary="join(NodeTag, node_tag_mapping, NodeTag.uuid == node_tag_mapping.c.tag_uuid)."
+        "join(NodeTree, NodeTree.node_uuid == node_tag_mapping.c.node_uuid)",
+        primaryjoin="Node.uuid == NodeTree.root_node_uuid",
+        viewonly=True,
+        lazy="selectin",
+    )
+
     comments = relationship("NodeComment", lazy="selectin")
 
     directives = relationship("NodeDirective", secondary=node_directive_mapping, lazy="selectin")

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -85,13 +85,13 @@
       <template #body="{ data }">
         <!-- NAME COLUMN - INCL. TAGS AND TODO: ALERT ICONS-->
         <div v-if="col.field === 'name'">
-          <span class="p-m-1">
+          <span class="p-m-1" data-cy="alertName">
             <router-link :to="getAlertLink(data.uuid)">{{
               data.name
             }}</router-link></span
           >
           <br />
-          <span>
+          <span data-cy="tags">
             <NodeTagVue
               v-for="tag in getAllTags(data)"
               :key="tag.uuid"

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -250,8 +250,10 @@
   const getAllTags = (alert) => {
     const allTags = alert.tags.concat(alert.childTags);
 
-    // Return a deduplicated list of the tags based on the tag UUID. Does not preserve tag ordering.
-    return [...new Map(allTags.map((v) => [v.uuid, v])).values()];
+    // Return a sorted and deduplicated list of the tags based on the tag UUID.
+    return [...new Map(allTags.map((v) => [v.uuid, v])).values()].sort((a, b) =>
+      a.value > b.value ? 1 : -1,
+    );
   };
 
   const initAlertTable = () => {

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -93,7 +93,7 @@
           <br />
           <span>
             <NodeTagVue
-              v-for="tag in data.tags"
+              v-for="tag in getAllTags(data)"
               :key="tag.uuid"
               :tag="tag"
             ></NodeTagVue>
@@ -245,6 +245,13 @@
 
   const getAlertLink = (uuid) => {
     return "/alert/" + uuid;
+  };
+
+  const getAllTags = (alert) => {
+    const allTags = alert.tags.concat(alert.childTags);
+
+    // Return a deduplicated list of the tags based on the tag UUID. Does not preserve tag ordering.
+    return [...new Map(allTags.map((v) => [v.uuid, v])).values()];
   };
 
   const initAlertTable = () => {

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -240,9 +240,14 @@
       [uuid],
       "observable",
     );
-    expandedRowsData.value[uuid] = observables.sort((a, b) =>
-      a.type.value < b.type.value ? -1 : a.type.value > b.type.value ? 1 : 0,
-    );
+
+    expandedRowsData.value[uuid] = observables.sort((a, b) => {
+      if (a.type.value === b.type.value) {
+        return a.value < b.value ? -1 : 1;
+      } else {
+        return a.type.value < b.type.value ? -1 : 1;
+      }
+    });
   };
 
   const rowCollapse = (uuid) => {

--- a/frontend/src/models/alert.ts
+++ b/frontend/src/models/alert.ts
@@ -33,6 +33,7 @@ export interface alertCreate extends nodeCreate {
 }
 
 export interface alertRead extends nodeRead {
+  childTags: nodeTagRead[];
   comments: nodeCommentRead[];
   description: string | null;
   disposition: alertDispositionRead | null;
@@ -55,6 +56,7 @@ export interface alertRead extends nodeRead {
 
 // High-level alert data that will be displayed in Manage Alerts or in an event
 export interface alertSummary {
+  childTags: nodeTagRead[];
   comments: nodeCommentRead[];
   description: string;
   disposition: string;

--- a/frontend/src/stores/alertTable.ts
+++ b/frontend/src/stores/alertTable.ts
@@ -5,6 +5,7 @@ import { Alert } from "@/services/api/alert";
 
 export function parseAlertSummary(alert: alertRead): alertSummary {
   return {
+    childTags: alert.childTags,
     comments: alert.comments,
     description: alert.description ? alert.description : "",
     disposition: alert.disposition ? alert.disposition.value : "OPEN",

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -438,9 +438,13 @@ describe("Manage Alerts Tags", () => {
     // Enter & close modal
     cy.get(".p-dialog-footer > :nth-child(2)").click();
     cy.get(".p-dialog-content").should("not.exist");
-    // Check for comment after adding
-    cy.get(".p-chip-text").first().should("have.text", "scan_me");
-    cy.get(".p-chip-text").last().should("have.text", "TestTag");
+    // Check for the tags after adding
+    cy.get("[data-cy='tags']")
+      .eq(0)
+      .within(() => {
+        cy.get(".p-chip-text").first().should("have.text", "TestTag");
+        cy.get(".p-chip-text").last().should("have.text", "scan_me");
+      });
   });
 });
 

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -222,27 +222,18 @@ describe("TheAlertsTable.vue", () => {
     // check api call
     cy.wait("@nameSortDesc").its("state").should("eq", "Complete");
     // check first alerts name
-    cy.get(".p-datatable-tbody > :nth-child(1) > :nth-child(4)").should(
-      "have.text",
-      "Small Alert",
-    );
+    cy.get('[data-cy="alertName"]').eq(0).should("have.text", "Small Alert");
     // sort by name again, this time it will remove all sorts
     cy.get(".p-datatable-thead > tr > :nth-child(4)").click();
     // there shouldn't be an API call this time
     // check first alerts name (will be the same)
-    cy.get(".p-datatable-tbody > :nth-child(1) > :nth-child(4)").should(
-      "have.text",
-      "Small Alert",
-    );
+    cy.get('[data-cy="alertName"]').eq(0).should("have.text", "Small Alert");
     // sort by event time again, will default to ascending
     cy.get(".p-datatable-thead > tr > :nth-child(3)").click();
     // check api call
     cy.wait("@eventTimeSortAsc").its("state").should("eq", "Complete");
     // check first alerts name
-    cy.get(".p-datatable-tbody > :nth-child(1) > :nth-child(4)").should(
-      "have.text",
-      "Small Alert",
-    );
+    cy.get('[data-cy="alertName"]').eq(0).should("have.text", "Small Alert");
     // click the reset table button
     cy.get(
       ".p-datatable-header > .p-toolbar > .p-toolbar-group-right > :nth-child(2)",
@@ -250,10 +241,7 @@ describe("TheAlertsTable.vue", () => {
     // check api call
     cy.wait("@defaultSort").its("state").should("eq", "Complete");
     // check first alerts name
-    cy.get(".p-datatable-tbody > :nth-child(1) > :nth-child(4)").should(
-      "have.text",
-      "Small Alert",
-    );
+    cy.get('[data-cy="alertName"]').eq(0).should("have.text", "Small Alert");
   });
 
   // This test broken by pagination changes

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -284,7 +284,7 @@ describe("TheAlertsTable.vue", () => {
       .click();
     // Wait for the filtered view to be requested
     cy.wait("@filterURL");
-    // Check which alerts checkboxes are visible (should be only 1 for the header, no alerts with that tag)
-    cy.get(".p-checkbox-box").should("have.length", 1);
+    // Check which alerts checkboxes are visible (should be only 1 for the header, and 1 alert with that tag)
+    cy.get(".p-checkbox-box").should("have.length", 2);
   });
 });

--- a/frontend/tests/mockData/alert.ts
+++ b/frontend/tests/mockData/alert.ts
@@ -426,6 +426,28 @@ export const mockAlert: alertTreeRead = {
   firstAppearance: true,
   parentTreeUuid: null,
   treeUuid: "7222dc2b-40a4-459b-81d1-7a831f7458dc",
+  childTags: [
+    {
+      description: null,
+      value: "recipient",
+      uuid: "c5d3321d-883c-4772-b511-489273e13fde",
+    },
+    {
+      description: null,
+      value: "from_address",
+      uuid: "f9081b70-c2bf-4a7d-ba90-a675e8a929d2",
+    },
+    {
+      description: null,
+      value: "contacted_host",
+      uuid: "3c1ca637-48d1-4d47-aeee-0962bc32d96d",
+    },
+    {
+      description: null,
+      value: "c2",
+      uuid: "a0b2d514-c544-4a8f-a059-b6151b9f1dd6",
+    },
+  ],
   tags: [],
   threatActors: [],
   threats: [],

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -1,5 +1,5 @@
 import TheAlertsTable from "@/components/Alerts/TheAlertsTable.vue";
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import PrimeVue from "primevue/config";
 import myNock from "@unit/services/api/nock";
 import router from "@/router";
@@ -17,6 +17,7 @@ import nock from "nock";
 import { alertRead } from "@/models/alert";
 
 const mockAPIAlert: alertRead = {
+  childTags: [],
   comments: [],
   description: "",
   disposition: null,

--- a/frontend/tests/unit/src/store/alertTable.spec.ts
+++ b/frontend/tests/unit/src/store/alertTable.spec.ts
@@ -1,6 +1,6 @@
 // TODO: Move to alertTable store tests
 import myNock from "@unit/services/api/nock";
-import { alertFilterParams, alertRead } from "@/models/alert";
+import { alertFilterParams, alertRead, alertSummary } from "@/models/alert";
 import { parseAlertSummary, useAlertTableStore } from "@/stores/alertTable";
 import { createTestingPinia } from "@pinia/testing";
 import { mockAlert } from "../../../mockData/alert";
@@ -11,6 +11,7 @@ const store = useAlertTableStore();
 const mockAlertReadA = Object.assign({}, mockAlert, { uuid: "uuid1" });
 const mockAlertReadB = Object.assign({}, mockAlert, { uuid: "uuid2" });
 const mockAlertReadC: alertRead = {
+  childTags: [],
   description: "test description",
   disposition: {
     value: "FALSE_POSITIVE",
@@ -39,7 +40,29 @@ const mockAlertReadC: alertRead = {
   threatActors: [],
 };
 
-const mockAlertReadASummary = {
+const mockAlertReadASummary: alertSummary = {
+  childTags: [
+    {
+      description: null,
+      value: "recipient",
+      uuid: "c5d3321d-883c-4772-b511-489273e13fde",
+    },
+    {
+      description: null,
+      value: "from_address",
+      uuid: "f9081b70-c2bf-4a7d-ba90-a675e8a929d2",
+    },
+    {
+      description: null,
+      value: "contacted_host",
+      uuid: "3c1ca637-48d1-4d47-aeee-0962bc32d96d",
+    },
+    {
+      description: null,
+      value: "c2",
+      uuid: "a0b2d514-c544-4a8f-a059-b6151b9f1dd6",
+    },
+  ],
   comments: [],
   description: "",
   disposition: "OPEN",
@@ -56,7 +79,29 @@ const mockAlertReadASummary = {
   uuid: "uuid1",
 };
 
-const mockAlertReadBSummary = {
+const mockAlertReadBSummary: alertSummary = {
+  childTags: [
+    {
+      description: null,
+      value: "recipient",
+      uuid: "c5d3321d-883c-4772-b511-489273e13fde",
+    },
+    {
+      description: null,
+      value: "from_address",
+      uuid: "f9081b70-c2bf-4a7d-ba90-a675e8a929d2",
+    },
+    {
+      description: null,
+      value: "contacted_host",
+      uuid: "3c1ca637-48d1-4d47-aeee-0962bc32d96d",
+    },
+    {
+      description: null,
+      value: "c2",
+      uuid: "a0b2d514-c544-4a8f-a059-b6151b9f1dd6",
+    },
+  ],
   comments: [],
   description: "",
   disposition: "OPEN",
@@ -72,7 +117,8 @@ const mockAlertReadBSummary = {
   type: "test_type",
   uuid: "uuid2",
 };
-const mockAlertReadCSummary = {
+const mockAlertReadCSummary: alertSummary = {
+  childTags: [],
   comments: [],
   description: "test description",
   disposition: "FALSE_POSITIVE",


### PR DESCRIPTION
This PR fixes an oversight on my part in the API: when you called the `/api/alert/` endpoint and filtered the alerts by tags, the results only included alerts that directly contained the given tag(s)... However, based on how this works in ACE 1.0, we actually want the search to include alerts if any of the Nodes inside of the alert tree (like observables) also have the given tags.

This is fixed in the `backend/app/api/routes/alert.py` file by adjusting the query to also consider the values in the `child_tags` list.

However, to actually get the `child_tags` list was a bit tricky, and a descriptive comment of how that works is given in the `backend/app/db/schemas/node.py` file.

Also, now that `child_tags` are available, this PR also makes sure that they are included when displaying the tags in the Manage Alerts table.