### PR TITLE
Initial Manage Events page

### DIFF
--- a/backend/app/api/models/event.py
+++ b/backend/app/api/models/event.py
@@ -138,3 +138,7 @@ class EventUpdate(NodeUpdate, EventBase):
     threats: Optional[List[type_str]] = Field(description="A list of threats to add to the event")
 
     _prevent_none: classmethod = validators.prevent_none("name", "queue", "status", "tags", "threat_actors", "threats")
+
+
+class EventUpdateMultiple(EventUpdate):
+    uuid: UUID4 = Field(description="The UUID of the event")

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -96,8 +96,7 @@ def get_event(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=Event, db=db)
 
 
-# It does not make sense to have a get_all_events route at this point (and certainly not without pagination).
-# helpers.api_route_read_all(router, get_all_events, List[EventRead])
+helpers.api_route_read_all(router, get_all_events, EventRead)
 helpers.api_route_read(router, get_event, EventRead)
 
 

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -1,8 +1,11 @@
 from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import select
+from typing import List
 from uuid import UUID
 
-from api.models.event import EventCreate, EventRead, EventUpdate
+from api.models.event import EventCreate, EventRead, EventUpdateMultiple
 from api.routes import helpers
 from api.routes.node import create_node, update_node
 from db import crud
@@ -83,8 +86,10 @@ helpers.api_route_create(router, create_event)
 #
 
 
-# def get_all_events(db: Session = Depends(get_db)):
-#     return crud.read_all(db_table=Event, db=db)
+def get_all_events(db: Session = Depends(get_db)):
+    query = select(Event)
+
+    return paginate(db, query)
 
 
 def get_event(uuid: UUID, db: Session = Depends(get_db)):
@@ -101,81 +106,81 @@ helpers.api_route_read(router, get_event, EventRead)
 #
 
 
-def update_event(
-    uuid: UUID,
-    event: EventUpdate,
+def update_events(
+    events: List[EventUpdateMultiple],
     request: Request,
     response: Response,
     db: Session = Depends(get_db),
 ):
-    # Update the Node attributes
-    db_event: Event = update_node(node_update=event, uuid=uuid, db_table=Event, db=db)
+    for event in events:
+        # Update the Node attributes
+        db_event: Event = update_node(node_update=event, uuid=event.uuid, db_table=Event, db=db)
 
-    # Get the data that was given in the request and use it to update the database object
-    update_data = event.dict(exclude_unset=True)
+        # Get the data that was given in the request and use it to update the database object
+        update_data = event.dict(exclude_unset=True)
 
-    if "alert_time" in update_data:
-        db_event.alert_time = update_data["alert_time"]
+        if "alert_time" in update_data:
+            db_event.alert_time = update_data["alert_time"]
 
-    if "contain_time" in update_data:
-        db_event.contain_time = update_data["contain_time"]
+        if "contain_time" in update_data:
+            db_event.contain_time = update_data["contain_time"]
 
-    if "disposition_time" in update_data:
-        db_event.disposition_time = update_data["disposition_time"]
+        if "disposition_time" in update_data:
+            db_event.disposition_time = update_data["disposition_time"]
 
-    if "event_time" in update_data:
-        db_event.event_time = update_data["event_time"]
+        if "event_time" in update_data:
+            db_event.event_time = update_data["event_time"]
 
-    if "name" in update_data:
-        db_event.name = update_data["name"]
+        if "name" in update_data:
+            db_event.name = update_data["name"]
 
-    if "owner" in update_data:
-        db_event.owner = crud.read_user_by_username(username=update_data["owner"], db=db)
+        if "owner" in update_data:
+            db_event.owner = crud.read_user_by_username(username=update_data["owner"], db=db)
 
-    if "ownership_time" in update_data:
-        db_event.ownership_time = update_data["ownership_time"]
+        if "ownership_time" in update_data:
+            db_event.ownership_time = update_data["ownership_time"]
 
-    if "prevention_tools" in update_data:
-        db_event.prevention_tools = crud.read_by_values(
-            values=update_data["prevention_tools"],
-            db_table=EventPreventionTool,
-            db=db,
-        )
+        if "prevention_tools" in update_data:
+            db_event.prevention_tools = crud.read_by_values(
+                values=update_data["prevention_tools"],
+                db_table=EventPreventionTool,
+                db=db,
+            )
 
-    if "queue" in update_data:
-        db_event.queue = crud.read_by_value(value=update_data["queue"], db_table=EventQueue, db=db)
+        if "queue" in update_data:
+            db_event.queue = crud.read_by_value(value=update_data["queue"], db_table=EventQueue, db=db)
 
-    if "remediation_time" in update_data:
-        db_event.remediation_time = update_data["remediation_time"]
+        if "remediation_time" in update_data:
+            db_event.remediation_time = update_data["remediation_time"]
 
-    if "remediations" in update_data:
-        db_event.remediations = crud.read_by_values(
-            values=update_data["remediations"],
-            db_table=EventRemediation,
-            db=db,
-        )
+        if "remediations" in update_data:
+            db_event.remediations = crud.read_by_values(
+                values=update_data["remediations"],
+                db_table=EventRemediation,
+                db=db,
+            )
 
-    if "risk_level" in update_data:
-        db_event.risk_level = crud.read_by_value(value=update_data["risk_level"], db_table=EventRiskLevel, db=db)
+        if "risk_level" in update_data:
+            db_event.risk_level = crud.read_by_value(value=update_data["risk_level"], db_table=EventRiskLevel, db=db)
 
-    if "source" in update_data:
-        db_event.source = crud.read_by_value(value=update_data["source"], db_table=EventSource, db=db)
+        if "source" in update_data:
+            db_event.source = crud.read_by_value(value=update_data["source"], db_table=EventSource, db=db)
 
-    if "status" in update_data:
-        db_event.status = crud.read_by_value(value=update_data["status"], db_table=EventStatus, db=db)
+        if "status" in update_data:
+            db_event.status = crud.read_by_value(value=update_data["status"], db_table=EventStatus, db=db)
 
-    if "type" in update_data:
-        db_event.type = crud.read_by_value(value=update_data["type"], db_table=EventType, db=db)
+        if "type" in update_data:
+            db_event.type = crud.read_by_value(value=update_data["type"], db_table=EventType, db=db)
 
-    if "vectors" in update_data:
-        db_event.vectors = crud.read_by_values(values=update_data["vectors"], db_table=EventVector, db=db)
+        if "vectors" in update_data:
+            db_event.vectors = crud.read_by_values(values=update_data["vectors"], db_table=EventVector, db=db)
 
-    crud.commit(db)
+        crud.commit(db)
 
-    response.headers["Content-Location"] = request.url_for("get_event", uuid=uuid)
+        response.headers["Content-Location"] = request.url_for("get_event", uuid=event.uuid)
 
 
-helpers.api_route_update(router, update_event)
+helpers.api_route_update(router, update_events, path="/")
 
 
 #

--- a/backend/app/insert-event.py
+++ b/backend/app/insert-event.py
@@ -1,0 +1,40 @@
+import sys
+
+from sqlalchemy.orm import Session
+
+from db.database import get_db
+from tests import helpers
+
+# Command line arguments:
+#
+# 0 - Name of the script (insert-event.py)
+# 1 - Path to alert JSON file to add into the event
+# 2 - Name of the event (no spaces)
+# 3 (Optional) - Number of times to insert the alert, defaults to 1
+
+if len(sys.argv) < 3:
+    print("You must specify the path to the alert JSON file and event name")
+    sys.exit()
+
+# When you specify the path to the JSON file, you do so from the perspective
+# of outisde the container, so you preface it with backend/ so that you can
+# use tab-completion on your local command line.
+#
+# However, this runs inside of the container, so the backend/ part of the path
+# does not exist and must be removed so that it is a valid path inside the container.
+#
+# Example: backend/app/tests/alerts/blah.json -> /app/tests/alerts/blah.json
+json_path = sys.argv[1].replace("backend", "")
+
+num_alerts = 1
+if len(sys.argv) == 4:
+    num_alerts = int(sys.argv[3])
+
+db: Session = next(get_db())
+
+for _ in range(num_alerts):
+    event = helpers.create_event(name=sys.argv[2], db=db)
+    alert_tree = helpers.create_alert_from_json_file(db=db, json_path=json_path)
+    alert_tree.node.event_uuid = event.uuid
+
+    db.commit()

--- a/backend/app/insert-event.py
+++ b/backend/app/insert-event.py
@@ -1,20 +1,32 @@
-import sys
+import argparse
 
 from sqlalchemy.orm import Session
 
 from db.database import get_db
 from tests import helpers
 
-# Command line arguments:
-#
-# 0 - Name of the script (insert-event.py)
-# 1 - Path to alert JSON file to add into the event
-# 2 - Name of the event (no spaces)
-# 3 (Optional) - Number of times to insert the alert, defaults to 1
+parser = argparse.ArgumentParser()
 
-if len(sys.argv) < 3:
-    print("You must specify the path to the alert JSON file and event name")
-    sys.exit()
+# Required
+parser.add_argument("alert_json_path", type=str, help="Path to the alert JSON template file to add to the event")
+parser.add_argument("event_name", type=str, help="The name of the event to create (without any space)")
+
+# Optional
+parser.add_argument("--num_alerts", type=int, default=1, help="The number of copies of the alert to add to the event")
+parser.add_argument("--owner", type=str, help="The username of the user to use as the event owner")
+parser.add_argument("--prevention_tools", type=str, help="Comma-separated list of prevention tools")
+parser.add_argument("--queue", type=str, help="The event queue")
+parser.add_argument("--remediations", type=str, help="Comma-separated list of remediations")
+parser.add_argument("--risk_level", type=str, help="The event risk level")
+parser.add_argument("--source", type=str, help="The event source")
+parser.add_argument("--status", type=str, help="The event status")
+parser.add_argument("--tags", type=str, help="Comma-separated list of tags for the event")
+parser.add_argument("--threat_actors", type=str, help="Comma-separated list of threat actors to add to the event")
+parser.add_argument("--threats", type=str, help="Comma-separated list of threats to add to the event")
+parser.add_argument("--type", type=str, help="The event type")
+parser.add_argument("--vectors", type=str, help="Comma-separated list of vectors to add to the event")
+
+args = parser.parse_args()
 
 # When you specify the path to the JSON file, you do so from the perspective
 # of outisde the container, so you preface it with backend/ so that you can
@@ -24,17 +36,52 @@ if len(sys.argv) < 3:
 # does not exist and must be removed so that it is a valid path inside the container.
 #
 # Example: backend/app/tests/alerts/blah.json -> /app/tests/alerts/blah.json
-json_path = sys.argv[1].replace("backend", "")
-
-num_alerts = 1
-if len(sys.argv) == 4:
-    num_alerts = int(sys.argv[3])
+alert_json_path = args.alert_json_path.replace("backend", "")
 
 db: Session = next(get_db())
 
-for _ in range(num_alerts):
-    event = helpers.create_event(name=sys.argv[2], db=db)
-    alert_tree = helpers.create_alert_from_json_file(db=db, json_path=json_path)
+event = helpers.create_event(name=args.event_name, db=db)
+
+if args.owner:
+    event.owner = helpers.create_user(username=args.owner, db=db, display_name=args.owner)
+
+if args.prevention_tools:
+    event.prevention_tools = [
+        helpers.create_event_prevention_tool(value=p, db=db) for p in args.prevention_tools.split(",")
+    ]
+
+if args.queue:
+    event.queue = helpers.create_event_queue(value=args.queue, db=db)
+
+if args.remediations:
+    event.remediations = [helpers.create_event_remediation(value=r, db=db) for r in args.remediations.split(",")]
+
+if args.risk_level:
+    event.risk_level = helpers.create_event_risk_level(value=args.risk_level, db=db)
+
+if args.source:
+    event.source = helpers.create_event_source(value=args.source, db=db)
+
+if args.status:
+    event.status = helpers.create_event_status(value=args.status, db=db)
+
+if args.tags:
+    event.tags = [helpers.create_node_tag(value=t, db=db) for t in args.tags.split(",")]
+
+if args.threat_actors:
+    event.threat_actors = [helpers.create_node_threat_actor(value=t, db=db) for t in args.threat_actors.split(",")]
+
+if args.threats:
+    event.threats = [helpers.create_node_threat(value=t, db=db) for t in args.threats.split(",")]
+
+if args.type:
+    event.type = helpers.create_event_type(value=args.type, db=db)
+
+if args.vectors:
+    event.vectors = [helpers.create_event_vector(value=v, db=db) for v in args.vectors.split(",")]
+
+for _ in range(args.num_alerts):
+    alert_tree = helpers.create_alert_from_json_file(db=db, json_path=alert_json_path)
     alert_tree.node.event_uuid = event.uuid
 
-    db.commit()
+db.commit()

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -1,6 +1,8 @@
 import uuid
 
+from datetime import datetime, timedelta
 from fastapi import status
+from urllib.parse import urlencode
 
 from tests import helpers
 
@@ -25,9 +27,676 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get(client_valid_access_token, db):
-    event = helpers.create_event(name="Test Event", db=db)
+def test_get_all_pagination(client_valid_access_token, db):
+    # Create 11 events
+    for i in range(11):
+        helpers.create_event(name=f"event{i}", db=db)
 
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}")
+    # Keep track of all of the event UUIDs to make sure we read them all
+    unique_event_uuids = set()
+
+    # Read every page in chunks of 2 while there are still results
+    offset = 0
+    while True:
+        get = client_valid_access_token.get(f"/api/event/?limit=2&offset={offset}")
+
+        # Store the event UUIDs
+        for event in get.json()["items"]:
+            unique_event_uuids.add(event["uuid"])
+
+            # Make sure the node_type field is "event"
+            assert event["node_type"] == "event"
+
+        # Check if there is another page to retrieve
+        if len(unique_event_uuids) < get.json()["total"]:
+            # Increase the offset to get the next page
+            offset += get.json()["limit"]
+            continue
+
+        break
+
+    # Should have gotten all 11 events across the pages
+    assert len(unique_event_uuids) == 11
+
+
+def test_get_all_empty(client_valid_access_token):
+    get = client_valid_access_token.get("/api/event/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["node_type"] == "event"
+    assert get.json() == {"items": [], "limit": 50, "offset": 0, "total": 0}
+
+
+def test_get_filter_alert_time_after(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(event=event1, insert_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(event=event2, insert_time=datetime.utcnow(), db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    helpers.create_alert(event=event3, insert_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by alert_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"alert_time_after": alert_tree2.node.insert_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_alert_time_before(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(event=event1, insert_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(event=event2, insert_time=datetime.utcnow(), db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    helpers.create_alert(event=event3, insert_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by alert_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"alert_time_before": alert_tree2.node.insert_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+
+def test_get_filter_contain_time_after(client_valid_access_token, db):
+    helpers.create_event(name="event1", contain_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", contain_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", contain_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by contain_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"contain_time_after": event2.contain_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_contain_time_before(client_valid_access_token, db):
+    helpers.create_event(name="event1", contain_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", contain_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", contain_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by contain_time_before. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"contain_time_before": event2.contain_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+
+def test_get_filter_created_time_after(client_valid_access_token, db):
+    helpers.create_event(name="event1", created_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", created_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", created_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by created_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"created_time_after": event2.creation_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_created_time_before(client_valid_access_token, db):
+    helpers.create_event(name="event1", created_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", created_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", created_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by created_time_before. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"created_time_before": event2.creation_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+
+def test_get_filter_disposition(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", contain_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    helpers.create_alert(event=event1, db=db)
+
+    event2 = helpers.create_event(name="event2", contain_time=datetime.utcnow(), db=db)
+    helpers.create_alert(event=event2, db=db, disposition="FALSE_POSITIVE")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by the disposition
+    get = client_valid_access_token.get("/api/event/?disposition=none")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+    get = client_valid_access_token.get("/api/event/?disposition=FALSE_POSITIVE")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event2"
+
+
+def test_get_filter_disposition_time_after(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(event=event1, disposition_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(event=event2, disposition_time=datetime.utcnow(), db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    helpers.create_alert(event=event3, disposition_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by disposition_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"disposition_time_after": alert_tree2.node.disposition_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_disposition_time_before(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(event=event1, disposition_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(event=event2, disposition_time=datetime.utcnow(), db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    helpers.create_alert(event=event3, disposition_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by disposition_time_before. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"disposition_time_before": alert_tree2.node.disposition_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+
+def test_get_filter_name(client_valid_access_token, db):
+    helpers.create_event(db=db, name="Test Event")
+    helpers.create_event(db=db, name="Some Other Event")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by the name
+    get = client_valid_access_token.get("/api/event/?name=test")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "Test Event"
+
+
+def test_get_filter_observable(client_valid_access_token, db):
+    # Create an empty event
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(db=db, event=event1)
+
+    # Create some events with one observable
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(db=db, event=event2)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type1", value="test_value1", db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    alert_tree3 = helpers.create_alert(db=db, event=event3)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value2", db=db)
+
+    # Create an event with multiple observables
+    event4 = helpers.create_event(name="event4", db=db)
+    alert_tree4 = helpers.create_alert(db=db, event=event4)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type2", value="test_value2", db=db)
+
+    # There should be 4 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 4
+
+    # There should only be 1 event when we filter by the test_type1/test_value1 observable
+    get = client_valid_access_token.get("/api/event/?observable=test_type1|test_value1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event2"
+
+    # There should be 2 events when we filter by the test_type2/test_value2 observable
+    get = client_valid_access_token.get("/api/event/?observable=test_type2|test_value2")
+    assert get.json()["total"] == 2
+    assert any(a["name"] == "event3" for a in get.json()["items"])
+    assert any(a["name"] == "event4" for a in get.json()["items"])
+
+
+def test_get_filter_observable_types(client_valid_access_token, db):
+    # Create an empty event
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(db=db, event=event1)
+
+    # Create an event with one observable
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(db=db, event=event2)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type1", value="test_value1", db=db)
+
+    # Create an alert with multiple observables
+    event3 = helpers.create_event(name="event3", db=db)
+    alert_tree3 = helpers.create_alert(db=db, event=event3)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value2", db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should be 2 events when we filter by just test_type1
+    get = client_valid_access_token.get("/api/event/?observable_types=test_type1")
+    assert get.json()["total"] == 2
+    assert any(a["name"] == "event2" for a in get.json()["items"])
+    assert any(a["name"] == "event3" for a in get.json()["items"])
+
+    # There should only be 1 event when we filter by the test_type1 and test_type2
+    get = client_valid_access_token.get("/api/event/?observable_types=test_type1,test_type2")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_observable_value(client_valid_access_token, db):
+    # Create an empty event
+    event1 = helpers.create_event(name="event1", db=db)
+    helpers.create_alert(db=db, event=event1)
+
+    # Create some alerts with one observable
+    event2 = helpers.create_event(name="event2", db=db)
+    alert_tree2 = helpers.create_alert(db=db, event=event2)
+    helpers.create_observable(parent_tree=alert_tree2, type="test_type1", value="test_value1", db=db)
+
+    event3 = helpers.create_event(name="event3", db=db)
+    alert_tree3 = helpers.create_alert(db=db, event=event3)
+    helpers.create_observable(parent_tree=alert_tree3, type="test_type2", value="test_value2", db=db)
+
+    # Create an event with multiple observables
+    event4 = helpers.create_event(name="event4", db=db)
+    alert_tree4 = helpers.create_alert(db=db, event=event4)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type1", value="test_value_asdf", db=db)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type2", value="test_value1", db=db)
+    helpers.create_observable(parent_tree=alert_tree4, type="test_type2", value="test_value2", db=db)
+
+    # There should be 4 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 4
+
+    # There should only be 1 event when we filter by the test_value_asdf observable value
+    get = client_valid_access_token.get("/api/event/?observable_value=test_value_asdf")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event4"
+
+    # There should be 2 events when we filter by the test_value1 observable value
+    get = client_valid_access_token.get("/api/event/?observable_value=test_value1")
+    assert get.json()["total"] == 2
+    assert any(a["name"] == "event2" for a in get.json()["items"])
+    assert any(a["name"] == "event4" for a in get.json()["items"])
+
+
+def test_get_filter_owner(client_valid_access_token, db):
+    helpers.create_user(username="analyst", db=db)
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, owner="analyst")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by the owner
+    get = client_valid_access_token.get("/api/event/?owner=analyst")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["owner"]["username"] == "analyst"
+
+
+def test_get_filter_prevention_tools(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, prevention_tools=["value1"])
+    helpers.create_event(name="event3", db=db, prevention_tools=["value2", "value3"])
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?prevention_tools=value1")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["prevention_tools"]) == 1
+    assert get.json()["items"][0]["prevention_tools"][0]["value"] == "value1"
+
+    # There should only be 1 event when we filter by value2 AND value3
+    get = client_valid_access_token.get("/api/event/?prevention_tools=value2,value3")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["prevention_tools"]) == 2
+    assert any(t["value"] == "value2" for t in get.json()["items"][0]["prevention_tools"])
+    assert any(t["value"] == "value3" for t in get.json()["items"][0]["prevention_tools"])
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?prevention_tools=")
+    assert get.json()["total"] == 3
+
+
+def test_get_filter_queue(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db, queue="test_queue1")
+    helpers.create_event(name="event2", db=db, queue="test_queue2")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by the queue
+    get = client_valid_access_token.get("/api/event/?queue=test_queue1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["queue"]["value"] == "test_queue1"
+
+
+def test_get_filter_remediation_time_after(client_valid_access_token, db):
+    helpers.create_event(name="event1", remediation_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", remediation_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", remediation_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by remediation_time_after. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"remediation_time_after": event2.remediation_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+
+def test_get_filter_remediation_time_before(client_valid_access_token, db):
+    helpers.create_event(name="event1", remediation_time=datetime.utcnow() - timedelta(seconds=5), db=db)
+    event2 = helpers.create_event(name="event2", remediation_time=datetime.utcnow(), db=db)
+    helpers.create_event(name="event3", remediation_time=datetime.utcnow() + timedelta(seconds=5), db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by remediation_time_before. But the timestamp
+    # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
+    # is a reserved URL character.
+    params = {"remediation_time_before": event2.remediation_time}
+    get = client_valid_access_token.get(f"/api/event/?{urlencode(params)}")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+
+def test_get_filter_remediations(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, remediations=["value1"])
+    helpers.create_event(name="event3", db=db, remediations=["value2", "value3"])
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?remediations=value1")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["remediations"]) == 1
+    assert get.json()["items"][0]["remediations"][0]["value"] == "value1"
+
+    # There should only be 1 event when we filter by value2 AND value3
+    get = client_valid_access_token.get("/api/event/?remediations=value2,value3")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["remediations"]) == 2
+    assert any(t["value"] == "value2" for t in get.json()["items"][0]["remediations"])
+    assert any(t["value"] == "value3" for t in get.json()["items"][0]["remediations"])
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?remediations=")
+    assert get.json()["total"] == 3
+
+
+def test_get_filter_risk_level(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, risk_level="value1")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?risk_level=value1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["risk_level"]["value"] == "value1"
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?risk_level=")
+    assert get.json()["total"] == 2
+
+
+def test_get_filter_source(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, source="value1")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?source=value1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["source"]["value"] == "value1"
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?source=")
+    assert get.json()["total"] == 2
+
+
+def test_get_filter_status(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db, status="value1")
+    helpers.create_event(name="event2", db=db, status="value2")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?status=value1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["status"]["value"] == "value1"
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?status=")
+    assert get.json()["total"] == 2
+
+
+def test_get_filter_tags(client_valid_access_token, db):
+    # Create an event with a tagged observable
+    event1 = helpers.create_event(name="event1", db=db)
+    alert_tree1 = helpers.create_alert(event=event1, db=db)
+    helpers.create_observable(type="fqdn", value="bad.com", parent_tree=alert_tree1, db=db, tags=["obs1"])
+
+    # Create an event with an alert with one tag
+    event2 = helpers.create_event(name="event2", db=db)
+    helpers.create_alert(event=event2, db=db, tags=["tag1"])
+
+    # Create an event with an alert with two tags
+    event3 = helpers.create_event(name="event3", db=db)
+    helpers.create_alert(event=event3, db=db, tags=["tag2", "tag3"])
+
+    # Create a tagged event
+    event4 = helpers.create_event(name="event4", db=db, tags=["tag4"])
+    helpers.create_alert(event=event4, db=db)
+
+    # There should be 4 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 4
+
+    # There should only be 1 event when we filter by tag1
+    get = client_valid_access_token.get("/api/event/?tags=tag1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event2"
+
+    # There should only be 1 event when we filter by tag2 AND tag3
+    get = client_valid_access_token.get("/api/event/?tags=tag2,tag3")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+    # There should only be 1 event when we filter by the child observable tag obs1
+    get = client_valid_access_token.get("/api/event/?tags=obs1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+    # There should only be 1 event when we filter by tag4
+    get = client_valid_access_token.get("/api/event/?tags=tag4")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event4"
+
+    # All the events should be returned if you don't specify any tags for the filter
+    get = client_valid_access_token.get("/api/event/?tags=")
+    assert get.json()["total"] == 4
+
+
+def test_get_filter_threat_actors(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    alert_tree1 = helpers.create_alert(event=event1, db=db)
+    helpers.create_observable(type="fqdn", value="bad.com", parent_tree=alert_tree1, db=db, threat_actors=["bad_guys"])
+
+    event2 = helpers.create_event(name="event2", db=db)
+    helpers.create_alert(event=event2, db=db, threat_actors=["test_actor"])
+
+    event3 = helpers.create_event(name="event3", db=db, threat_actors=["test_actor2"])
+    helpers.create_alert(event=event3, db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should be 1 event when we filter test_actor
+    get = client_valid_access_token.get("/api/event/?threat_actors=test_actor")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event2"
+
+    # There should be 1 event when we filter by the child observable threat_actor
+    get = client_valid_access_token.get("/api/event/?threat_actors=bad_guys")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+    # There should be 1 event when we filter test_actor2
+    get = client_valid_access_token.get("/api/event/?threat_actors=test_actor2")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+    # All the alerts should be returned if you don't specify anything for the filter
+    get = client_valid_access_token.get("/api/event/?threat_actors=")
+    assert get.json()["total"] == 3
+
+
+def test_get_filter_threats(client_valid_access_token, db):
+    event1 = helpers.create_event(name="event1", db=db)
+    alert_tree1 = helpers.create_alert(event=event1, db=db)
+    helpers.create_observable(type="fqdn", value="bad.com", parent_tree=alert_tree1, db=db, threats=["malz"])
+
+    event2 = helpers.create_event(name="event2", db=db)
+    helpers.create_alert(event=event2, db=db, threats=["threat1"])
+
+    event3 = helpers.create_event(name="event3", db=db, threats=["threat2", "threat3"])
+    helpers.create_alert(event=event3, db=db)
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should be 1 event when we filter by threat1
+    get = client_valid_access_token.get("/api/event/?threats=threat1")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event2"
+
+    # There should be 1 event when we filter by the child observable threat
+    get = client_valid_access_token.get("/api/event/?threats=malz")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event1"
+
+    # There should be 1 event when we filter by threat2 AND threat3
+    get = client_valid_access_token.get("/api/event/?threats=threat2,threat3")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["name"] == "event3"
+
+    # All the alerts should be returned if you don't specify anything for the filter
+    get = client_valid_access_token.get("/api/event/?threats=")
+    assert get.json()["total"] == 3
+
+
+def test_get_filter_type(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db, type="test_type")
+    helpers.create_event(name="event2", db=db, type="test_type2")
+
+    # There should be 2 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 2
+
+    # There should only be 1 event when we filter by test_type
+    get = client_valid_access_token.get("/api/event/?type=test_type")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["type"]["value"] == "test_type"
+
+
+def test_get_filter_vectors(client_valid_access_token, db):
+    helpers.create_event(name="event1", db=db)
+    helpers.create_event(name="event2", db=db, vectors=["value1"])
+    helpers.create_event(name="event3", db=db, vectors=["value2", "value3"])
+
+    # There should be 3 total events
+    get = client_valid_access_token.get("/api/event/")
+    assert get.json()["total"] == 3
+
+    # There should only be 1 event when we filter by value1
+    get = client_valid_access_token.get("/api/event/?vectors=value1")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["vectors"]) == 1
+    assert get.json()["items"][0]["vectors"][0]["value"] == "value1"
+
+    # There should only be 1 event when we filter by value2 AND value3
+    get = client_valid_access_token.get("/api/event/?vectors=value2,value3")
+    assert get.json()["total"] == 1
+    assert len(get.json()["items"][0]["vectors"]) == 2
+    assert any(t["value"] == "value2" for t in get.json()["items"][0]["vectors"])
+    assert any(t["value"] == "value3" for t in get.json()["items"][0]["vectors"])
+
+    # All the events should be returned if you don't specify any value for the filter
+    get = client_valid_access_token.get("/api/event/?vectors=")
+    assert get.json()["total"] == 3

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -95,6 +95,7 @@ def create_alert(
     disposition: Optional[str] = None,
     disposition_time: Optional[datetime] = None,
     disposition_user: Optional[str] = None,
+    event: Optional[Event] = None,
     event_time: datetime = None,
     insert_time: datetime = None,
     name: str = "Test Alert",
@@ -140,6 +141,9 @@ def create_alert(
             db=db,
             alert_queue=alert_queue,
         )
+
+    if event:
+        alert.event = event
 
     if event_time:
         alert.event_time = event_time
@@ -274,7 +278,27 @@ def create_analysis_module_type(
     return obj
 
 
-def create_event(name: str, db: Session, queue: str = "default", status: str = "OPEN") -> Event:
+def create_event(
+    name: str,
+    db: Session,
+    alert_time: Optional[datetime] = None,
+    contain_time: Optional[datetime] = None,
+    created_time: Optional[datetime] = None,
+    disposition_time: Optional[datetime] = None,
+    owner: Optional[str] = None,
+    prevention_tools: Optional[List[str]] = None,
+    queue: str = "default",
+    remediation_time: Optional[datetime] = None,
+    remediations: Optional[List[str]] = None,
+    risk_level: Optional[str] = None,
+    source: Optional[str] = None,
+    status: str = "OPEN",
+    tags: Optional[List[str]] = None,
+    threat_actors: Optional[List[str]] = None,
+    threats: Optional[List[str]] = None,
+    type: Optional[str] = None,
+    vectors: Optional[List[str]] = None,
+) -> Event:
     obj = Event(
         name=name,
         queue=create_event_queue(value=queue, db=db),
@@ -282,6 +306,52 @@ def create_event(name: str, db: Session, queue: str = "default", status: str = "
         uuid=uuid.uuid4(),
         version=uuid.uuid4(),
     )
+
+    if alert_time:
+        obj.alert_time = alert_time
+
+    if contain_time:
+        obj.contain_time = contain_time
+
+    if created_time:
+        obj.creation_time = created_time
+
+    if disposition_time:
+        obj.disposition_time = disposition_time
+
+    if owner:
+        obj.owner = create_user(email=f"{owner}@{owner}.com", username=owner, db=db, event_queue=queue)
+
+    if prevention_tools:
+        obj.prevention_tools = [create_event_prevention_tool(value=p, db=db) for p in prevention_tools]
+
+    if remediation_time:
+        obj.remediation_time = remediation_time
+
+    if remediations:
+        obj.remediations = [create_event_remediation(value=r, db=db) for r in remediations]
+
+    if risk_level:
+        obj.risk_level = create_event_risk_level(value=risk_level, db=db)
+
+    if source:
+        obj.source = create_event_source(value=source, db=db)
+
+    if tags:
+        obj.tags = [create_node_tag(value=tag, db=db) for tag in tags]
+
+    if threat_actors:
+        obj.threat_actors = [create_node_threat_actor(value=threat_actor, db=db) for threat_actor in threat_actors]
+
+    if threats:
+        obj.threats = [create_node_threat(value=threat, db=db) for threat in threats]
+
+    if type:
+        obj.type = create_event_type(value=type, db=db)
+
+    if vectors:
+        obj.vectors = [create_event_vector(value=v, db=db) for v in vectors]
+
     db.add(obj)
     crud.commit(db)
     return obj

--- a/bin/insert-event.sh
+++ b/bin/insert-event.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Load the environment variables for the dev containers
+ACE2_ENV_PATH="$HOME/.ace2.env"
+set -a
+source "$ACE2_ENV_PATH"
+set +a
+
+docker-compose up -d
+docker exec -e SQL_ECHO=no ace2-ams-api python insert-event.py $@

--- a/frontend/src/components/Events/TheEventActionToolbar.vue
+++ b/frontend/src/components/Events/TheEventActionToolbar.vue
@@ -1,0 +1,108 @@
+<!-- Toolbar containing all event-related actions, such as Assign, Comment, etc. -->
+
+<template>
+  <div>
+    <div v-if="error" class="p-col">
+      <Message severity="error" @close="handleError">{{ error }}</Message>
+    </div>
+  </div>
+  <Toolbar id="EventActionToolbar" style="overflow-x: auto">
+    <template #start>
+      <!--      COMMENT -->
+      <Button
+        class="p-m-1 p-button-sm"
+        icon="pi pi-comment"
+        label="Comment"
+        @click="open('CommentModal')"
+      />
+      <CommentModal name="CommentModal" @requestReload="requestReload" />
+      <!--      TAKE OWNERSHIP -- NO MODAL -->
+      <Button
+        class="p-m-1 p-button-sm"
+        icon="pi pi-briefcase"
+        label="Take Ownership"
+        :disabled="!selectedEventStore.anySelected"
+        @click="takeOwnership"
+      />
+      <!--      ASSIGN -->
+      <Button
+        class="p-m-1 p-button-sm"
+        icon="pi pi-user"
+        label="Assign"
+        @click="open('AssignModal')"
+      />
+      <AssignModal name="AssignModal" @requestReload="requestReload" />
+      <!--      TAG MODAL -->
+      <Button
+        class="p-m-1 p-button-sm"
+        icon="pi pi-tags"
+        label="Tag"
+        @click="open('TagModal')"
+        @requestReload="requestReload"
+      />
+      <TagModal name="TagModal" @requestReload="requestReload" />
+    </template>
+  </Toolbar>
+</template>
+
+<script setup>
+  import { ref, defineProps } from "vue";
+
+  import Button from "primevue/button";
+  import Message from "primevue/message";
+  import Toolbar from "primevue/toolbar";
+
+  import AssignModal from "@/components/Modals/AssignModal";
+  import CommentModal from "@/components/Modals/CommentModal";
+  import TagModal from "@/components/Modals/TagModal";
+
+  import { useEventStore } from "@/stores/event";
+  import { useEventTableStore } from "@/stores/eventTable";
+  import { useAuthStore } from "@/stores/auth";
+  import { useModalStore } from "@/stores/modal";
+  import { useSelectedEventStore } from "@/stores/selectedEvent";
+
+  const eventStore = useEventStore();
+  const eventTableStore = useEventTableStore();
+  const authStore = useAuthStore();
+  const modalStore = useModalStore();
+  const selectedEventStore = useSelectedEventStore();
+
+  const props = defineProps({
+    page: { type: String, required: true },
+  });
+
+  const error = ref(null);
+
+  const open = (name) => {
+    modalStore.open(name);
+  };
+
+  async function takeOwnership() {
+    try {
+      const updateData = selectedEventStore.selected.map((uuid) => ({
+        uuid: uuid,
+        owner: authStore.user.username,
+      }));
+
+      await eventStore.update(updateData);
+    } catch (err) {
+      error.value = err.message;
+    }
+    if (!error.value) {
+      requestReload();
+    }
+  }
+
+  function requestReload() {
+    if (props.page == "Manage Events") {
+      eventTableStore.requestReload = true;
+    } else if (props.page == "View Event") {
+      eventStore.requestReload = true;
+    }
+  }
+
+  const handleError = () => {
+    error.value = null;
+  };
+</script>

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -106,6 +106,9 @@
         <span v-else-if="col.field.includes('Time')">
           {{ formatDateTime(data[col.field]) }}</span
         >
+        <span v-else-if="Array.isArray(data[col.field])">
+          {{ joinStringArray(data[col.field]) }}
+        </span>
         <span v-else> {{ data[col.field] }}</span>
       </template>
     </Column>
@@ -160,7 +163,7 @@
   const selectedEventStore = useSelectedEventStore();
 
   const defaultColumns = [
-    "date",
+    "createdTime",
     "name",
     "type",
     "vectors",
@@ -173,7 +176,7 @@
   });
 
   const columns = ref([
-    { field: "date", header: "Date" },
+    { field: "createdTime", header: "Created" },
     { field: "name", header: "Name" },
     { field: "owner", header: "Owner" },
     { field: "status", header: "Status" },
@@ -326,6 +329,10 @@
       sortField.value = null;
       sortOrder.value = null;
     }
+  };
+
+  const joinStringArray = (arr) => {
+    return arr.join(", ");
   };
 </script>
 

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -159,7 +159,14 @@
   const filterStore = useFilterStore();
   const selectedEventStore = useSelectedEventStore();
 
-  const defaultColumns = ["date", "name", "owner", "disposition"];
+  const defaultColumns = [
+    "date",
+    "name",
+    "type",
+    "vectors",
+    "owner",
+    "disposition",
+  ];
 
   const eventTableFilter = ref({
     global: { value: null, matchMode: FilterMatchMode.CONTAINS },

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -1,0 +1,331 @@
+/* eslint-disable vue/attribute-hyphenation */
+<!-- TheEventsTable.vue -->
+<!-- The table where all currently filtered events are displayed, selected to take action, or link to an individual event page -->
+
+<template>
+  <DataTable
+    ref="dt"
+    v-model:expandedRows="expandedRows"
+    v-model:filters="eventTableFilter"
+    v-model:selection="selectedRows"
+    :value="eventTableStore.visibleQueriedEventSummaries"
+    :global-filter-fields="selectedColumns.field"
+    :resizable-columns="true"
+    :sort-order="-1"
+    :loading="isLoading"
+    column-resize-mode="expand"
+    data-key="uuid"
+    removable-sort
+    responsive-layout="scroll"
+    :sort-field="sortField"
+    @sort="sort"
+    @row-expand="rowExpand($event.data.uuid)"
+    @row-collapse="rowCollapse($event.data.uuid)"
+    @rowSelect="selectedEventStore.select($event.data.uuid)"
+    @rowUnselect="selectedEventStore.unselect($event.data.uuid)"
+    @rowSelect-all="
+      selectedEventStore.selectAll(eventTableStore.visibleQueriedEventsUuids)
+    "
+    @rowUnselect-all="selectedEventStore.unselectAll()"
+  >
+    <!--        EVENT TABLE TOOLBAR-->
+    <template #header>
+      <Toolbar style="border: none">
+        <template #start>
+          <MultiSelect
+            :model-value="selectedColumns"
+            :options="columns"
+            option-label="header"
+            placeholder="Select Columns"
+            @update:modelValue="onColumnToggle"
+          />
+        </template>
+        <template #end>
+          <span class="p-input-icon-left p-m-1">
+            <i class="pi pi-search" />
+            <InputText
+              v-model="eventTableFilter['global'].value"
+              placeholder="Search in table"
+            />
+          </span>
+          <!--            CLEAR TABLE FILTERS -->
+          <Button
+            icon="pi pi-refresh"
+            class="p-button-rounded p-m-1"
+            @click="reset()"
+          />
+          <!--            EXPORT TABLE -->
+          <Button
+            class="p-button-rounded p-m-1"
+            icon="pi pi-download"
+            @click="exportCSV($event)"
+          />
+        </template>
+      </Toolbar>
+    </template>
+
+    <!-- DROPDOWN COLUMN-->
+    <Column id="event-expand" :expander="true" header-style="width: 3rem" />
+
+    <!-- CHECKBOX COLUMN -->
+    <!-- It's annoying, but the PrimeVue DataTable selectionMode attribute works when camelCase -->
+    <Column
+      id="event-select"
+      header-style="width: 3em"
+      selection-mode="multiple"
+    />
+
+    <!-- DATA COLUMN -->
+    <Column
+      v-for="(col, index) of selectedColumns"
+      :key="col.field + '_' + index"
+      :field="col.field"
+      :header="col.header"
+      :sortable="true"
+    >
+      <!-- DATA COLUMN BODY-->
+      <template #body="{ data }">
+        <!-- NAME COLUMN - INCL. TAGS AND TODO: EVENT ICONS-->
+        <div v-if="col.field === 'name'">
+          <span class="p-m-1" data-cy="eventName">
+            <router-link :to="getEventLink(data.uuid)">{{
+              data.name
+            }}</router-link></span
+          >
+          <br />
+          <span v-if="data.comments">
+            <pre
+              v-for="comment in data.comments"
+              :key="comment.uuid"
+              class="p-mr-2 comment"
+            >
+({{ comment.user.displayName }}) {{ comment.value }}</pre
+            >
+          </span>
+        </div>
+        <span v-else-if="col.field.includes('Time')">
+          {{ formatDateTime(data[col.field]) }}</span
+        >
+        <span v-else> {{ data[col.field] }}</span>
+      </template>
+    </Column>
+
+    <!--      EVENT ROW DROPDOWN -->
+    <template #expansion="slotProps">
+      <ul>
+        <li
+          v-for="obs of expandedRowsData[slotProps.data.uuid]"
+          :key="obs.value"
+        >
+          <span class="link-text" @click="1"
+            >{{ obs.type.value }} : {{ obs.value }}</span
+          >
+        </li>
+      </ul>
+    </template>
+  </DataTable>
+  <Paginator
+    :rows="numRows"
+    :rows-per-page-options="[5, 10, 50, 100]"
+    :total-records="eventTableStore.totalEvents"
+    template="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
+    current-page-report-template="Showing {first} to {last} of {totalRecords}"
+    @page="
+      onPage($event);
+      selectedEventStore.unselectAll();
+    "
+  ></Paginator>
+</template>
+
+<script setup>
+  import { computed, onMounted, ref } from "vue";
+
+  import Button from "primevue/button";
+  import Column from "primevue/column";
+  import DataTable from "primevue/datatable";
+  import { FilterMatchMode } from "primevue/api";
+  import InputText from "primevue/inputtext";
+  import MultiSelect from "primevue/multiselect";
+  import Toolbar from "primevue/toolbar";
+  import Paginator from "primevue/paginator";
+
+  import { camelToSnakeCase } from "@/etc/helpers";
+
+  import { useFilterStore } from "@/stores/filter";
+  import { useEventTableStore } from "@/stores/eventTable";
+  import { useSelectedEventStore } from "@/stores/selectedEvent";
+
+  const eventTableStore = useEventTableStore();
+  const filterStore = useFilterStore();
+  const selectedEventStore = useSelectedEventStore();
+
+  const defaultColumns = ["date", "name", "owner", "disposition"];
+
+  const eventTableFilter = ref({
+    global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+  });
+
+  const columns = ref([
+    { field: "date", header: "Date" },
+    { field: "name", header: "Name" },
+    { field: "owner", header: "Owner" },
+    { field: "status", header: "Status" },
+    { field: "type", header: "Type" },
+    { field: "vectors", header: "Vectors" },
+    { field: "threatActors", header: "Threat Actors" },
+    { field: "threats", header: "Threats" },
+    { field: "preventionTools", header: "Prevention Tools" },
+    { field: "riskLevel", header: "Risk Level" },
+  ]);
+  const dt = ref(null);
+  const error = ref(null);
+  const expandedRows = ref([]);
+  const expandedRowsData = ref({});
+  const isLoading = ref(false);
+  const selectedColumns = ref([]);
+  const sortField = ref("date");
+  const sortOrder = ref("desc");
+  const numRows = ref(10);
+  const page = ref(0);
+
+  const sortFilter = computed(() => {
+    return sortField.value
+      ? `${camelToSnakeCase(sortField.value)}|${sortOrder.value}`
+      : null;
+  });
+
+  const pageOptions = computed(() => {
+    return {
+      limit: numRows.value,
+      offset: numRows.value * page.value,
+    };
+  });
+
+  filterStore.$subscribe(
+    async () => {
+      await loadEvents();
+    },
+    { deep: true },
+  );
+
+  eventTableStore.$subscribe(async (_, state) => {
+    if (state.requestReload) {
+      await reloadTable();
+    }
+  });
+
+  const selectedRows = computed(() => {
+    return eventTableStore.visibleQueriedEvents.filter((event) =>
+      selectedEventStore.selected.includes(event.uuid),
+    );
+  });
+
+  const reloadTable = async () => {
+    selectedEventStore.unselectAll();
+    eventTableStore.requestReload = false;
+    await loadEvents();
+  };
+
+  const rowExpand = async (uuid) => {
+    // const observables = await NodeTree.readNodesOfNodeTree(
+    //   [uuid],
+    //   "observable",
+    // );
+    // expandedRowsData.value[uuid] = observables.sort((a, b) => {
+    //   if (a.type.value === b.type.value) {
+    //     return a.value < b.value ? -1 : 1;
+    //   } else {
+    //     return a.type.value < b.type.value ? -1 : 1;
+    //   }
+    // });
+  };
+
+  const rowCollapse = (uuid) => {
+    delete expandedRowsData.value[uuid];
+  };
+
+  onMounted(async () => {
+    initEventTable();
+    await loadEvents();
+  });
+
+  const exportCSV = () => {
+    // Exports currently filtered events to CSV
+    dt.value.exportCSV();
+  };
+
+  const formatDateTime = (dateTime) => {
+    if (dateTime) {
+      const d = new Date(dateTime);
+      return d.toLocaleString("en-US");
+    }
+
+    return "None";
+  };
+
+  const getEventLink = (uuid) => {
+    return "/event/" + uuid;
+  };
+
+  const initEventTable = () => {
+    // Initializes event filter (the keyword search)
+    eventTableFilter.value = {
+      global: { value: null, matchMode: FilterMatchMode.CONTAINS },
+    };
+    selectedColumns.value = columns.value.filter((col) => {
+      return defaultColumns.includes(col.field);
+    });
+    error.value = null;
+  };
+
+  const loadEvents = async () => {
+    isLoading.value = true;
+    try {
+      await eventTableStore.readPage({
+        sort: sortFilter.value,
+        ...pageOptions.value,
+        ...filterStore.events,
+      });
+    } catch (err) {
+      error.value = err.message || "Something went wrong!";
+    }
+    isLoading.value = false;
+  };
+
+  const onColumnToggle = (val) => {
+    // Toggles selected columns to display
+    // This method required/provided by Primevue 'ColToggle' docs
+    selectedColumns.value = columns.value.filter((col) => val.includes(col));
+  };
+
+  const onPage = async (event) => {
+    selectedEventStore.unselectAll();
+    numRows.value = event.rows;
+    page.value = event.page;
+    await loadEvents();
+  };
+
+  const reset = async () => {
+    initEventTable();
+    await sort({ sortField: "date", sortOrder: "-1" });
+  };
+
+  const sort = async (event) => {
+    if (event.sortField) {
+      sortField.value = event.sortField;
+      sortOrder.value = event.sortOrder > 0 ? "asc" : "desc";
+      await loadEvents();
+    } else {
+      sortField.value = null;
+      sortOrder.value = null;
+    }
+  };
+</script>
+
+<style>
+  .link-text:hover {
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
+  }
+</style>

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -81,7 +81,7 @@
       :key="col.field + '_' + index"
       :field="col.field"
       :header="col.header"
-      :sortable="true"
+      :sortable="col.sortable"
     >
       <!-- DATA COLUMN BODY-->
       <template #body="{ data }">
@@ -176,16 +176,16 @@
   });
 
   const columns = ref([
-    { field: "createdTime", header: "Created" },
-    { field: "name", header: "Name" },
-    { field: "owner", header: "Owner" },
-    { field: "status", header: "Status" },
-    { field: "type", header: "Type" },
-    { field: "vectors", header: "Vectors" },
-    { field: "threatActors", header: "Threat Actors" },
-    { field: "threats", header: "Threats" },
-    { field: "preventionTools", header: "Prevention Tools" },
-    { field: "riskLevel", header: "Risk Level" },
+    { field: "createdTime", header: "Created", sortable: true },
+    { field: "name", header: "Name", sortable: true },
+    { field: "owner", header: "Owner", sortable: true },
+    { field: "status", header: "Status", sortable: true },
+    { field: "type", header: "Type", sortable: true },
+    { field: "vectors", header: "Vectors", sortable: false },
+    { field: "threatActors", header: "Threat Actors", sortable: false },
+    { field: "threats", header: "Threats", sortable: false },
+    { field: "preventionTools", header: "Prevention Tools", sortable: false },
+    { field: "riskLevel", header: "Risk Level", sortable: true },
   ]);
   const dt = ref(null);
   const error = ref(null);
@@ -193,7 +193,7 @@
   const expandedRowsData = ref({});
   const isLoading = ref(false);
   const selectedColumns = ref([]);
-  const sortField = ref("date");
+  const sortField = ref("createdTime");
   const sortOrder = ref("desc");
   const numRows = ref(10);
   const page = ref(0);

--- a/frontend/src/components/Filters/FilterChip.vue
+++ b/frontend/src/components/Filters/FilterChip.vue
@@ -39,7 +39,8 @@
   const filterType = inject("filterType");
 
   const availableFilters = { alerts: alertFilters, events: eventFilters };
-  const filterOptions = availableFilters[filterType];
+  const filterOptions =
+    filterType in availableFilters ? availableFilters[filterType] : [];
   const filterNameObject = filterOptions.find((filter) => {
     return filter.name === props.filterName;
   });

--- a/frontend/src/components/Filters/FilterChip.vue
+++ b/frontend/src/components/Filters/FilterChip.vue
@@ -26,7 +26,7 @@
 
   import { useFilterStore } from "@/stores/filter";
 
-  import { alertFilters } from "@/etc/constants";
+  import { alertFilters, eventFilters } from "@/etc/constants";
   import { isObject } from "@/etc/helpers";
   import Chip from "primevue/chip";
 
@@ -37,7 +37,9 @@
 
   const filterStore = useFilterStore();
   const filterType = inject("filterType");
-  const filterOptions = filterType === "alerts" ? alertFilters : [];
+
+  const availableFilters = { alerts: alertFilters, events: eventFilters };
+  const filterOptions = availableFilters[filterType];
   const filterNameObject = filterOptions.find((filter) => {
     return filter.name === props.filterName;
   });

--- a/frontend/src/components/Filters/TheFilterToolbar.vue
+++ b/frontend/src/components/Filters/TheFilterToolbar.vue
@@ -66,13 +66,15 @@
   const modalStore = useModalStore();
 
   function generateLink() {
-    let link = `${window.location.origin}/manage_alerts`;
+    let link = `${window.location.origin}/manage_${filterType}`;
     // If there are filters set, build the link for it
     if (Object.keys(filterStore[filterType]).length) {
       let urlParams = new URLSearchParams(
         formatForAPI(filterStore[filterType]),
       );
-      link = `${window.location.origin}/manage_alerts?${urlParams.toString()}`;
+      link = `${
+        window.location.origin
+      }/manage_${filterType}?${urlParams.toString()}`;
     }
     return link;
   }

--- a/frontend/src/components/UserInterface/TheHeader.vue
+++ b/frontend/src/components/UserInterface/TheHeader.vue
@@ -11,7 +11,7 @@
       <router-link class="p-m-1" to="/manage_alerts"
         ><Button label="Alerts" class="p-button-raised"
       /></router-link>
-      <router-link class="p-m-1" to="/"
+      <router-link class="p-m-1" to="/manage_events"
         ><Button label="Events" class="p-button-raised"
       /></router-link>
     </template>

--- a/frontend/src/etc/constants.ts
+++ b/frontend/src/etc/constants.ts
@@ -11,7 +11,6 @@ import { useAlertQueueStore } from "@/stores/alertQueue";
 import { useAlertToolStore } from "@/stores/alertTool";
 import { useAlertToolInstanceStore } from "@/stores/alertToolInstance";
 import { useAlertTypeStore } from "@/stores/alertType";
-import { useEventStore } from "@/stores/event";
 import { useEventPreventionToolStore } from "@/stores/eventPreventionTool";
 import { useEventQueueStore } from "@/stores/eventQueue";
 import { useEventRiskLevelStore } from "@/stores/eventRiskLevel";
@@ -96,15 +95,6 @@ export const alertFilters: readonly filterOption[] = [
     stringRepr: (filter: Date) => {
       return filter.toISOString();
     },
-    parseStringRepr: (filterString: string) => {
-      return new Date(filterString);
-    },
-  },
-  {
-    name: alertFilterNames.EVENT_UUID_FILTER,
-    label: "Event",
-    type: filterTypes.SELECT,
-    store: useEventStore,
     parseStringRepr: (filterString: string) => {
       return new Date(filterString);
     },
@@ -295,6 +285,7 @@ export const eventFilterNames: Record<string, eventFilterNameTypes> = {
   CREATED_AFTER_FILTER: "createdAfter",
   CREATED_BEFORE_FILTER: "createdBefore",
   DISPOSITION_FILTER: "disposition",
+  NAME_FILTER: "name",
   OBSERVABLE_TYPES_FILTER: "observableTypes",
   OBSERVABLE_VALUE_FILTER: "observableValue",
   OWNER_FILTER: "owner",
@@ -339,6 +330,11 @@ export const eventFilters: readonly filterOption[] = [
     store: useAlertDispositionStore,
     optionProperty: "value",
     valueProperty: "value",
+  },
+  {
+    name: eventFilterNames.NAME_FILTER,
+    label: "Name",
+    type: filterTypes.INPUT_TEXT,
   },
   {
     name: eventFilterNames.OBSERVABLE_FILTER,

--- a/frontend/src/etc/constants.ts
+++ b/frontend/src/etc/constants.ts
@@ -5,6 +5,13 @@ import { alertQueueRead } from "@/models/alertQueue";
 import { alertToolRead } from "@/models/alertTool";
 import { alertToolInstanceRead } from "@/models/alertToolInstance";
 import { alertTypeRead } from "@/models/alertType";
+import { eventFilterNameTypes } from "@/models/event";
+import { eventPreventionToolRead } from "@/models/eventPreventionTool";
+import { eventQueueRead } from "@/models/eventQueue";
+import { eventRiskLevelRead } from "@/models/eventRiskLevel";
+import { eventStatusRead } from "@/models/eventStatus";
+import { eventTypeRead } from "@/models/eventType";
+import { eventVectorRead } from "@/models/eventVector";
 import { nodeTagRead } from "@/models/nodeTag";
 import { nodeThreatRead } from "@/models/nodeThreat";
 import { nodeThreatActorRead } from "@/models/nodeThreatActor";
@@ -17,6 +24,12 @@ import { useAlertToolStore } from "@/stores/alertTool";
 import { useAlertToolInstanceStore } from "@/stores/alertToolInstance";
 import { useAlertTypeStore } from "@/stores/alertType";
 import { useEventStore } from "@/stores/event";
+import { useEventPreventionToolStore } from "@/stores/eventPreventionTool";
+import { useEventQueueStore } from "@/stores/eventQueue";
+import { useEventRiskLevelStore } from "@/stores/eventRiskLevel";
+import { useEventStatusStore } from "@/stores/eventStatus";
+import { useEventTypeStore } from "@/stores/eventType";
+import { useEventVectorStore } from "@/stores/eventVector";
 import { useNodeTagStore } from "@/stores/nodeTag";
 import { useNodeThreatStore } from "@/stores/nodeThreat";
 import { useNodeThreatActorStore } from "@/stores/nodeThreatActor";
@@ -279,5 +292,200 @@ export const alertRangeFilters = {
   "Disposition Time": {
     start: alertFilterNames.DISPOSITIONED_AFTER_FILTER,
     end: alertFilterNames.DISPOSITIONED_BEFORE_FILTER,
+  },
+};
+
+// ** Events ** //
+
+export const eventFilterNames: Record<string, eventFilterNameTypes> = {
+  CREATED_AFTER_FILTER: "createdAfter",
+  CREATED_BEFORE_FILTER: "createdBefore",
+  DISPOSITION_FILTER: "disposition",
+  OBSERVABLE_TYPES_FILTER: "observableTypes",
+  OBSERVABLE_VALUE_FILTER: "observableValue",
+  OWNER_FILTER: "owner",
+  PREVENTION_TOOL_FILTER: "preventionTool",
+  QUEUE_FILTER: "queue",
+  RISK_LEVEL_FILTER: "riskLevel",
+  STATUS_FILTER: "status",
+  TAGS_FILTER: "tags",
+  THREAT_ACTOR_FILTER: "threatActor",
+  THREATS_FILTER: "threats",
+  TYPE_FILTER: "type",
+  VECTOR_FILTER: "vector",
+};
+
+export const eventFilters: readonly filterOption[] = [
+  {
+    name: eventFilterNames.CREATED_AFTER_FILTER,
+    label: "Created After",
+    type: filterTypes.DATE,
+    parseFormattedFilterString: (filterString: string) => {
+      return new Date(filterString);
+    },
+  },
+  {
+    name: eventFilterNames.CREATED_BEFORE_FILTER,
+    label: "Created Before",
+    type: filterTypes.DATE,
+    parseFormattedFilterString: (filterString: string) => {
+      return new Date(filterString);
+    },
+  },
+  {
+    name: eventFilterNames.DISPOSITION_FILTER,
+    label: "Disposition",
+    type: filterTypes.SELECT,
+    store: useAlertDispositionStore,
+    formatForAPI: (filter: alertDispositionRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.OBSERVABLE_FILTER,
+    label: "Observable",
+    type: filterTypes.CATEGORIZED_VALUE,
+    store: useObservableTypeStore,
+    formatForAPI: (filter: { category: observableTypeRead; value: string }) => {
+      return `${filter.category.value}|${filter.value}`;
+    },
+    parseFormattedFilterString: (filterString: string) => {
+      const [category, value] = filterString.split("|");
+      return { category: category, value: value };
+    },
+  },
+  {
+    name: eventFilterNames.OBSERVABLE_TYPES_FILTER,
+    label: "Observable Types",
+    type: filterTypes.MULTISELECT,
+    store: useObservableTypeStore,
+    formatForAPI: (filter: observableTypeRead[]) => {
+      return filter
+        .map(function (elem) {
+          return elem.value;
+        })
+        .join();
+    },
+    parseFormattedFilterString: (filterString: string) => {
+      return filterString.split(",");
+    },
+  },
+  {
+    name: eventFilterNames.OBSERVABLE_VALUE_FILTER,
+    label: "Observable Value",
+    type: filterTypes.INPUT_TEXT,
+  },
+  {
+    name: eventFilterNames.OWNER_FILTER,
+    label: "Owner",
+    type: filterTypes.SELECT,
+    store: useUserStore,
+    optionLabel: "displayName",
+    valueProperty: "username",
+    formatForAPI: (filter: userRead) => {
+      return filter.username;
+    },
+  },
+  {
+    name: eventFilterNames.PREVENTION_TOOL_FILTER,
+    label: "Prevention Tool",
+    type: filterTypes.SELECT,
+    store: useEventPreventionToolStore,
+    formatForAPI: (filter: eventPreventionToolRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.QUEUE_FILTER,
+    label: "Queue",
+    type: filterTypes.SELECT,
+    store: useEventQueueStore,
+    formatForAPI: (filter: eventQueueRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.RISK_LEVEL_FILTER,
+    label: "Risk Level",
+    type: filterTypes.SELECT,
+    store: useEventRiskLevelStore,
+    formatForAPI: (filter: eventRiskLevelRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.STATUS_FILTER,
+    label: "Status",
+    type: filterTypes.SELECT,
+    store: useEventStatusStore,
+    formatForAPI: (filter: eventStatusRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.TAGS_FILTER,
+    label: "Tags",
+    type: filterTypes.CHIPS,
+    store: useNodeTagStore,
+    formatForAPI: (filter: nodeTagRead[]) => {
+      return filter
+        .map(function (elem) {
+          return elem;
+        })
+        .join();
+    },
+    parseFormattedFilterString: (filterString: string) => {
+      return filterString.split(",");
+    },
+  },
+  {
+    name: eventFilterNames.THREAT_ACTOR_FILTER,
+    label: "Threat Actor",
+    type: filterTypes.SELECT,
+    store: useNodeThreatActorStore,
+    formatForAPI: (filter: nodeThreatActorRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.THREATS_FILTER,
+    label: "Threats",
+    type: filterTypes.MULTISELECT,
+    store: useNodeThreatStore,
+    formatForAPI: (filter: nodeThreatRead[]) => {
+      return filter
+        .map(function (elem) {
+          return elem.value;
+        })
+        .join();
+    },
+    parseFormattedFilterString: (filterString: string) => {
+      return filterString.split(",");
+    },
+  },
+  {
+    name: eventFilterNames.TYPE_FILTER,
+    label: "Type",
+    type: filterTypes.SELECT,
+    store: useEventTypeStore,
+    formatForAPI: (filter: eventTypeRead) => {
+      return filter.value;
+    },
+  },
+  {
+    name: eventFilterNames.VECTOR_FILTER,
+    label: "Vector",
+    type: filterTypes.SELECT,
+    store: useEventVectorStore,
+    formatForAPI: (filter: eventVectorRead) => {
+      return filter.value;
+    },
+  },
+] as const;
+
+export const eventRangeFilters = {
+  "Created Time": {
+    start: eventFilterNames.CREATED_AFTER_FILTER,
+    end: eventFilterNames.CREATED_BEFORE_FILTER,
   },
 };

--- a/frontend/src/etc/constants.ts
+++ b/frontend/src/etc/constants.ts
@@ -2,8 +2,10 @@ import { alertFilterNameTypes } from "@/models/alert";
 import { filterOption } from "@/models/base";
 import { eventFilterNameTypes } from "@/models/event";
 import { eventPreventionToolRead } from "@/models/eventPreventionTool";
+import { eventVectorRead } from "@/models/eventVector";
 import { nodeTagRead } from "@/models/nodeTag";
 import { nodeThreatRead } from "@/models/nodeThreat";
+import { nodeThreatActorRead } from "@/models/nodeThreatActor";
 import { observableTypeRead } from "@/models/observableType";
 
 import { useAlertDispositionStore } from "@/stores/alertDisposition";
@@ -14,6 +16,7 @@ import { useAlertTypeStore } from "@/stores/alertType";
 import { useEventPreventionToolStore } from "@/stores/eventPreventionTool";
 import { useEventQueueStore } from "@/stores/eventQueue";
 import { useEventRiskLevelStore } from "@/stores/eventRiskLevel";
+import { useEventSourceStore } from "@/stores/eventSource";
 import { useEventStatusStore } from "@/stores/eventStatus";
 import { useEventTypeStore } from "@/stores/eventType";
 import { useEventVectorStore } from "@/stores/eventVector";
@@ -203,7 +206,7 @@ export const alertFilters: readonly filterOption[] = [
     label: "Tags",
     type: filterTypes.CHIPS,
     store: useNodeTagStore,
-    stringRepr: (filter: nodeTagRead[]) => {
+    stringRepr: (filter: string[]) => {
       return filter
         .map(function (elem) {
           return elem;
@@ -292,12 +295,13 @@ export const eventFilterNames: Record<string, eventFilterNameTypes> = {
   PREVENTION_TOOLS_FILTER: "preventionTools",
   QUEUE_FILTER: "queue",
   RISK_LEVEL_FILTER: "riskLevel",
+  SOURCE_FILTER: "source",
   STATUS_FILTER: "status",
   TAGS_FILTER: "tags",
-  THREAT_ACTOR_FILTER: "threatActor",
+  THREAT_ACTORS_FILTER: "threatActors",
   THREATS_FILTER: "threats",
   TYPE_FILTER: "type",
-  VECTOR_FILTER: "vector",
+  VECTORS_FILTER: "vectors",
 };
 
 export const eventFilters: readonly filterOption[] = [
@@ -411,6 +415,14 @@ export const eventFilters: readonly filterOption[] = [
     valueProperty: "value",
   },
   {
+    name: eventFilterNames.SOURCE_FILTER,
+    label: "Source",
+    type: filterTypes.SELECT,
+    store: useEventSourceStore,
+    optionProperty: "value",
+    valueProperty: "value",
+  },
+  {
     name: eventFilterNames.STATUS_FILTER,
     label: "Status",
     type: filterTypes.SELECT,
@@ -423,7 +435,23 @@ export const eventFilters: readonly filterOption[] = [
     label: "Tags",
     type: filterTypes.CHIPS,
     store: useNodeTagStore,
-    stringRepr: (filter: nodeTagRead[]) => {
+    stringRepr: (filter: string[]) => {
+      return filter
+        .map(function (elem) {
+          return elem;
+        })
+        .join();
+    },
+    parseStringRepr: (filterString: string) => {
+      return filterString.split(",");
+    },
+  },
+  {
+    name: eventFilterNames.THREAT_ACTORS_FILTER,
+    label: "Threat Actors",
+    type: filterTypes.MULTISELECT,
+    store: useNodeThreatActorStore,
+    stringRepr: (filter: nodeThreatActorRead[]) => {
       return filter
         .map(function (elem) {
           return elem.value;
@@ -433,14 +461,6 @@ export const eventFilters: readonly filterOption[] = [
     parseStringRepr: (filterString: string) => {
       return filterString.split(",");
     },
-  },
-  {
-    name: eventFilterNames.THREAT_ACTOR_FILTER,
-    label: "Threat Actor",
-    type: filterTypes.SELECT,
-    store: useNodeThreatActorStore,
-    optionProperty: "value",
-    valueProperty: "value",
   },
   {
     name: eventFilterNames.THREATS_FILTER,
@@ -467,12 +487,20 @@ export const eventFilters: readonly filterOption[] = [
     valueProperty: "value",
   },
   {
-    name: eventFilterNames.VECTOR_FILTER,
-    label: "Vector",
-    type: filterTypes.SELECT,
+    name: eventFilterNames.VECTORS_FILTER,
+    label: "Vectors",
+    type: filterTypes.MULTISELECT,
     store: useEventVectorStore,
-    optionProperty: "value",
-    valueProperty: "value",
+    stringRepr: (filter: eventVectorRead[]) => {
+      return filter
+        .map(function (elem) {
+          return elem.value;
+        })
+        .join();
+    },
+    parseStringRepr: (filterString: string) => {
+      return filterString.split(",");
+    },
   },
 ] as const;
 

--- a/frontend/src/etc/helpers.ts
+++ b/frontend/src/etc/helpers.ts
@@ -3,6 +3,12 @@ import { useAlertQueueStore } from "@/stores/alertQueue";
 import { useAlertToolStore } from "@/stores/alertTool";
 import { useAlertToolInstanceStore } from "@/stores/alertToolInstance";
 import { useAlertTypeStore } from "@/stores/alertType";
+import { useEventPreventionToolStore } from "@/stores/eventPreventionTool";
+import { useEventQueueStore } from "@/stores/eventQueue";
+import { useEventRiskLevelStore } from "@/stores/eventRiskLevel";
+import { useEventStatusStore } from "@/stores/eventStatus";
+import { useEventTypeStore } from "@/stores/eventType";
+import { useEventVectorStore } from "@/stores/eventVector";
 import { useNodeDirectiveStore } from "@/stores/nodeDirective";
 import { useObservableTypeStore } from "@/stores/observableType";
 import { useUserStore } from "@/stores/user";
@@ -16,6 +22,12 @@ export async function populateCommonStores(): Promise<void> {
   const alertTypeStore = useAlertTypeStore();
   const alertToolStore = useAlertToolStore();
   const alertToolInstanceStore = useAlertToolInstanceStore();
+  const eventPreventionToolStore = useEventPreventionToolStore();
+  const eventQueueStore = useEventQueueStore();
+  const eventRiskLevelStore = useEventRiskLevelStore();
+  const eventStatusStore = useEventStatusStore();
+  const eventTypeStore = useEventTypeStore();
+  const eventVectorStore = useEventVectorStore();
   const nodeDirectiveStore = useNodeDirectiveStore();
   const observableTypeStore = useObservableTypeStore();
   const userStore = useUserStore();
@@ -26,6 +38,12 @@ export async function populateCommonStores(): Promise<void> {
     alertTypeStore.readAll(),
     alertToolStore.readAll(),
     alertToolInstanceStore.readAll(),
+    eventPreventionToolStore.readAll(),
+    eventQueueStore.readAll(),
+    eventRiskLevelStore.readAll(),
+    eventStatusStore.readAll(),
+    eventTypeStore.readAll(),
+    eventVectorStore.readAll(),
     nodeDirectiveStore.readAll(),
     observableTypeStore.readAll(),
     userStore.readAll(),
@@ -57,6 +75,6 @@ export function copyToClipboard(text: string) {
 }
 
 // https://stackoverflow.com/questions/1353684/detecting-an-invalid-date-date-instance-in-javascript
-export function isValidDate(d: any) {
+export function isValidDate(d: unknown): boolean {
   return d instanceof Date && !isNaN(d.getTime());
 }

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -110,6 +110,7 @@ export interface eventFilterParams extends pageOptionParams {
   createdAfter?: Date;
   createdBefore?: Date;
   disposition?: alertDispositionRead;
+  name?: string;
   observable?: { category: observableTypeRead; value: string };
   observableTypes?: observableTypeRead[];
   observableValue?: string;

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -18,7 +18,7 @@ import { userRead } from "./user";
 
 // High-level event data that will be displayed in Manage Events
 export interface eventSummary {
-  date: Date;
+  createdTime: Date;
   // disposition: string;
   name: string;
   owner: string;

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,4 +1,5 @@
-import { UUID } from "./base";
+import { pageOptionParams, UUID } from "./base";
+import { alertDispositionRead } from "./alertDisposition";
 import { eventPreventionToolRead } from "./eventPreventionTool";
 import { eventQueueRead } from "./eventQueue";
 import { eventRemediationRead } from "./eventRemediation";
@@ -12,7 +13,24 @@ import { nodeCommentRead } from "./nodeComment";
 import { nodeTagRead } from "./nodeTag";
 import { nodeThreatRead } from "./nodeThreat";
 import { nodeThreatActorRead } from "./nodeThreatActor";
+import { observableTypeRead } from "./observableType";
 import { userRead } from "./user";
+
+// High-level event data that will be displayed in Manage Events
+export interface eventSummary {
+  date: Date;
+  // disposition: string;
+  name: string;
+  owner: string;
+  preventionTools: string[];
+  riskLevel: string;
+  status: string;
+  threatActors?: string[];
+  threats?: string[];
+  type: string;
+  uuid: UUID;
+  vectors: string[];
+}
 
 export interface eventCreate extends nodeCreate {
   alertTime?: Date;
@@ -83,6 +101,51 @@ export interface eventUpdate extends nodeUpdate {
   threatActors?: string[];
   threats?: string[];
   type?: string | null;
+  uuid: UUID;
   vectors?: string[];
   [key: string]: unknown;
 }
+
+export interface eventFilterParams extends pageOptionParams {
+  createdAfter?: Date;
+  createdBefore?: Date;
+  disposition?: alertDispositionRead;
+  observable?: { category: observableTypeRead; value: string };
+  observableTypes?: observableTypeRead[];
+  observableValue?: string;
+  owner?: userRead;
+  preventionTool?: eventPreventionToolRead;
+  queue?: eventQueueRead;
+  riskLevel?: eventRiskLevelRead;
+  status?: eventStatusRead;
+  tags?: string[];
+  threatActor?: nodeThreatActorRead;
+  threats?: nodeThreatRead[];
+  type?: eventTypeRead;
+  vector?: eventVectorRead;
+  [key: string]: any;
+}
+
+export type eventFilterNameTypes = Extract<keyof eventFilterParams, string>;
+
+export type eventFilterValues =
+  | (
+      | alertDispositionRead
+      | Date
+      | eventPreventionToolRead
+      | eventQueueRead
+      | eventRiskLevelRead
+      | eventStatusRead
+      | eventTypeRead
+      | eventVectorRead
+      | nodeThreatActorRead
+      | nodeThreatRead
+      | observableTypeRead
+      | string
+      | userRead
+      | {
+          category: observableTypeRead;
+          value: string;
+        }
+    )
+  | undefined;

--- a/frontend/src/pages/Events/ManageEvents.vue
+++ b/frontend/src/pages/Events/ManageEvents.vue
@@ -1,0 +1,178 @@
+<!-- ManageEvents.vue -->
+
+<template>
+  <br />
+  <TheEventActionToolbar page="Manage Events" />
+  <br />
+  <TheFilterToolbar id="FilterToolbar" />
+  <br />
+  <div id="EventsTable" class="card">
+    <TheEventsTable />
+  </div>
+</template>
+
+<script setup>
+  import { onMounted, provide, watch } from "vue";
+
+  import {
+    eventFilters,
+    eventRangeFilters,
+    filterTypes,
+  } from "@/etc/constants";
+
+  import TheEventActionToolbar from "@/components/Events/TheEventActionToolbar.vue";
+  import TheFilterToolbar from "@/components/Filters/TheFilterToolbar";
+  import TheEventsTable from "@/components/Events/TheEventsTable";
+  import { useRoute, useRouter } from "vue-router";
+
+  import { useFilterStore } from "@/stores/filter";
+  import { populateCommonStores, isValidDate } from "@/etc/helpers";
+
+  const route = useRoute();
+  const router = useRouter();
+
+  provide("availableFilters", eventFilters);
+  provide("filterType", "events");
+  provide("rangeFilters", eventRangeFilters);
+
+  const filterStore = useFilterStore();
+
+  onMounted(async () => {
+    if (Object.keys(route.query).length) {
+      // Will need to load common stores in order to find filter values
+      await populateCommonStores();
+      loadRouteQuery();
+    }
+  });
+
+  watch(route, () => {
+    if (Object.keys(route.query).length) {
+      loadRouteQuery();
+    }
+  });
+
+  function loadRouteQuery() {
+    // load filters given in route
+    loadFilters();
+    // Reload page to clear URL params
+    router.push("/manage_events");
+  }
+
+  function loadFilters() {
+    const parsedFilters = {};
+
+    // parse each filter
+    for (const filterName in route.query) {
+      // first get the filter object so you can validate the filter exists and use its metadata
+      let filterNameObject = eventFilters.find((filter) => {
+        return filter.name === filterName;
+      });
+      filterNameObject = filterNameObject ? filterNameObject : null;
+
+      // if the filter doesn't exist, skip it
+      if (!filterNameObject) {
+        continue;
+      }
+
+      let filterValueUnparsed = route.query[filterName]; // the filter value from URL
+      // format filterValueUnparsed for GUI if method available
+      if (filterNameObject.parseFormattedFilterString) {
+        filterValueUnparsed = filterNameObject.parseFormattedFilterString(
+          route.query[filterName],
+        );
+      }
+
+      // use correct property for determinining equality (default is 'value')
+      const filterValueProperty = filterNameObject.valueProperty
+        ? filterNameObject.valueProperty
+        : "value";
+
+      // load the filter options store if available
+      let store = null; // store that may be used to find filter value object
+      if (filterNameObject.store) {
+        store = filterNameObject.store();
+      }
+
+      let filterValueParsed = null; // the target filter value, might be an Object, Array, Date, or string
+      // based on the filter type, parse/format the filter value
+      switch (filterNameObject.type) {
+        case filterTypes.MULTISELECT:
+          // look up each array item in store, add to filter value
+          filterValueParsed = [];
+          if (store) {
+            for (const value of filterValueUnparsed) {
+              const valueObject = store.allItems.find((element) => {
+                return element[filterValueProperty] === value;
+              });
+              if (valueObject) {
+                filterValueParsed.push(valueObject);
+              }
+            }
+          }
+          filterValueParsed = filterValueParsed.length
+            ? filterValueParsed
+            : null;
+          break;
+
+        case filterTypes.CHIPS:
+          // array of strings, handled in parseFormattedFilterString
+          filterValueParsed = filterValueUnparsed;
+          break;
+
+        case filterTypes.SELECT:
+          // look item up in store
+          if (store) {
+            filterValueParsed = store.allItems.find((element) => {
+              return element[filterValueProperty] === filterValueUnparsed;
+            });
+          }
+          break;
+
+        case filterTypes.DATE:
+          // Date string, handled in parseFormattedFilterString
+          filterValueParsed = isValidDate(filterValueUnparsed)
+            ? filterValueUnparsed
+            : null;
+          break;
+
+        case filterTypes.INPUT_TEXT:
+          // does not need parsing
+          filterValueParsed = filterValueUnparsed;
+          break;
+
+        case filterTypes.CATEGORIZED_VALUE:
+          // look up category value in store, sub-value stays untouched
+          if (store) {
+            const category = store.allItems.find((element) => {
+              return (
+                element[filterValueProperty] === filterValueUnparsed.category
+              );
+            });
+            filterValueParsed = {
+              category: category,
+              value: filterValueUnparsed.value,
+            };
+          }
+          break;
+
+        // Unsupported filter types will be ignored
+        default:
+          console.log(
+            `Unsupported filter type found: ${filterNameObject.type}`,
+          );
+          continue;
+      }
+
+      // If filter value was successfully parsed add it to the new filter object
+      if (filterValueParsed) {
+        parsedFilters[filterName] = filterValueParsed;
+      }
+    }
+
+    // Set filters in store (evemts will auto-reload)
+    filterStore.bulkSetFilters({
+      filterType: "events",
+      filters: parsedFilters,
+    });
+  }
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -3,6 +3,7 @@ import AnalyzeAlert from "@/pages/Alerts/AnalyzeAlert.vue";
 import ViewAlert from "@/pages/Alerts/ViewAlert.vue";
 import ViewAnalysis from "@/pages/Alerts/ViewAnalysis.vue";
 import ManageAlerts from "@/pages/Alerts/ManageAlerts.vue";
+import ManageEvents from "@/pages/Events/ManageEvents.vue";
 import TheLogin from "@/pages/User/TheLogin.vue";
 import { useAuthStore } from "@/stores/auth";
 
@@ -16,6 +17,11 @@ const routes: Array<RouteRecordRaw> = [
     path: "/manage_alerts",
     name: "Manage Alerts",
     component: ManageAlerts,
+  },
+  {
+    path: "/manage_events",
+    name: "Manage Events",
+    component: ManageEvents,
   },
   {
     path: "/analyze",

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -1,14 +1,45 @@
+import { isObject } from "@/etc/helpers";
 import {
   eventCreate,
+  eventFilterParams,
   eventRead,
   eventReadPage,
   eventUpdate,
 } from "@/models/event";
-import { pageOptionParams, UUID } from "@/models/base";
+import { UUID } from "@/models/base";
 import { BaseApi } from "./base";
+import { eventFilters } from "@/etc/constants";
 
 const api = new BaseApi();
 const endpoint = "/event/";
+
+export function formatForAPI(
+  params: eventFilterParams,
+): Record<string, string> {
+  const formattedParams = {} as eventFilterParams;
+  for (const param in params) {
+    let paramValue = params[param] as any;
+
+    //  check if the given param is specific to events and not pageOptionParams, i.e. disposition
+    const filterType = eventFilters.find((filter) => {
+      return filter.name === param;
+    });
+
+    // if so, check if the param's value needs to be formatted, and replace with the newly formatted val
+    if (filterType) {
+      // First check if there is a method provided to get string representation
+      if (filterType.stringRepr) {
+        paramValue = filterType.stringRepr(paramValue) as never;
+        // Otherwise check if the param's value is a specific property
+      } else if (filterType.valueProperty && isObject(paramValue)) {
+        paramValue = paramValue[filterType.valueProperty];
+      }
+    }
+
+    formattedParams[param] = paramValue;
+  }
+  return formattedParams;
+}
 
 export const Event = {
   create: (data: eventCreate, getAfterCreate = false): Promise<void> => {
@@ -23,8 +54,13 @@ export const Event = {
     return api.readAll(endpoint);
   },
 
-  readPage: (params?: pageOptionParams): Promise<eventReadPage> => {
-    return api.read(`${endpoint}`, params);
+  readPage: (params?: eventFilterParams): Promise<eventReadPage> => {
+    let formattedParams = {} as eventFilterParams;
+    if (params) {
+      formattedParams = formatForAPI(params);
+    }
+
+    return api.read(`${endpoint}`, formattedParams);
   },
 
   update: (data: eventUpdate[]): Promise<void> => {

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -27,7 +27,7 @@ export const Event = {
     return api.read(`${endpoint}`, params);
   },
 
-  update: (uuid: UUID, data: eventUpdate): Promise<void> => {
-    return api.update(`${endpoint}${uuid}`, data);
+  update: (data: eventUpdate[]): Promise<void> => {
+    return api.update(`${endpoint}`, data);
   },
 };

--- a/frontend/src/services/api/eventPreventionTool.ts
+++ b/frontend/src/services/api/eventPreventionTool.ts
@@ -1,0 +1,38 @@
+import {
+  eventPreventionToolCreate,
+  eventPreventionToolRead,
+  eventPreventionToolReadPage,
+  eventPreventionToolUpdate,
+} from "@/models/eventPreventionTool";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/prevention_tool/";
+
+export const EventPreventionTool = {
+  create: (
+    data: eventPreventionToolCreate,
+    getAfterCreate = false,
+  ): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventPreventionToolRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventPreventionToolRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (
+    params?: pageOptionParams,
+  ): Promise<eventPreventionToolReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventPreventionToolUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventQueue.ts
+++ b/frontend/src/services/api/eventQueue.ts
@@ -1,0 +1,33 @@
+import {
+  eventQueueCreate,
+  eventQueueRead,
+  eventQueueReadPage,
+  eventQueueUpdate,
+} from "@/models/eventQueue";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/queue/";
+
+export const EventQueue = {
+  create: (data: eventQueueCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventQueueRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventQueueRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventQueueReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventQueueUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventRiskLevel.ts
+++ b/frontend/src/services/api/eventRiskLevel.ts
@@ -1,0 +1,36 @@
+import {
+  eventRiskLevelCreate,
+  eventRiskLevelRead,
+  eventRiskLevelReadPage,
+  eventRiskLevelUpdate,
+} from "@/models/eventRiskLevel";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/risk_level/";
+
+export const EventRiskLevel = {
+  create: (
+    data: eventRiskLevelCreate,
+    getAfterCreate = false,
+  ): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventRiskLevelRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventRiskLevelRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventRiskLevelReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventRiskLevelUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventSource.ts
+++ b/frontend/src/services/api/eventSource.ts
@@ -1,0 +1,33 @@
+import {
+  eventSourceCreate,
+  eventSourceRead,
+  eventSourceReadPage,
+  eventSourceUpdate,
+} from "@/models/eventSource";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/source/";
+
+export const EventSource = {
+  create: (data: eventSourceCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventSourceRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventSourceRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventSourceReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventSourceUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventStatus.ts
+++ b/frontend/src/services/api/eventStatus.ts
@@ -1,0 +1,33 @@
+import {
+  eventStatusCreate,
+  eventStatusRead,
+  eventStatusReadPage,
+  eventStatusUpdate,
+} from "@/models/eventStatus";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/status/";
+
+export const EventStatus = {
+  create: (data: eventStatusCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventStatusRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventStatusRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventStatusReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventStatusUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventType.ts
+++ b/frontend/src/services/api/eventType.ts
@@ -1,0 +1,33 @@
+import {
+  eventTypeCreate,
+  eventTypeRead,
+  eventTypeReadPage,
+  eventTypeUpdate,
+} from "@/models/eventType";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/type/";
+
+export const EventType = {
+  create: (data: eventTypeCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventTypeRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventTypeRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventTypeReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventTypeUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/services/api/eventVector.ts
+++ b/frontend/src/services/api/eventVector.ts
@@ -1,0 +1,33 @@
+import {
+  eventVectorCreate,
+  eventVectorRead,
+  eventVectorReadPage,
+  eventVectorUpdate,
+} from "@/models/eventVector";
+import { pageOptionParams, UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/event/vector/";
+
+export const EventVector = {
+  create: (data: eventVectorCreate, getAfterCreate = false): Promise<void> => {
+    return api.create(endpoint, data, getAfterCreate);
+  },
+
+  read: (uuid: UUID): Promise<eventVectorRead> => {
+    return api.read(`${endpoint}${uuid}`);
+  },
+
+  readAll: (): Promise<eventVectorRead[]> => {
+    return api.readAll(endpoint);
+  },
+
+  readPage: (params?: pageOptionParams): Promise<eventVectorReadPage> => {
+    return api.read(`${endpoint}`, params);
+  },
+
+  update: (uuid: UUID, data: eventVectorUpdate): Promise<void> => {
+    return api.update(`${endpoint}${uuid}`, data);
+  },
+};

--- a/frontend/src/stores/event.ts
+++ b/frontend/src/stores/event.ts
@@ -1,24 +1,36 @@
 import { defineStore } from "pinia";
-import { eventRead } from "@/models/event";
+import { eventRead, eventUpdate } from "@/models/event";
 import { Event } from "@/services/api/event";
+import { UUID } from "@/models/base";
 
 export const useEventStore = defineStore({
   id: "eventStore",
 
   state: () => ({
-    items: [] as eventRead[],
+    openEvent: null as unknown as eventRead,
+
+    // whether the event should be reloaded
+    requestReload: false,
   }),
 
-  getters: {
-    allItems(): eventRead[] {
-      return this.items;
-    },
-  },
-
   actions: {
-    async readAll() {
-      // this.items = await Event.readAll();
-      this.items = [];
+    async read(uuid: UUID) {
+      await Event.read(uuid)
+        .then((event) => {
+          this.openEvent = event;
+        })
+        .catch((error) => {
+          throw error;
+        });
+    },
+
+    async update(data: eventUpdate[]) {
+      // once we get around to updating events, we will need to update the base api service to have a
+      // 'getAfterUpdate' option like there is for 'create'
+      // then we can reset the open/queried event(s)
+      await Event.update(data).catch((error) => {
+        throw error;
+      });
     },
   },
 });

--- a/frontend/src/stores/eventPreventionTool.ts
+++ b/frontend/src/stores/eventPreventionTool.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventPreventionToolRead } from "@/models/eventPreventionTool";
+import { EventPreventionTool } from "@/services/api/eventPreventionTool";
+
+export const useEventPreventionToolStore = defineStore({
+  id: "eventPreventionToolStore",
+
+  state: () => ({
+    items: [] as eventPreventionToolRead[],
+  }),
+
+  getters: {
+    allItems(): eventPreventionToolRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventPreventionTool.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventQueue.ts
+++ b/frontend/src/stores/eventQueue.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventQueueRead } from "@/models/eventQueue";
+import { EventQueue } from "@/services/api/eventQueue";
+
+export const useEventQueueStore = defineStore({
+  id: "eventQueueStore",
+
+  state: () => ({
+    items: [] as eventQueueRead[],
+  }),
+
+  getters: {
+    allItems(): eventQueueRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventQueue.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventRiskLevel.ts
+++ b/frontend/src/stores/eventRiskLevel.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventRiskLevelRead } from "@/models/eventRiskLevel";
+import { EventRiskLevel } from "@/services/api/eventRiskLevel";
+
+export const useEventRiskLevelStore = defineStore({
+  id: "eventRiskLevelStore",
+
+  state: () => ({
+    items: [] as eventRiskLevelRead[],
+  }),
+
+  getters: {
+    allItems(): eventRiskLevelRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventRiskLevel.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventSource.ts
+++ b/frontend/src/stores/eventSource.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventSourceRead } from "@/models/eventSource";
+import { EventSource } from "@/services/api/eventSource";
+
+export const useEventSourceStore = defineStore({
+  id: "eventSourceStore",
+
+  state: () => ({
+    items: [] as eventSourceRead[],
+  }),
+
+  getters: {
+    allItems(): eventSourceRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventSource.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventStatus.ts
+++ b/frontend/src/stores/eventStatus.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventStatusRead } from "@/models/eventStatus";
+import { EventStatus } from "@/services/api/eventStatus";
+
+export const useEventStatusStore = defineStore({
+  id: "eventStatusStore",
+
+  state: () => ({
+    items: [] as eventStatusRead[],
+  }),
+
+  getters: {
+    allItems(): eventStatusRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventStatus.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventTable.ts
+++ b/frontend/src/stores/eventTable.ts
@@ -5,7 +5,7 @@ import { eventFilterParams, eventRead, eventSummary } from "@/models/event";
 
 export function parseEventSummary(event: eventRead): eventSummary {
   return {
-    date: event.creationTime,
+    createdTime: event.creationTime,
     // disposition: event.disposition,  // Need to edit the API so that it adds disposition into the Event response
     name: event.name,
     owner: event.owner ? event.owner.displayName : "None",

--- a/frontend/src/stores/eventTable.ts
+++ b/frontend/src/stores/eventTable.ts
@@ -1,0 +1,64 @@
+import { defineStore } from "pinia";
+import { UUID } from "@/models/base";
+import { Event } from "@/services/api/event";
+import { eventFilterParams, eventRead, eventSummary } from "@/models/event";
+
+export function parseEventSummary(event: eventRead): eventSummary {
+  return {
+    date: event.creationTime,
+    // disposition: event.disposition,  // Need to edit the API so that it adds disposition into the Event response
+    name: event.name,
+    owner: event.owner ? event.owner.displayName : "None",
+    preventionTools: event.preventionTools.map((x) => x.value),
+    riskLevel: event.riskLevel ? event.riskLevel.value : "None",
+    status: event.status ? event.status.value : "None",
+    threatActors: event.threatActors.map((x) => x.value),
+    threats: event.threats.map((x) => x.value),
+    type: event.type ? event.type.value : "None",
+    uuid: event.uuid,
+    vectors: event.vectors.map((x) => x.value),
+  };
+}
+
+export const useEventTableStore = defineStore({
+  id: "eventTableStore",
+
+  state: () => ({
+    // all events returned from the current page using the current filters
+    visibleQueriedEvents: [] as eventRead[],
+
+    // total number of events from all pages
+    totalEvents: 0,
+
+    // whether the event table should be reloaded
+    requestReload: false,
+  }),
+
+  getters: {
+    visibleQueriedEventSummaries(): eventSummary[] {
+      return this.visibleQueriedEvents.map((x) => parseEventSummary(x));
+    },
+
+    visibleQueriedEventsUuids(): UUID[] {
+      return this.visibleQueriedEvents.map((x) => x.uuid);
+    },
+
+    visibleQueriedEventById: (state) => {
+      return (eventUuid: UUID) =>
+        state.visibleQueriedEvents.find((event) => event.uuid === eventUuid);
+    },
+  },
+
+  actions: {
+    async readPage(params: eventFilterParams) {
+      await Event.readPage(params)
+        .then((page) => {
+          this.visibleQueriedEvents = page.items;
+          this.totalEvents = page.total;
+        })
+        .catch((error) => {
+          throw error;
+        });
+    },
+  },
+});

--- a/frontend/src/stores/eventType.ts
+++ b/frontend/src/stores/eventType.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventTypeRead } from "@/models/eventType";
+import { EventType } from "@/services/api/eventType";
+
+export const useEventTypeStore = defineStore({
+  id: "eventTypeStore",
+
+  state: () => ({
+    items: [] as eventTypeRead[],
+  }),
+
+  getters: {
+    allItems(): eventTypeRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventType.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/eventVector.ts
+++ b/frontend/src/stores/eventVector.ts
@@ -1,0 +1,23 @@
+import { defineStore } from "pinia";
+import { eventVectorRead } from "@/models/eventVector";
+import { EventVector } from "@/services/api/eventVector";
+
+export const useEventVectorStore = defineStore({
+  id: "eventVectorStore",
+
+  state: () => ({
+    items: [] as eventVectorRead[],
+  }),
+
+  getters: {
+    allItems(): eventVectorRead[] {
+      return this.items;
+    },
+  },
+
+  actions: {
+    async readAll() {
+      this.items = await EventVector.readAll();
+    },
+  },
+});

--- a/frontend/src/stores/filter.ts
+++ b/frontend/src/stores/filter.ts
@@ -4,41 +4,47 @@ import {
   alertFilterValues,
   alertFilterNameTypes,
 } from "@/models/alert";
+import {
+  eventFilterNameTypes,
+  eventFilterParams,
+  eventFilterValues,
+} from "@/models/event";
 
 export const useFilterStore = defineStore({
   id: "filterStore",
 
   state: () => ({
     alerts: {} as alertFilterParams,
+    events: {} as eventFilterParams,
   }),
 
   actions: {
     bulkSetFilters(payload: {
-      filterType: "alerts";
-      filters: alertFilterParams;
+      filterType: "alerts" | "events";
+      filters: alertFilterParams | eventFilterParams;
     }) {
       this.$state[payload.filterType] = payload.filters;
       localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
     setFilter(payload: {
-      filterType: "alerts";
-      filterName: alertFilterNameTypes;
-      filterValue: alertFilterValues;
+      filterType: "alerts" | "events";
+      filterName: alertFilterNameTypes | eventFilterNameTypes;
+      filterValue: alertFilterValues | eventFilterValues;
     }) {
       this.$state[payload.filterType][payload.filterName] = payload.filterValue;
       localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
     unsetFilter(payload: {
-      filterType: "alerts";
-      filterName: alertFilterNameTypes;
+      filterType: "alerts" | "events";
+      filterName: alertFilterNameTypes | eventFilterNameTypes;
     }) {
       delete this.$state[payload.filterType][payload.filterName];
       localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },
 
-    clearAll(payload: { filterType: "alerts" }) {
+    clearAll(payload: { filterType: "alerts" | "events" }) {
       this.$state[payload.filterType] = {};
       localStorage.setItem("aceFilters", JSON.stringify(this.$state));
     },

--- a/frontend/src/stores/selectedEvent.ts
+++ b/frontend/src/stores/selectedEvent.ts
@@ -1,0 +1,39 @@
+import { defineStore } from "pinia";
+
+import { UUID } from "@/models/base";
+
+export const useSelectedEventStore = defineStore({
+  id: "selectedEventStore",
+
+  state: () => ({
+    selected: [] as UUID[],
+  }),
+
+  getters: {
+    anySelected(): boolean {
+      return this.selected.length > 0;
+    },
+
+    multipleSelected(): boolean {
+      return this.selected.length > 1;
+    },
+  },
+
+  actions: {
+    select(uuid: UUID) {
+      this.selected.push(uuid);
+    },
+
+    selectAll(uuids: UUID[]) {
+      this.selected = uuids;
+    },
+
+    unselect(uuid: UUID) {
+      this.selected = this.selected.filter((u) => u !== uuid);
+    },
+
+    unselectAll() {
+      this.selected = [];
+    },
+  },
+});

--- a/frontend/tests/unit/src/App.spec.ts
+++ b/frontend/tests/unit/src/App.spec.ts
@@ -70,7 +70,10 @@ describe("App setup", () => {
       filters: { alerts: { tags: ["tag1"] } },
     });
 
-    expect(filterStore.$state).toEqual({ alerts: { tags: ["tag1"] } });
+    expect(filterStore.$state).toEqual({
+      alerts: { tags: ["tag1"] },
+      events: {},
+    });
   });
 
   it("will not hydrate the filter store from localStorage if the user is not authenticated", () => {
@@ -79,6 +82,6 @@ describe("App setup", () => {
       filters: { alerts: { tags: ["tag1"] } },
     });
 
-    expect(filterStore.$state).toEqual({ alerts: {} });
+    expect(filterStore.$state).toEqual({ alerts: {}, events: {} });
   });
 });

--- a/frontend/tests/unit/src/store/filter.spec.ts
+++ b/frontend/tests/unit/src/store/filter.spec.ts
@@ -38,6 +38,7 @@ describe("filters Actions", () => {
       alerts: {
         testFilterName: "testFilterValue",
       },
+      events: {},
     };
 
     expect(store.$state).toEqual(expectedState);
@@ -63,6 +64,7 @@ describe("filters Actions", () => {
       alerts: {
         testFilterName4: "testFilterValue",
       },
+      events: {},
     });
   });
 
@@ -80,6 +82,7 @@ describe("filters Actions", () => {
       alerts: {
         testFilterName: "testFilterValue",
       },
+      events: {},
     };
 
     expect(store.$state).toEqual(expectedState);
@@ -99,6 +102,7 @@ describe("filters Actions", () => {
 
     expect(store.$state).toEqual({
       alerts: {},
+      events: {},
     });
 
     store.setFilter({
@@ -109,19 +113,20 @@ describe("filters Actions", () => {
 
     expect(store.$state).toEqual({
       alerts: {},
+      events: {},
     });
   });
 
   it("will delete a given property for a given filter object upon the unsetFilter action", () => {
-    store.$state = { alerts: { name: "test" } };
+    store.$state = { alerts: { name: "test" }, events: {} };
     localStorage.setItem(
       "aceFilters",
-      JSON.stringify({ alerts: { name: "test" } }),
+      JSON.stringify({ alerts: { name: "test" }, events: {} }),
     );
 
     expect(store.alerts).toStrictEqual({ name: "test" });
     expect(localStorage.getItem("aceFilters")).toStrictEqual(
-      JSON.stringify({ alerts: { name: "test" } }),
+      JSON.stringify({ alerts: { name: "test" }, events: {} }),
     );
 
     store.unsetFilter({
@@ -131,23 +136,33 @@ describe("filters Actions", () => {
 
     expect(store.$state).toEqual({
       alerts: {},
+      events: {},
     });
 
     expect(localStorage.getItem("aceFilters")).toStrictEqual(
-      JSON.stringify({ alerts: {} }),
+      JSON.stringify({ alerts: {}, events: {} }),
     );
   });
 
   it("will delete all properties from a given filter object upon the clearAll action", () => {
-    store.$state = { alerts: { name: "test", description: "test" } };
+    store.$state = {
+      alerts: { name: "test", description: "test" },
+      events: {},
+    };
     localStorage.setItem(
       "aceFilters",
-      JSON.stringify({ alerts: { name: "test", description: "test" } }),
+      JSON.stringify({
+        alerts: { name: "test", description: "test" },
+        events: {},
+      }),
     );
 
     expect(store.alerts).toStrictEqual({ name: "test", description: "test" });
     expect(localStorage.getItem("aceFilters")).toStrictEqual(
-      JSON.stringify({ alerts: { name: "test", description: "test" } }),
+      JSON.stringify({
+        alerts: { name: "test", description: "test" },
+        events: {},
+      }),
     );
 
     store.clearAll({
@@ -156,10 +171,11 @@ describe("filters Actions", () => {
 
     expect(store.$state).toEqual({
       alerts: {},
+      events: {},
     });
 
     expect(localStorage.getItem("aceFilters")).toStrictEqual(
-      JSON.stringify({ alerts: {} }),
+      JSON.stringify({ alerts: {}, events: {} }),
     );
   });
 });


### PR DESCRIPTION
Closes #87 

### What this PR does

This PR adds the initial version of the Manage Events page. This includes filtering and sorting events through the API. The table is almost identical in function to the Manage Alerts table with the exception that some of the columns are not sortable (the ones with many-to-many relationships).

### What this PR does not do

- This PR introduces a good deal of duplicated code, since most of it was copied from various alert related files that support the Manage Alerts page. Now that the Manage Events page exists, we will use this as an opportunity to refactor some of the Vue components and supporting code to DRY up the project.
- This PR does not add any frontend tests for the new Manage Events page, the new event related API services, nor the event related data stores. Those tests will come in a follow-up PR.
- It also does not add the functionality of expanding a row in the events table on the Manage Events page (like how expanding an alert row in the Manage Alerts table shows a list of observables in the alert). Eventually this will show a list of alerts inside of the event.
- There is also some extra work to be done around the various time columns in the events database schema... most of those values can be calculated/inferred based on the alerts inside of the event. However, there will be an option to override them if necessary.

**File changes:**

- backend/app/api/models/event.py: Adds a Pydantic model for updating multiple events at one time
- backend/app/api/routes/event.py: Adds the event filtering and sorting functionality
- backend/app/insert-event.py: Adds more robust command line arguments to insert test events into the database
- backend/app/tests/api/event/test_read.py: Adds tests for the event filtering and sorting functionality
- backend/app/tests/api/event/test_update.py: Updates tests to reflect that you now update multiple events at once\
- backend/app/tests/helpers.py: Enhances the helper function to create an event
- bin/insert-event.sh: Adds a helper script to add an event into the database
- frontend/src/components/Events/TheEventActionToolbar.vue: Mostly a copy of TheAlertActionToolbar
- frontend/src/components/Events/TheEventsTable.vue: Mostly a copy of TheAlertsTable
- frontend/src/components/Filters/FilterChip.vue: Adds event filters to the logic
- frontend/src/components/Filters/TheFilterToolbar.vue: Adds manage_events to the logic of creating the link
- frontend/src/components/UserInterface/TheHeader.vue: Enables the Events link in the header
- frontend/src/etc/constants.ts: Adds event filters
- frontend/src/etc/helpers.ts: Adds event related items to the populateCommonStores function
- frontend/src/models/event.ts: Mostly a copy of the logic for the alert models
- frontend/src/pages/Events/ManageEvents.vue: Mostly a copy of ManageAlerts
- frontend/src/router/index.ts: Adds the Manage Events as a page/route
- frontend/src/services/api/event.ts: Mostly a copy of the alerts API service
- frontend/src/services/api/event*.ts: Adds various event related API services
- frontend/src/stores/event.ts: Mostly a copy of the alert store
- frontend/src/stores/event*.ts: Adds various event related data stores
- frontend/src/stores/eventTable.ts: Mostly a copy of the alertTable store
- frontend/src/stores/filter.ts: Adds event filters to the logic
- frontend/src/stores/selectedEvent.ts: Mostly a copy of selectedAlert
- frontend/tests/unit/src/App.spec.ts: Adds event filters to the logic
- frontend/tests/unit/src/store/filter.spec.ts: Adds event filters to the logic