### PR TITLE
Persist filters

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -6,39 +6,41 @@
   <router-view />
 </template>
 
-<script>
-  import { mapState } from "pinia";
+<script setup>
+  import { onBeforeMount } from "vue";
+  import { useRoute, useRouter } from "vue-router";
 
   import TheHeader from "@/components/UserInterface/TheHeader";
-
   import { populateCommonStores } from "@/etc/helpers";
   import authApi from "@/services/api/auth";
   import { useAuthStore } from "@/stores/auth";
+  import { useFilterStore } from "@/stores/filter";
 
-  export default {
-    components: { TheHeader },
+  const authStore = useAuthStore();
 
-    computed: {
-      ...mapState(useAuthStore, ["isAuthenticated"]),
-    },
+  onBeforeMount(async () => {
+    const route = useRoute();
+    const router = useRouter();
 
-    async created() {
-      // Create a 60s interval to check if the user is still authenticated.
-      // If they are not authenticated, kick them back to the Login page.
-      setInterval(() => {
-        if (this.$route.name !== "Login") {
-          authApi.validate().catch(() => {
-            console.debug("redirecting to login page");
-            this.$router.replace({ name: "Login" });
-          });
-        }
-      }, 60000);
-
-      // If the user is authenticated, populate some of the stores with items
-      // from the API that will be used throughout the application.
-      if (this.isAuthenticated) {
-        await populateCommonStores();
+    // Create a 60s interval to check if the user is still authenticated.
+    // If they are not authenticated, kick them back to the Login page.
+    setInterval(async () => {
+      if (route.name !== "Login") {
+        await authApi.validate().catch(() => {
+          console.debug("redirecting to login page");
+          router.replace({ name: "Login" });
+        });
       }
-    },
-  };
+    }, 60000);
+
+    // If the user is authenticated, load their most recent filters from
+    // localStorage and populate some of the stores with items from
+    // the API that will be used throughout the application.
+    if (authStore.isAuthenticated) {
+      const filterStore = useFilterStore();
+      filterStore.$state = JSON.parse(localStorage.getItem("aceFilters"));
+
+      await populateCommonStores();
+    }
+  });
 </script>

--- a/frontend/src/components/Modals/FilterModal.vue
+++ b/frontend/src/components/Modals/FilterModal.vue
@@ -6,7 +6,7 @@
     :name="name"
     header="Edit Filters"
     class="xl: w-5 lg:w-5 md:w-8"
-    @dialogClose="resetFormFilters"
+    @dialogClose="loadFormFilters"
   >
     <div class="flex flex-wrap">
       <FilterInput
@@ -44,7 +44,7 @@
 </template>
 
 <script setup>
-  import { computed, defineProps, inject, ref } from "vue";
+  import { computed, defineProps, inject, onMounted, ref } from "vue";
 
   import Button from "primevue/button";
 
@@ -57,6 +57,10 @@
   const filterStore = useFilterStore();
   const modalStore = useModalStore();
 
+  onMounted(() => {
+    loadFormFilters();
+  });
+
   const props = defineProps({
     name: { type: String, required: true },
   });
@@ -65,7 +69,7 @@
 
   filterStore.$subscribe(
     () => {
-      resetFormFilters();
+      loadFormFilters();
     },
     { deep: true },
   );
@@ -104,7 +108,7 @@
     formFilters.value.push({ filterName: null, filterValue: null });
   };
 
-  const resetFormFilters = () => {
+  const loadFormFilters = () => {
     formFilters.value = [];
     for (const filter in filterStore.$state[filterType]) {
       formFilters.value.push({
@@ -115,7 +119,7 @@
   };
 
   const close = () => {
-    resetFormFilters();
+    loadFormFilters();
     modalStore.close(props.name);
   };
 </script>

--- a/frontend/src/stores/filter.ts
+++ b/frontend/src/stores/filter.ts
@@ -18,6 +18,7 @@ export const useFilterStore = defineStore({
       filters: alertFilterParams;
     }) {
       this.$state[payload.filterType] = payload.filters;
+      localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
     setFilter(payload: {
@@ -26,6 +27,7 @@ export const useFilterStore = defineStore({
       filterValue: alertFilterValues;
     }) {
       this.$state[payload.filterType][payload.filterName] = payload.filterValue;
+      localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
     unsetFilter(payload: {
@@ -33,10 +35,12 @@ export const useFilterStore = defineStore({
       filterName: alertFilterNameTypes;
     }) {
       delete this.$state[payload.filterType][payload.filterName];
+      localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
     clearAll(payload: { filterType: "alerts" }) {
       this.$state[payload.filterType] = {};
+      localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
   },
 });

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -384,6 +384,41 @@ describe("Manage Alerts Filter Modal", () => {
     // Exit modal for end of test
     cy.get(".p-dialog-header-close-icon").click();
   });
+
+  it("will load any currently set filters from localStorage and add them in the form", () => {
+    // Open the modal
+    cy.get("#FilterToolbar > .p-toolbar-group-left > .p-m-1").click();
+    cy.get(".p-dialog-footer > :nth-child(2)").click();
+    cy.get(".col > .field > .p-dropdown").should("be.visible");
+
+    // Select name filter
+    cy.get(
+      ".formgrid > :nth-child(1) > .p-dropdown > .p-dropdown-trigger",
+    ).click();
+    cy.get(".p-dropdown-items-wrapper").should("be.visible");
+    cy.get("[aria-label='Name']").click();
+    cy.get(".field > .p-inputtext").should("be.visible");
+
+    // Add a filter value
+    cy.get(".field > .p-inputtext").type("hello world");
+
+    // Submit
+    cy.get(".p-dialog-footer > :nth-child(4)").click();
+
+    // Refresh the page
+    cy.reload();
+
+    // Reopen the modal
+    cy.get("#FilterToolbar > .p-toolbar-group-left > .p-m-1").click();
+
+    // Verify the form data
+    cy.get(".flex").children().should("have.length", 1);
+    cy.get(":nth-child(1) > .p-dropdown").should("have.text", "Name");
+    cy.get(".inputfield").should("have.value", "hello world");
+
+    // Exit modal for end of test
+    cy.get(".p-dialog-header-close-icon").click();
+  });
 });
 
 // Comment will not change sort

--- a/frontend/tests/unit/src/App.spec.ts
+++ b/frontend/tests/unit/src/App.spec.ts
@@ -1,0 +1,84 @@
+import App from "@/App.vue";
+import { mount } from "@vue/test-utils";
+import { createTestingPinia, TestingOptions } from "@pinia/testing";
+import { createRouterMock, injectRouterMock } from "vue-router-mock";
+
+import { useAuthStore } from "@/stores/auth";
+import { useFilterStore } from "@/stores/filter";
+
+function factory(args: {
+  authenticated?: boolean;
+  filters?: Record<string, unknown>;
+  options?: TestingOptions;
+}) {
+  const testingPinia = createTestingPinia(args.options);
+  const authStore = useAuthStore();
+  const filterStore = useFilterStore();
+
+  const router = createRouterMock();
+  injectRouterMock(router);
+
+  // If we want to simulate the user already being authenticated, set the user in the authStore
+  if (args.authenticated) {
+    authStore.$state.user = {
+      defaultAlertQueue: {
+        uuid: "alertQueue1",
+        description: null,
+        value: "alertQueue",
+      },
+      defaultEventQueue: {
+        uuid: "eventQueue1",
+        description: null,
+        value: "eventQueue",
+      },
+      displayName: "analyst",
+      email: "analyst@analyst.com",
+      enabled: true,
+      roles: [{ uuid: "role1", description: null, value: "role1" }],
+      timezone: "UTC",
+      training: false,
+      username: "analyst",
+      uuid: "1",
+    };
+  }
+
+  // If filters were given, place them in localStorage
+  if (args.filters) {
+    localStorage.setItem("aceFilters", JSON.stringify(args.filters));
+  }
+
+  const wrapper = mount(App, {
+    attachTo: document.body,
+    global: {
+      plugins: [testingPinia],
+    },
+  });
+
+  return { wrapper, authStore, filterStore };
+}
+
+describe("App setup", () => {
+  it("renders", () => {
+    const { wrapper } = factory({});
+
+    expect(wrapper.exists()).toBe(true);
+  });
+
+  it("hydrates the filter store from localStorage if the user is authenticated", () => {
+    const { filterStore } = factory({
+      authenticated: true,
+      filters: { alerts: { tags: ["tag1"] } },
+    });
+
+    expect(filterStore.$state).toEqual({ alerts: { tags: ["tag1"] } });
+  });
+
+  it("will not hydrate the filter store from localStorage if the user is not authenticated", () => {
+    const { filterStore } = factory({
+      authenticated: false,
+      filters: { alerts: { tags: ["tag1"] } },
+    });
+
+    expect(filterStore.$state).toEqual({ alerts: {} });
+  });
+});

--- a/frontend/tests/unit/src/components/Modals/FilterModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/FilterModal.spec.ts
@@ -4,12 +4,24 @@ import { createTestingPinia, TestingOptions } from "@pinia/testing";
 
 import { useFilterStore } from "@/stores/filter";
 import { useModalStore } from "@/stores/modal";
+import { alertFilterParams } from "@/models/alert";
 
-function factory(options?: TestingOptions) {
+function factory(args: {
+  filters?: { filterType: "alerts"; filters: alertFilterParams };
+  options?: TestingOptions;
+}) {
+  const testingPinia = createTestingPinia(args.options);
+  const filterStore = useFilterStore();
+  const modalStore = useModalStore();
+
+  if (args.filters) {
+    filterStore.bulkSetFilters(args.filters);
+  }
+
   const wrapper = mount(FilterModal, {
     attachTo: document.body,
     global: {
-      plugins: [createTestingPinia(options)],
+      plugins: [testingPinia],
       provide: {
         filterType: "alerts",
       },
@@ -17,36 +29,54 @@ function factory(options?: TestingOptions) {
     props: { name: "FilterModal" },
   });
 
-  const filterStore = useFilterStore();
-  const modalStore = useModalStore();
-
   return { wrapper, filterStore, modalStore };
 }
 
 describe("FilterModal setup", () => {
   it("renders", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     expect(wrapper.exists()).toBe(true);
   });
 
   it("sets up data correctly", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     expect(wrapper.vm.formFilters).toEqual([]);
+  });
+
+  it("executes loadFormFilters when the modal is mounted so preexisting filters are shown in the form", () => {
+    const { wrapper } = factory({
+      filters: {
+        filterType: "alerts",
+        filters: { name: "hello world" },
+      },
+      options: { stubActions: false },
+    });
+
+    expect(wrapper.vm.filterStore.$state[wrapper.vm.filterType]).toEqual({
+      name: "hello world",
+    });
+    expect(wrapper.vm.submitFilters).toEqual({ name: "hello world" });
+    expect(wrapper.vm.formFilters).toEqual([
+      {
+        filterName: "name",
+        filterValue: "hello world",
+      },
+    ]);
   });
 });
 
 describe("FilterModal computed properties", () => {
   it("contains expected computed data when no filters are set", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     expect(wrapper.vm.submitFilters).toEqual({});
     expect(wrapper.vm.name).toEqual("FilterModal");
   });
 
   it("contains expected computed data when there are filters are set", () => {
-    const { wrapper } = factory({ stubActions: false });
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     wrapper.vm.filterStore.bulkSetFilters({
       filterType: "alerts",
@@ -56,15 +86,15 @@ describe("FilterModal computed properties", () => {
       name: "hello world",
     });
 
-    // if filters had been set, resetFormFilters would have been ran, so simulate that here before checking submitFilters
-    wrapper.vm.resetFormFilters();
+    // if filters had been set, loadFormFilters would have been ran, so simulate that here before checking submitFilters
+    wrapper.vm.loadFormFilters();
     expect(wrapper.vm.submitFilters).toEqual({ name: "hello world" });
   });
 });
 
 describe("FilterModal watchers", () => {
-  it("executes resetFormFilters when filters change", async () => {
-    const { wrapper } = factory({ stubActions: false });
+  it("executes loadFormFilters when filters change", async () => {
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     expect(wrapper.vm.filterStore.$state[wrapper.vm.filterType]).toEqual({});
     expect(wrapper.vm.formFilters).toEqual([]);
@@ -90,7 +120,7 @@ describe("FilterModal watchers", () => {
 
 describe("FilterModal methods", () => {
   it("executes submit as expected when there are new filters", () => {
-    const { wrapper } = factory({ stubActions: false });
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     // Test submitting new filters
     expect(wrapper.vm.filterStore.$state[wrapper.vm.filterType]).toEqual({});
@@ -107,14 +137,14 @@ describe("FilterModal methods", () => {
     });
   });
   it("executes submit as expected when there no filters (cleared)", () => {
-    const { wrapper } = factory({ stubActions: false });
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     wrapper.vm.formFilters = [];
     wrapper.vm.submit();
     expect(wrapper.vm.filterStore.$state[wrapper.vm.filterType]).toEqual({});
   });
   it("executes deleteFormFilter as expected", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     wrapper.vm.formFilters = [
       {
@@ -145,7 +175,7 @@ describe("FilterModal methods", () => {
     ]);
   });
   it("executes clear as expected", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     wrapper.vm.formFilters = [
       {
@@ -167,7 +197,7 @@ describe("FilterModal methods", () => {
     expect(wrapper.vm.formFilters).toEqual([]);
   });
   it("executes addNewFilter as expected", () => {
-    const { wrapper } = factory();
+    const { wrapper } = factory({});
 
     expect(wrapper.vm.formFilters).toEqual([]);
     wrapper.vm.addNewFilter();
@@ -178,8 +208,8 @@ describe("FilterModal methods", () => {
       },
     ]);
   });
-  it("executes resetFormFilters as expected", async () => {
-    const { wrapper } = factory({ stubActions: false });
+  it("executes loadFormFilters as expected", async () => {
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     expect(wrapper.vm.filterStore.$state[wrapper.vm.filterType]).toEqual({});
     expect(wrapper.vm.formFilters).toEqual([]);
@@ -189,7 +219,7 @@ describe("FilterModal methods", () => {
       filters: { name: "hello world", owner: "test analyst" },
     });
 
-    wrapper.vm.resetFormFilters();
+    wrapper.vm.loadFormFilters();
     expect(wrapper.vm.formFilters).toEqual([
       {
         filterName: "name",
@@ -202,7 +232,7 @@ describe("FilterModal methods", () => {
     ]);
   });
   it("executes close as expected", () => {
-    const { wrapper } = factory({ stubActions: false });
+    const { wrapper } = factory({ options: { stubActions: false } });
 
     wrapper.vm.filterStore.bulkSetFilters({
       filterType: "alerts",

--- a/frontend/tests/unit/src/store/filter.spec.ts
+++ b/frontend/tests/unit/src/store/filter.spec.ts
@@ -8,25 +8,33 @@ const store = useFilterStore();
 describe("filters Actions", () => {
   beforeEach(() => {
     store.$reset();
+    localStorage.removeItem("aceFilters");
   });
 
   it("will set the given filterTypes filter object to the given filter object argument upon the bulkSetFilters action", () => {
     expect(store.alerts).toStrictEqual({});
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(null);
 
     store.bulkSetFilters({
       filterType: "alerts",
       filters: { testFilterName: "testFilterValue" },
     });
 
-    expect(store.$state).toEqual({
+    const expectedState = {
       alerts: {
         testFilterName: "testFilterValue",
       },
-    });
+    };
+
+    expect(store.$state).toEqual(expectedState);
+    expect(localStorage.getItem("aceFilters")).toEqual(
+      JSON.stringify(expectedState),
+    );
   });
 
   it("will add a new property and specified to a given filter object upon the setFilter action", () => {
     expect(store.alerts).toStrictEqual({});
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(null);
 
     store.setFilter({
       filterType: "alerts",
@@ -34,17 +42,29 @@ describe("filters Actions", () => {
       filterValue: "testFilterValue",
     });
 
-    expect(store.$state).toEqual({
+    const expectedState = {
       alerts: {
         testFilterName: "testFilterValue",
       },
-    });
+    };
+
+    expect(store.$state).toEqual(expectedState);
+    expect(localStorage.getItem("aceFilters")).toEqual(
+      JSON.stringify(expectedState),
+    );
   });
 
   it("will delete a given proprty for a given filter object upon the unsetFilter action", () => {
     store.$state = { alerts: { name: "test" } };
+    localStorage.setItem(
+      "aceFilters",
+      JSON.stringify({ alerts: { name: "test" } }),
+    );
 
     expect(store.alerts).toStrictEqual({ name: "test" });
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
+      JSON.stringify({ alerts: { name: "test" } }),
+    );
 
     store.unsetFilter({
       filterType: "alerts",
@@ -54,12 +74,23 @@ describe("filters Actions", () => {
     expect(store.$state).toEqual({
       alerts: {},
     });
+
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
+      JSON.stringify({ alerts: {} }),
+    );
   });
 
   it("will delete all properties from a given filter object upon the clearAll action", () => {
     store.$state = { alerts: { name: "test", description: "test" } };
+    localStorage.setItem(
+      "aceFilters",
+      JSON.stringify({ alerts: { name: "test", description: "test" } }),
+    );
 
     expect(store.alerts).toStrictEqual({ name: "test", description: "test" });
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
+      JSON.stringify({ alerts: { name: "test", description: "test" } }),
+    );
 
     store.clearAll({
       filterType: "alerts",
@@ -68,5 +99,9 @@ describe("filters Actions", () => {
     expect(store.$state).toEqual({
       alerts: {},
     });
+
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
+      JSON.stringify({ alerts: {} }),
+    );
   });
 });


### PR DESCRIPTION
Closes #96

This PR persists any filters that are set in the GUI by saving them in localStorage. When the GUI is initially loaded, if the user is already authenticated, it will read the filters from localStorage and use them as the initial state for the filterStore.

This allows you to refresh the page and keep the filters you had applied. It also lets you close your browser, and, provided you still have valid authentication tokens, have your most recently applied filters automatically applied.

It also converts the App.vue component to the Composition API since I had to make changes there anyway.