### PR TITLE
Fix multiple API calls when row in TheAlertsTable/TheEventsTable expanded

### DIFF
--- a/frontend/src/components/Alerts/AlertTableExpansion.vue
+++ b/frontend/src/components/Alerts/AlertTableExpansion.vue
@@ -12,7 +12,7 @@
   </div>
   <ul v-else>
     <!-- List each observable with link to filter -->
-    <li v-for="obs of props.observables" :key="obs.value">
+    <li v-for="obs of observables" :key="obs.value">
       <span class="link-text" @click="filterByObservable(obs)">{{
         formatObservable(obs)
       }}</span>
@@ -29,11 +29,11 @@
   import NodeTagVue from "../Node/NodeTag.vue";
 
   const props = defineProps({
-    observables: { type: Array, required: false, default: () => [] },
+    observables: { type: [Array, null], required: true },
   });
 
   const isLoading = computed(() => {
-    return props.observables == undefined;
+    return props.observables === null;
   });
 
   const formatObservable = (observable) => {

--- a/frontend/src/components/Alerts/AlertTableExpansion.vue
+++ b/frontend/src/components/Alerts/AlertTableExpansion.vue
@@ -2,7 +2,15 @@
 <!-- Contains logic and functionality for displaying data in alert row dropdown, currently list of alert's observables -->
 
 <template>
-  <ul>
+  <div v-if="isLoading" style="flex: 1">
+    <ul>
+      <li><Skeleton width="30%"></Skeleton></li>
+      <li><Skeleton width="25%"></Skeleton></li>
+      <li><Skeleton width="30%"></Skeleton></li>
+      <li><Skeleton width="25%"></Skeleton></li>
+    </ul>
+  </div>
+  <ul v-else>
     <!-- List each observable with link to filter -->
     <li v-for="obs of props.observables" :key="obs.value">
       <span class="link-text" @click="filterByObservable(obs)">{{
@@ -15,11 +23,17 @@
 </template>
 
 <script setup>
-  import { defineProps } from "vue";
+  import { computed, defineProps } from "vue";
+  import Skeleton from "primevue/skeleton";
+
   import NodeTagVue from "../Node/NodeTag.vue";
 
   const props = defineProps({
-    observables: { type: Array, required: true },
+    observables: { type: Array, required: false, default: () => [] },
+  });
+
+  const isLoading = computed(() => {
+    return props.observables == undefined;
   });
 
   const formatObservable = (observable) => {

--- a/frontend/src/components/Alerts/AlertTableExpansion.vue
+++ b/frontend/src/components/Alerts/AlertTableExpansion.vue
@@ -4,7 +4,7 @@
 <template>
   <ul>
     <!-- List each observable with link to filter -->
-    <li v-for="obs of observables" :key="obs.value">
+    <li v-for="obs of props.observables" :key="obs.value">
       <span class="link-text" @click="filterByObservable(obs)">{{
         formatObservable(obs)
       }}</span>
@@ -15,36 +15,12 @@
 </template>
 
 <script setup>
-  import { ref, defineProps, onMounted } from "vue";
-
+  import { defineProps } from "vue";
   import NodeTagVue from "../Node/NodeTag.vue";
 
-  import { NodeTree } from "@/services/api/nodeTree";
-
-  const observables = ref(null);
-
-  onMounted(async () => {
-    await getObservables(props.uuid);
-  });
-
   const props = defineProps({
-    uuid: { type: String, required: true },
+    observables: { type: Array, required: true },
   });
-
-  const getObservables = async (uuid) => {
-    const unsortedObservables = await NodeTree.readNodesOfNodeTree(
-      [uuid],
-      "observable",
-    );
-
-    observables.value = unsortedObservables.sort((a, b) => {
-      if (a.type.value === b.type.value) {
-        return a.value < b.value ? -1 : 1;
-      } else {
-        return a.type.value < b.type.value ? -1 : 1;
-      }
-    });
-  };
 
   const formatObservable = (observable) => {
     return `${observable.type.value} : ${observable.value}`;

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -14,25 +14,14 @@
     <!-- Row Expansion -->
     <template #rowExpansion="{ data }">
       <AlertTableExpansion
-        v-if="alertObservables[data.uuid]"
         :observables="alertObservables[data.uuid]"
       ></AlertTableExpansion>
-      <div v-else style="flex: 1">
-        <ul>
-          <li><Skeleton width="30%"></Skeleton></li>
-          <li><Skeleton width="25%"></Skeleton></li>
-          <li><Skeleton width="30%"></Skeleton></li>
-          <li><Skeleton width="25%"></Skeleton></li>
-        </ul>
-      </div>
     </template>
   </TheNodeTable>
 </template>
 
 <script setup>
   import { ref } from "vue";
-
-  import Skeleton from "primevue/skeleton";
 
   import TheNodeTable from "../Node/TheNodeTable";
   import AlertTableCell from "./AlertTableCell";

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -44,6 +44,8 @@
 
   const onRowExpand = async (event) => {
     const alertUuid = event.data.uuid;
+    // Set to null first so AlertTableExpansion can show loading
+    alertObservables.value[alertUuid] = null;
     alertObservables.value[alertUuid] = await getObservables(alertUuid);
   };
   const onRowCollapse = (event) => {

--- a/frontend/src/components/Alerts/TheAlertsTable.vue
+++ b/frontend/src/components/Alerts/TheAlertsTable.vue
@@ -2,24 +2,29 @@
 <!-- The table where all currently filtered alerts are displayed, selected to take action, or link to an individual alert page -->
 
 <template>
-  <TheNodeTable :columns="columns">
+  <TheNodeTable
+    :columns="columns"
+    @rowExpand="onRowExpand"
+    @rowCollapse="onRowCollapse"
+  >
     <template #rowCell="{ data, field }">
       <AlertTableCell :data="data" :field="field"></AlertTableCell>
     </template>
 
     <!-- Row Expansion -->
     <template #rowExpansion="{ data }">
-      <suspense>
-        <template #fallback>
-          <ul></ul>
-        </template>
-        <template #default>
-          <AlertTableExpansion
-            :uuid="data.uuid"
-            :data="data"
-          ></AlertTableExpansion>
-        </template>
-      </suspense>
+      <AlertTableExpansion
+        v-if="alertObservables[data.uuid]"
+        :observables="alertObservables[data.uuid]"
+      ></AlertTableExpansion>
+      <div v-else style="flex: 1">
+        <ul>
+          <li><Skeleton width="30%"></Skeleton></li>
+          <li><Skeleton width="25%"></Skeleton></li>
+          <li><Skeleton width="30%"></Skeleton></li>
+          <li><Skeleton width="25%"></Skeleton></li>
+        </ul>
+      </div>
     </template>
   </TheNodeTable>
 </template>
@@ -27,9 +32,12 @@
 <script setup>
   import { ref } from "vue";
 
+  import Skeleton from "primevue/skeleton";
+
   import TheNodeTable from "../Node/TheNodeTable";
   import AlertTableCell from "./AlertTableCell";
   import AlertTableExpansion from "./AlertTableExpansion";
+  import { NodeTree } from "@/services/api/nodeTree";
 
   const columns = ref([
     { field: "dispositionTime", header: "Dispositioned Time", default: false },
@@ -42,6 +50,32 @@
     { field: "queue", header: "Queue", default: false },
     { field: "type", header: "Type", default: false },
   ]);
+
+  const alertObservables = ref({});
+
+  const onRowExpand = async (event) => {
+    const alertUuid = event.data.uuid;
+    alertObservables.value[alertUuid] = await getObservables(alertUuid);
+  };
+  const onRowCollapse = (event) => {
+    const alertUuid = event.data.uuid;
+    delete alertObservables.value[alertUuid];
+  };
+
+  const getObservables = async (uuid) => {
+    const unsortedObservables = await NodeTree.readNodesOfNodeTree(
+      [uuid],
+      "observable",
+    );
+
+    return unsortedObservables.sort((a, b) => {
+      if (a.type.value === b.type.value) {
+        return a.value < b.value ? -1 : 1;
+      } else {
+        return a.type.value < b.type.value ? -1 : 1;
+      }
+    });
+  };
 </script>
 
 <style>

--- a/frontend/src/components/Events/EventTableExpansion.vue
+++ b/frontend/src/components/Events/EventTableExpansion.vue
@@ -2,8 +2,10 @@
 <!-- Contains logic and functionality for displaying data in event row dropdown, currently table of alerts -->
 
 <template>
+  <div v-if="isLoading">Loading alerts, please hold...</div>
   <DataTable
-    :value="alerts"
+    v-else
+    :value="props.alerts"
     :paginator="true"
     :rows="10"
     paginator-template="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
@@ -11,10 +13,8 @@
     :total-records="alerts.length"
     responsive-layout="scroll"
     current-page-report-template="Showing {first} to {last} of {totalRecords} alerts in the event"
-    :loading="isLoading"
     data-cy="expandedEvent"
   >
-    <template #loading>Loading alerts, please wait...</template>
     <Column
       v-for="col of columns"
       :key="col.field"
@@ -28,44 +28,24 @@
 </template>
 
 <script setup>
-  import { ref, defineProps, onMounted } from "vue";
+  import { computed, defineProps } from "vue";
 
   import Column from "primevue/column";
   import DataTable from "primevue/datatable";
 
   import AlertTableCell from "../Alerts/AlertTableCell.vue";
-
-  import { Alert } from "@/services/api/alert";
-  import { parseAlertSummary } from "@/etc/helpers";
-
-  const alerts = ref([]);
-  const isLoading = ref(false);
-
   const columns = [
     { field: "eventTime", header: "Event Time" },
     { field: "name", header: "Name" },
     { field: "owner", header: "Owner" },
     { field: "disposition", header: "Disposition" },
   ];
-
-  onMounted(async () => {
-    await getAlerts(props.uuid);
-  });
-
   const props = defineProps({
-    uuid: { type: String, required: true },
+    alerts: { type: Array, required: false, default: () => [] },
   });
-
-  const getAlerts = async (uuid) => {
-    isLoading.value = true;
-    const allAlerts = await Alert.readAllPages({
-      eventUuid: uuid,
-      sort: "event_time|asc",
-    });
-
-    alerts.value = allAlerts.map((x) => parseAlertSummary(x));
-    isLoading.value = false;
-  };
+  const isLoading = computed(() => {
+    return props.alerts == undefined;
+  });
 </script>
 
 <style>

--- a/frontend/src/components/Events/EventTableExpansion.vue
+++ b/frontend/src/components/Events/EventTableExpansion.vue
@@ -5,7 +5,7 @@
   <div v-if="isLoading">Loading alerts, please hold...</div>
   <DataTable
     v-else
-    :value="props.alerts"
+    :value="alerts"
     :paginator="true"
     :rows="10"
     paginator-template="CurrentPageReport FirstPageLink PrevPageLink PageLinks NextPageLink LastPageLink RowsPerPageDropdown"
@@ -41,10 +41,10 @@
     { field: "disposition", header: "Disposition" },
   ];
   const props = defineProps({
-    alerts: { type: Array, required: false, default: () => [] },
+    alerts: { type: [Array, null], required: true },
   });
   const isLoading = computed(() => {
-    return props.alerts == undefined;
+    return props.alerts === null;
   });
 </script>
 

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -63,6 +63,7 @@
 
   const onRowExpand = async (event) => {
     const eventUuid = event.data.uuid;
+    eventAlerts.value[eventUuid] = null;
     eventAlerts.value[eventUuid] = await getAlerts(eventUuid);
   };
   const onRowCollapse = (event) => {

--- a/frontend/src/components/Events/TheEventsTable.vue
+++ b/frontend/src/components/Events/TheEventsTable.vue
@@ -3,24 +3,20 @@
 <!-- The table where all currently filtered events are displayed, selected to take action, or link to an individual event page -->
 
 <template>
-  <TheNodeTable :columns="columns">
+  <TheNodeTable
+    :columns="columns"
+    @rowExpand="onRowExpand"
+    @rowCollapse="onRowCollapse"
+  >
     <template #rowCell="{ data, field }">
       <EventTableCell :data="data" :field="field"></EventTableCell>
     </template>
 
     <!-- Row Expansion -->
     <template #rowExpansion="{ data }">
-      <suspense>
-        <template #fallback>
-          <ul></ul>
-        </template>
-        <template #default>
-          <EventTableExpansion
-            :uuid="data.uuid"
-            :data="data"
-          ></EventTableExpansion>
-        </template>
-      </suspense>
+      <EventTableExpansion
+        :alerts="eventAlerts[data.uuid]"
+      ></EventTableExpansion>
     </template>
   </TheNodeTable>
 </template>
@@ -31,6 +27,9 @@
   import TheNodeTable from "../Node/TheNodeTable";
   import EventTableCell from "./EventTableCell";
   import EventTableExpansion from "./EventTableExpansion";
+
+  import { Alert } from "@/services/api/alert";
+  import { parseAlertSummary } from "@/etc/helpers";
 
   const columns = ref([
     { field: "createdTime", header: "Created", sortable: true, default: true },
@@ -59,4 +58,24 @@
       default: false,
     },
   ]);
+
+  const eventAlerts = ref({});
+
+  const onRowExpand = async (event) => {
+    const eventUuid = event.data.uuid;
+    eventAlerts.value[eventUuid] = await getAlerts(eventUuid);
+  };
+  const onRowCollapse = (event) => {
+    const eventUuid = event.data.uuid;
+    delete eventAlerts.value[eventUuid];
+  };
+
+  const getAlerts = async (uuid) => {
+    const allAlerts = await Alert.readAllPages({
+      eventUuid: uuid,
+      sort: "event_time|asc",
+    });
+
+    return allAlerts.map((x) => parseAlertSummary(x));
+  };
 </script>

--- a/frontend/src/etc/helpers.ts
+++ b/frontend/src/etc/helpers.ts
@@ -283,13 +283,15 @@ export function parseAlertSummary(alert: alertRead): alertSummary {
     comments: alert.comments,
     description: alert.description ? alert.description : "",
     disposition: alert.disposition ? alert.disposition.value : "OPEN",
-    dispositionTime: alert.dispositionTime ? alert.dispositionTime : null,
+    dispositionTime: alert.dispositionTime
+      ? new Date(alert.dispositionTime)
+      : null,
     dispositionUser: alert.dispositionUser
       ? alert.dispositionUser.displayName
       : "None",
-    eventTime: alert.eventTime,
+    eventTime: new Date(alert.eventTime),
     eventUuid: alert.eventUuid ? alert.eventUuid : "None",
-    insertTime: alert.insertTime,
+    insertTime: new Date(alert.insertTime),
     name: alert.name,
     owner: alert.owner ? alert.owner.displayName : "None",
     queue: alert.queue.value,

--- a/frontend/tests/unit/src/components/Alerts/AlertTableExpansion.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AlertTableExpansion.spec.ts
@@ -1,19 +1,26 @@
 import AlertTableExpansion from "@/components/Alerts/AlertTableExpansion.vue";
-import { flushPromises, mount, VueWrapper } from "@vue/test-utils";
+import { mount, VueWrapper } from "@vue/test-utils";
 import { createTestingPinia, TestingOptions } from "@pinia/testing";
 
 import { useFilterStore } from "@/stores/filter";
-import myNock from "@unit/services/api/nock";
-import nock from "nock";
 
-function factory(options: TestingOptions = {}) {
+function factory(
+  options: TestingOptions = {},
+  observables: unknown = [
+    { type: { value: "type_A" }, value: "value_A", tags: [] },
+    { type: { value: "type_A" }, value: "value_C", tags: [] },
+    { type: { value: "type_B" }, value: "value_A", tags: [] },
+    { type: { value: "type_B" }, value: "value_B", tags: [] },
+    { type: { value: "type_C" }, value: "value_C", tags: [] },
+  ],
+) {
   const wrapper: VueWrapper<any> = mount(AlertTableExpansion, {
     global: {
       plugins: [createTestingPinia(options)],
       provide: { nodeType: "alerts" },
     },
     props: {
-      uuid: "uuid1",
+      observables: observables,
     },
   });
 
@@ -23,43 +30,22 @@ function factory(options: TestingOptions = {}) {
 }
 
 describe("AlertTableExpansion", () => {
-  myNock
-    .post("/node/tree/observable", '["uuid1"]')
-    .reply(200, [
-      { type: { value: "type_B" }, value: "value_B", tags: [] },
-      { type: { value: "type_C" }, value: "value_C", tags: [] },
-      { type: { value: "type_B" }, value: "value_A", tags: [] },
-      { type: { value: "type_A" }, value: "value_A", tags: [] },
-      { type: { value: "type_A" }, value: "value_C", tags: [] },
-    ])
-    .persist();
-
-  afterAll(async () => {
-    await flushPromises();
-    nock.cleanAll();
-  });
-
-  it("renders", async () => {
+  it("renders", () => {
     const { wrapper } = factory();
     expect(wrapper.exists()).toBe(true);
   });
 
-  it("correctly fetches, sets, and sorts observables on getObservables", async () => {
-    const { wrapper } = factory();
-
-    await wrapper.vm.getObservables("uuid1");
-
-    expect(wrapper.vm.observables).toEqual([
-      { type: { value: "type_A" }, value: "value_A", tags: [] },
-      { type: { value: "type_A" }, value: "value_C", tags: [] },
-      { type: { value: "type_B" }, value: "value_A", tags: [] },
-
-      { type: { value: "type_B" }, value: "value_B", tags: [] },
-      { type: { value: "type_C" }, value: "value_C", tags: [] },
-    ]);
+  it("correctly computes isLoading as true when observables prop is null", () => {
+    const { wrapper } = factory({}, null);
+    expect(wrapper.vm.isLoading).toBeTruthy();
   });
 
-  it("correctly formats a given observable object into string", async () => {
+  it("correctly computes isLoading as true when observables prop is not null", () => {
+    const { wrapper } = factory();
+    expect(wrapper.vm.isLoading).toBeFalsy();
+  });
+
+  it("correctly formats a given observable object into string", () => {
     const { wrapper } = factory();
     const result = wrapper.vm.formatObservable({
       type: { value: "type_B" },
@@ -69,7 +55,7 @@ describe("AlertTableExpansion", () => {
     expect(result).toEqual("type_B : value_B");
   });
 
-  it("correctly sets an observable filter on filterByObservable", async () => {
+  it("correctly sets an observable filter on filterByObservable", () => {
     const { wrapper, filterStore } = factory({ stubActions: false });
     wrapper.vm.filterByObservable({
       type: { value: "type_B" },

--- a/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/TheAlertsTable.spec.ts
@@ -3,6 +3,7 @@ import { shallowMount, VueWrapper } from "@vue/test-utils";
 import PrimeVue from "primevue/config";
 import { createTestingPinia, TestingOptions } from "@pinia/testing";
 
+import myNock from "@unit/services/api/nock";
 import { createRouterMock, injectRouterMock } from "vue-router-mock";
 
 function factory(options?: TestingOptions) {
@@ -42,5 +43,57 @@ describe("TheAlertsTable data/creation", () => {
       { field: "queue", header: "Queue", default: false },
       { field: "type", header: "Type", default: false },
     ]);
+    expect(wrapper.vm.alertObservables).toEqual({});
+  });
+});
+
+describe("TheAlertsTable methods", () => {
+  it("correctly fetches, sorts, and returns observables on getObservables", async () => {
+    myNock.post("/node/tree/observable", '["uuid1"]').reply(200, [
+      { type: { value: "type_B" }, value: "value_B", tags: [] },
+      { type: { value: "type_C" }, value: "value_C", tags: [] },
+      { type: { value: "type_B" }, value: "value_A", tags: [] },
+      { type: { value: "type_A" }, value: "value_A", tags: [] },
+      { type: { value: "type_A" }, value: "value_C", tags: [] },
+    ]);
+
+    const { wrapper } = factory();
+
+    const result = await wrapper.vm.getObservables("uuid1");
+    expect(result).toEqual([
+      { type: { value: "type_A" }, value: "value_A", tags: [] },
+      { type: { value: "type_A" }, value: "value_C", tags: [] },
+      { type: { value: "type_B" }, value: "value_A", tags: [] },
+      { type: { value: "type_B" }, value: "value_B", tags: [] },
+      { type: { value: "type_C" }, value: "value_C", tags: [] },
+    ]);
+  });
+
+  it("fetches observables and caches in alertObservables for a given alert on onRowExpand", async () => {
+    myNock.post("/node/tree/observable", '["uuid1"]').reply(200, [
+      { type: { value: "type_B" }, value: "value_B", tags: [] },
+      { type: { value: "type_C" }, value: "value_C", tags: [] },
+      { type: { value: "type_B" }, value: "value_A", tags: [] },
+      { type: { value: "type_A" }, value: "value_A", tags: [] },
+      { type: { value: "type_A" }, value: "value_C", tags: [] },
+    ]);
+    const { wrapper } = factory();
+    await wrapper.vm.onRowExpand({ data: { uuid: "uuid1" } });
+    expect(wrapper.vm.alertObservables).toEqual({
+      uuid1: [
+        { type: { value: "type_A" }, value: "value_A", tags: [] },
+        { type: { value: "type_A" }, value: "value_C", tags: [] },
+        { type: { value: "type_B" }, value: "value_A", tags: [] },
+        { type: { value: "type_B" }, value: "value_B", tags: [] },
+        { type: { value: "type_C" }, value: "value_C", tags: [] },
+      ],
+    });
+  });
+
+  it("deletes a given uuid from alertObservables on onRowCollapse", () => {
+    const { wrapper } = factory();
+    wrapper.vm.alertObservables = { uuid1: [], uuid2: [], uuid3: [] };
+    wrapper.vm.onRowCollapse({ data: { uuid: "uuid2" } });
+    expect(wrapper.vm.alertObservables).toEqual({ uuid1: [], uuid3: [] });
   });
 });

--- a/frontend/tests/unit/src/components/Events/TheEventsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Events/TheEventsTable.spec.ts
@@ -2,8 +2,12 @@ import TheEventsTable from "@/components/Events/TheEventsTable.vue";
 import { shallowMount, VueWrapper } from "@vue/test-utils";
 import PrimeVue from "primevue/config";
 import { createTestingPinia, TestingOptions } from "@pinia/testing";
+import myNock from "@unit/services/api/nock";
 
 import { createRouterMock, injectRouterMock } from "vue-router-mock";
+
+import { mockAlertPage } from "../../../../mocks/alert";
+import { parseAlertSummary } from "@/etc/helpers";
 
 function factory(options?: TestingOptions) {
   const router = createRouterMock();
@@ -59,5 +63,42 @@ describe("TheEventsTable data/creation", () => {
         default: false,
       },
     ]);
+  });
+});
+
+// METHODS
+describe("TheEventsTable methods", () => {
+  myNock
+    .get("/alert/?event_uuid=uuid1&sort=event_time|asc&offset=0")
+    .reply(200, mockAlertPage)
+    .persist();
+
+  it("correctly fetches alerts and sets alert summaries on getAlerts", async () => {
+    const { wrapper } = factory();
+
+    const result = await wrapper.vm.getAlerts("uuid1");
+
+    expect(result.length).toStrictEqual(2);
+    expect(result[0].disposition).toStrictEqual("OPEN");
+    expect(result[1].name).toStrictEqual("Manual Alert 1");
+  });
+
+  it("correctly sets the alerts for a given eventUuid in eventAlerts on onRowExpand", async () => {
+    const { wrapper } = factory();
+
+    await wrapper.vm.onRowExpand({ data: { uuid: "uuid1" } });
+
+    const expected = mockAlertPage.items.map((x) => parseAlertSummary(x));
+    expect(wrapper.vm.eventAlerts).toStrictEqual({ uuid1: expected });
+  });
+
+  it("correctly deletes a given eventUuid from eventAlerts on onRowCollapse", () => {
+    const { wrapper } = factory();
+
+    wrapper.vm.eventAlerts = { uuid1: [], uuid2: [], uuid3: [] };
+
+    wrapper.vm.onRowCollapse({ data: { uuid: "uuid2" } });
+
+    expect(wrapper.vm.eventAlerts).toStrictEqual({ uuid1: [], uuid3: [] });
   });
 });


### PR DESCRIPTION
This PR fixes (or works around, rather) a bug in which an API call would be made for every open row in TheAlertsTable/TheEventsTable when any row was toggled (due to a quirk with PrimeVue's DataTable component).

As a workaround, the logic for fetching the data in AlertTable/EventTableExpansions has been moved to the parent 'Table' component, where it is "cached" as long as a row is expanded, and simply passed to the child expansion logic. This way, requests are only made when a row is expanded, but the display logic is still contained in the expansion component.

Detailed file changelist: 
- frontend/src/components/Alerts/AlertTableExpansion.vue
    - Remove API calls
    - Add more stylized 'loading'  
- frontend/src/components/Alerts/TheAlertsTable.vue
    - Add API calls and 'caching' 
- frontend/src/components/Events/EventTableExpansion.vue
    - Remove API calls
    - Fix loading style for new logic
- frontend/src/components/Events/TheEventsTable.vue
    - Add API calls and 'caching' 
- frontend/src/etc/helpers.ts
     - Parse out dates in parseAlertSummary  