### PR TITLE
Calculate event times

### DIFF
--- a/backend/app/api/models/event.py
+++ b/backend/app/api/models/event.py
@@ -84,6 +84,22 @@ class EventCreate(NodeCreate, EventBase):
 class EventRead(NodeRead, EventBase):
     alert_uuids: List[UUID4] = Field(default_factory=list, description="A list of alert UUIDs contained in the event")
 
+    auto_alert_time: Optional[datetime] = Field(
+        description="The automatically calculated time of the earliest insert time from the alerts in the event"
+    )
+
+    auto_disposition_time: Optional[datetime] = Field(
+        description="The automatically calculated earliest time one of the alerts in the event was dispositioned"
+    )
+
+    auto_event_time: Optional[datetime] = Field(
+        description="The automatically calculated time of the earliest event time from the alerts in the event"
+    )
+
+    auto_ownership_time: Optional[datetime] = Field(
+        description="The automatically calculated earliest time an analyst took ownership of one of the alerts"
+    )
+
     comments: List[NodeCommentRead] = Field(description="A list of comments added to the event")
 
     creation_time: datetime = Field(description="The time the event was created")

--- a/backend/app/api/models/history.py
+++ b/backend/app/api/models/history.py
@@ -30,7 +30,7 @@ class HistoryBase(BaseModel):
 
     action: type_str = Field(description="The action that was performed (CREATE/UPDATE/DELETE)")
 
-    action_by: type_str = Field(description="The username that performed the action")
+    action_by: UserRead = Field(description="The user that performed the action")
 
     action_time: datetime = Field(description="The time the action was performed")
 

--- a/backend/app/api/routes/auth.py
+++ b/backend/app/api/routes/auth.py
@@ -70,10 +70,10 @@ def auth(response: Response, form_data: OAuth2PasswordRequestForm = Depends(), d
     if user is None or not user.enabled:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid username or password")
 
-    access_token = create_access_token(sub=user.username, full_name=user.display_name)
+    access_token = create_access_token(sub=user.username)
     _set_access_token_cookie(response, access_token)
 
-    refresh_token = create_refresh_token(sub=user.username, full_name=user.display_name)
+    refresh_token = create_refresh_token(sub=user.username)
     _set_refresh_token_cookie(response, refresh_token)
 
     # Save the refresh token to the database

--- a/backend/app/api/routes/observable.py
+++ b/backend/app/api/routes/observable.py
@@ -81,7 +81,7 @@ def create_observables(
         # Add an entry to the history table
         crud.record_create_history(
             history_table=ObservableHistory,
-            action_by=claims["full_name"],
+            action_by=crud.read_user_by_username(username=claims["sub"], db=db),
             record_read_model=ObservableRead,
             record_table=Observable,
             record_uuid=new_observable.uuid,
@@ -200,7 +200,7 @@ def update_observable(
     # Add the entries to the history table
     crud.record_update_histories(
         history_table=ObservableHistory,
-        action_by=claims["full_name"],
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
         record_read_model=ObservableRead,
         record_table=Observable,
         record_uuid=db_observable.uuid,

--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -59,7 +59,7 @@ def create_user(
     # Add an entry to the history table
     crud.record_create_history(
         history_table=UserHistory,
-        action_by=claims["full_name"],
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
         record_read_model=UserRead,
         record_table=User,
         record_uuid=new_user.uuid,
@@ -179,7 +179,7 @@ def update_user(
     # Add the entries to the history table
     crud.record_update_histories(
         history_table=UserHistory,
-        action_by=claims["full_name"],
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
         record_read_model=UserRead,
         record_table=User,
         record_uuid=db_user.uuid,

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -141,9 +141,13 @@ def record_update_histories(
     record_uuid: UUID,
     diffs: list[Diff],
     db: Session,
+    action_time: Optional[datetime] = None,
 ):
     db_obj = read(uuid=record_uuid, db_table=record_table, db=db)
     snapshot = json.loads(record_read_model(**db_obj.__dict__).json())
+
+    if action_time is None:
+        action_time = datetime.utcnow()
 
     for diff in diffs:
         if diff:
@@ -151,7 +155,7 @@ def record_update_histories(
                 history_table(
                     action="UPDATE",
                     action_by=action_by,
-                    action_time=datetime.utcnow(),
+                    action_time=action_time,
                     record_uuid=record_uuid,
                     field=diff.field,
                     diff={

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -80,7 +80,7 @@ def read_history_records(history_table: DeclarativeMeta, record_uuid: UUID, db: 
 
 def record_create_history(
     history_table: DeclarativeMeta,
-    action_by: str,
+    action_by: User,
     record_read_model: BaseModel,
     record_table: DeclarativeMeta,
     record_uuid: UUID,
@@ -100,7 +100,7 @@ def record_create_history(
     commit(db)
 
 
-def record_comment_history(record_node: Node, action_by: str, diff: Diff, db: Session):
+def record_comment_history(record_node: Node, action_by: User, diff: Diff, db: Session):
     if record_node.node_type == "alert":
         record_update_histories(
             history_table=AlertHistory,
@@ -135,7 +135,7 @@ def record_comment_history(record_node: Node, action_by: str, diff: Diff, db: Se
 
 def record_update_histories(
     history_table: DeclarativeMeta,
-    action_by: str,
+    action_by: User,
     record_read_model: BaseModel,
     record_table: DeclarativeMeta,
     record_uuid: UUID,

--- a/backend/app/db/migrations/versions/7ac462762562_initial.py
+++ b/backend/app/db/migrations/versions/7ac462762562_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: ba73b5b3708c
+Revision ID: 7ac462762562
 Revises: 
-Create Date: 2022-02-07 20:13:52.511694
+Create Date: 2022-02-14 20:47:16.331789
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = 'ba73b5b3708c'
+revision = '7ac462762562'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -26,18 +26,6 @@ def upgrade() -> None:
     sa.UniqueConstraint('rank')
     )
     op.create_index(op.f('ix_alert_disposition_value'), 'alert_disposition', ['value'], unique=True)
-    op.create_table('alert_history',
-    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
-    sa.Column('action', sa.String(), nullable=False),
-    sa.Column('action_by', sa.String(), nullable=False),
-    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
-    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
-    sa.Column('field', sa.String(), nullable=True),
-    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.PrimaryKeyConstraint('uuid')
-    )
-    op.create_index(op.f('ix_alert_history_record_uuid'), 'alert_history', ['record_uuid'], unique=False)
     op.create_table('alert_queue',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -78,18 +66,6 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_analysis_module_type_value'), 'analysis_module_type', ['value'], unique=False)
     op.create_index(op.f('ix_analysis_module_type_version'), 'analysis_module_type', ['version'], unique=False)
-    op.create_table('event_history',
-    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
-    sa.Column('action', sa.String(), nullable=False),
-    sa.Column('action_by', sa.String(), nullable=False),
-    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
-    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
-    sa.Column('field', sa.String(), nullable=True),
-    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.PrimaryKeyConstraint('uuid')
-    )
-    op.create_index(op.f('ix_event_history_record_uuid'), 'event_history', ['record_uuid'], unique=False)
     op.create_table('event_prevention_tool',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -187,18 +163,6 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_node_threat_type_value'), 'node_threat_type', ['value'], unique=True)
-    op.create_table('observable_history',
-    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
-    sa.Column('action', sa.String(), nullable=False),
-    sa.Column('action_by', sa.String(), nullable=False),
-    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
-    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
-    sa.Column('field', sa.String(), nullable=True),
-    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.PrimaryKeyConstraint('uuid')
-    )
-    op.create_index(op.f('ix_observable_history_record_uuid'), 'observable_history', ['record_uuid'], unique=False)
     op.create_table('observable_type',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -206,18 +170,6 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_observable_type_value'), 'observable_type', ['value'], unique=True)
-    op.create_table('user_history',
-    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
-    sa.Column('action', sa.String(), nullable=False),
-    sa.Column('action_by', sa.String(), nullable=False),
-    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
-    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
-    sa.Column('field', sa.String(), nullable=True),
-    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
-    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
-    sa.PrimaryKeyConstraint('uuid')
-    )
-    op.create_index(op.f('ix_user_history_record_uuid'), 'user_history', ['record_uuid'], unique=False)
     op.create_table('user_role',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -403,6 +355,36 @@ def upgrade() -> None:
     )
     op.create_index('comment_value_trgm', 'node_comment', ['value'], unique=False, postgresql_ops={'value': 'gin_trgm_ops'}, postgresql_using='gin')
     op.create_index(op.f('ix_node_comment_node_uuid'), 'node_comment', ['node_uuid'], unique=False)
+    op.create_table('observable_history',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('action', sa.String(), nullable=False),
+    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
+    sa.Column('field', sa.String(), nullable=True),
+    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('action_by_user_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.ForeignKeyConstraint(['action_by_user_uuid'], ['user.uuid'], ),
+    sa.ForeignKeyConstraint(['record_uuid'], ['observable.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_observable_history_action_by_user_uuid'), 'observable_history', ['action_by_user_uuid'], unique=False)
+    op.create_index(op.f('ix_observable_history_record_uuid'), 'observable_history', ['record_uuid'], unique=False)
+    op.create_table('user_history',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('action', sa.String(), nullable=False),
+    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
+    sa.Column('field', sa.String(), nullable=True),
+    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('action_by_user_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.ForeignKeyConstraint(['action_by_user_uuid'], ['user.uuid'], ),
+    sa.ForeignKeyConstraint(['record_uuid'], ['user.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_user_history_action_by_user_uuid'), 'user_history', ['action_by_user_uuid'], unique=False)
+    op.create_index(op.f('ix_user_history_record_uuid'), 'user_history', ['record_uuid'], unique=False)
     op.create_table('user_role_mapping',
     sa.Column('user_uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('user_role_uuid', postgresql.UUID(as_uuid=True), nullable=False),
@@ -451,6 +433,21 @@ def upgrade() -> None:
     op.create_index(op.f('ix_alert_tool_uuid'), 'alert', ['tool_uuid'], unique=False)
     op.create_index(op.f('ix_alert_type_uuid'), 'alert', ['type_uuid'], unique=False)
     op.create_index('name_trgm', 'alert', ['name'], unique=False, postgresql_ops={'name': 'gin_trgm_ops'}, postgresql_using='gin')
+    op.create_table('event_history',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('action', sa.String(), nullable=False),
+    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
+    sa.Column('field', sa.String(), nullable=True),
+    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('action_by_user_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.ForeignKeyConstraint(['action_by_user_uuid'], ['user.uuid'], ),
+    sa.ForeignKeyConstraint(['record_uuid'], ['event.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_event_history_action_by_user_uuid'), 'event_history', ['action_by_user_uuid'], unique=False)
+    op.create_index(op.f('ix_event_history_record_uuid'), 'event_history', ['record_uuid'], unique=False)
     op.create_table('event_prevention_tool_mapping',
     sa.Column('event_uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('prevention_tool_uuid', postgresql.UUID(as_uuid=True), nullable=False),
@@ -478,10 +475,28 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_event_vector_mapping_event_uuid'), 'event_vector_mapping', ['event_uuid'], unique=False)
     op.create_index(op.f('ix_event_vector_mapping_vector_uuid'), 'event_vector_mapping', ['vector_uuid'], unique=False)
+    op.create_table('alert_history',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('action', sa.String(), nullable=False),
+    sa.Column('action_time', sa.DateTime(timezone=True), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=False),
+    sa.Column('field', sa.String(), nullable=True),
+    sa.Column('diff', postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    sa.Column('snapshot', postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+    sa.Column('record_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('action_by_user_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.ForeignKeyConstraint(['action_by_user_uuid'], ['user.uuid'], ),
+    sa.ForeignKeyConstraint(['record_uuid'], ['alert.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_alert_history_action_by_user_uuid'), 'alert_history', ['action_by_user_uuid'], unique=False)
+    op.create_index(op.f('ix_alert_history_record_uuid'), 'alert_history', ['record_uuid'], unique=False)
     # ### end Alembic commands ###
 
 def downgrade() -> None:
     # ### commands auto generated by Alembic - please adjust! ###
+    op.drop_index(op.f('ix_alert_history_record_uuid'), table_name='alert_history')
+    op.drop_index(op.f('ix_alert_history_action_by_user_uuid'), table_name='alert_history')
+    op.drop_table('alert_history')
     op.drop_index(op.f('ix_event_vector_mapping_vector_uuid'), table_name='event_vector_mapping')
     op.drop_index(op.f('ix_event_vector_mapping_event_uuid'), table_name='event_vector_mapping')
     op.drop_table('event_vector_mapping')
@@ -491,6 +506,9 @@ def downgrade() -> None:
     op.drop_index(op.f('ix_event_prevention_tool_mapping_prevention_tool_uuid'), table_name='event_prevention_tool_mapping')
     op.drop_index(op.f('ix_event_prevention_tool_mapping_event_uuid'), table_name='event_prevention_tool_mapping')
     op.drop_table('event_prevention_tool_mapping')
+    op.drop_index(op.f('ix_event_history_record_uuid'), table_name='event_history')
+    op.drop_index(op.f('ix_event_history_action_by_user_uuid'), table_name='event_history')
+    op.drop_table('event_history')
     op.drop_index('name_trgm', table_name='alert', postgresql_ops={'name': 'gin_trgm_ops'}, postgresql_using='gin')
     op.drop_index(op.f('ix_alert_type_uuid'), table_name='alert')
     op.drop_index(op.f('ix_alert_tool_uuid'), table_name='alert')
@@ -507,6 +525,12 @@ def downgrade() -> None:
     op.drop_index(op.f('ix_user_role_mapping_user_uuid'), table_name='user_role_mapping')
     op.drop_index(op.f('ix_user_role_mapping_user_role_uuid'), table_name='user_role_mapping')
     op.drop_table('user_role_mapping')
+    op.drop_index(op.f('ix_user_history_record_uuid'), table_name='user_history')
+    op.drop_index(op.f('ix_user_history_action_by_user_uuid'), table_name='user_history')
+    op.drop_table('user_history')
+    op.drop_index(op.f('ix_observable_history_record_uuid'), table_name='observable_history')
+    op.drop_index(op.f('ix_observable_history_action_by_user_uuid'), table_name='observable_history')
+    op.drop_table('observable_history')
     op.drop_index(op.f('ix_node_comment_node_uuid'), table_name='node_comment')
     op.drop_index('comment_value_trgm', table_name='node_comment', postgresql_ops={'value': 'gin_trgm_ops'}, postgresql_using='gin')
     op.drop_table('node_comment')
@@ -554,12 +578,8 @@ def downgrade() -> None:
     op.drop_table('analysis')
     op.drop_index(op.f('ix_user_role_value'), table_name='user_role')
     op.drop_table('user_role')
-    op.drop_index(op.f('ix_user_history_record_uuid'), table_name='user_history')
-    op.drop_table('user_history')
     op.drop_index(op.f('ix_observable_type_value'), table_name='observable_type')
     op.drop_table('observable_type')
-    op.drop_index(op.f('ix_observable_history_record_uuid'), table_name='observable_history')
-    op.drop_table('observable_history')
     op.drop_index(op.f('ix_node_threat_type_value'), table_name='node_threat_type')
     op.drop_table('node_threat_type')
     op.drop_index(op.f('ix_node_threat_actor_value'), table_name='node_threat_actor')
@@ -587,8 +607,6 @@ def downgrade() -> None:
     op.drop_table('event_queue')
     op.drop_index(op.f('ix_event_prevention_tool_value'), table_name='event_prevention_tool')
     op.drop_table('event_prevention_tool')
-    op.drop_index(op.f('ix_event_history_record_uuid'), table_name='event_history')
-    op.drop_table('event_history')
     op.drop_index(op.f('ix_analysis_module_type_version'), table_name='analysis_module_type')
     op.drop_index(op.f('ix_analysis_module_type_value'), table_name='analysis_module_type')
     op.drop_table('analysis_module_type')
@@ -600,8 +618,6 @@ def downgrade() -> None:
     op.drop_table('alert_tool')
     op.drop_index(op.f('ix_alert_queue_value'), table_name='alert_queue')
     op.drop_table('alert_queue')
-    op.drop_index(op.f('ix_alert_history_record_uuid'), table_name='alert_history')
-    op.drop_table('alert_history')
     op.drop_index(op.f('ix_alert_disposition_value'), table_name='alert_disposition')
     op.drop_table('alert_disposition')
     # ### end Alembic commands ###

--- a/backend/app/db/schemas/alert.py
+++ b/backend/app/db/schemas/alert.py
@@ -1,16 +1,20 @@
+from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, Index, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
+from typing import Optional
 
 from api.models.alert import AlertTreeRead
 from db.database import Base
-from db.schemas.history import History
-from db.schemas.node import Node
 from db.schemas.helpers import utcnow
+from db.schemas.history import HistoryMixin
+from db.schemas.node import Node
 
 
-class AlertHistory(Base, History):
+class AlertHistory(Base, HistoryMixin):
     __tablename__ = "alert_history"
+
+    record_uuid = Column(UUID(as_uuid=True), ForeignKey("alert.uuid"), index=True, nullable=False)
 
 
 class Alert(Node):
@@ -24,8 +28,12 @@ class Alert(Node):
 
     disposition_uuid = Column(UUID(as_uuid=True), ForeignKey("alert_disposition.uuid"), index=True)
 
+    # Stores the most recent time the alert was dispositioned.
+    # Needed for the "sort by disposition_time" feature.
     disposition_time = Column(DateTime(timezone=True), index=True)
 
+    # Stores the user UUID of who most recently dispositioned the alert.
+    # Needed for the "sort by disposition_user" feature.
     disposition_user_uuid = Column(UUID(as_uuid=True), ForeignKey("user.uuid"), index=True)
 
     disposition_user = relationship("User", foreign_keys=[disposition_user_uuid], lazy="selectin")
@@ -35,6 +43,13 @@ class Alert(Node):
     event_uuid = Column(UUID(as_uuid=True), ForeignKey("event.uuid"), index=True)
 
     event = relationship("Event", foreign_keys=[event_uuid])
+
+    history = relationship(
+        "AlertHistory",
+        primaryjoin="AlertHistory.record_uuid == Alert.uuid",
+        lazy="selectin",
+        order_by="AlertHistory.action_time",
+    )
 
     insert_time = Column(DateTime(timezone=True), server_default=utcnow(), nullable=False, index=True)
 
@@ -75,3 +90,19 @@ class Alert(Node):
 
     def serialize_for_node_tree(self) -> AlertTreeRead:
         return AlertTreeRead(**self.__dict__)
+
+    @property
+    def disposition_time_earliest(self) -> Optional[datetime]:
+        """Returns the earliest time the alert was dispositioned"""
+        history: Optional[AlertHistory] = next((x for x in self.history if x.field == "disposition"), None)
+        if history:
+            return history.action_time
+        return None
+
+    @property
+    def ownership_time_earliest(self) -> Optional[datetime]:
+        """Returns the earliest time an analyst took ownership of the alert"""
+        history: Optional[AlertHistory] = next((x for x in self.history if x.field == "owner"), None)
+        if history:
+            return history.action_time
+        return None

--- a/backend/app/db/schemas/alert.py
+++ b/backend/app/db/schemas/alert.py
@@ -44,10 +44,10 @@ class Alert(Node):
 
     event = relationship("Event", foreign_keys=[event_uuid])
 
+    # History is lazy loaded and is not included by default when fetching an alert from the API.
     history = relationship(
         "AlertHistory",
         primaryjoin="AlertHistory.record_uuid == Alert.uuid",
-        lazy="selectin",
         order_by="AlertHistory.action_time",
     )
 

--- a/backend/app/db/schemas/event.py
+++ b/backend/app/db/schemas/event.py
@@ -41,10 +41,10 @@ class Event(Node):
 
     event_time = Column(DateTime(timezone=True), index=True)
 
+    # History is lazy loaded and is not included by default when fetching an event from the API.
     history = relationship(
         "EventHistory",
         primaryjoin="EventHistory.record_uuid == Event.uuid",
-        lazy="selectin",
         order_by="EventHistory.action_time",
     )
 

--- a/backend/app/db/schemas/event.py
+++ b/backend/app/db/schemas/event.py
@@ -1,7 +1,9 @@
+from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
+from typing import Optional
 
 from api.models.event import EventRead
 from db.database import Base
@@ -9,12 +11,14 @@ from db.schemas.event_prevention_tool_mapping import event_prevention_tool_mappi
 from db.schemas.event_remediation_mapping import event_remediation_mapping
 from db.schemas.event_vector_mapping import event_vector_mapping
 from db.schemas.helpers import utcnow
-from db.schemas.history import History
+from db.schemas.history import HistoryMixin
 from db.schemas.node import Node
 
 
-class EventHistory(Base, History):
+class EventHistory(Base, HistoryMixin):
     __tablename__ = "event_history"
+
+    record_uuid = Column(UUID(as_uuid=True), ForeignKey("event.uuid"), index=True, nullable=False)
 
 
 class Event(Node):
@@ -28,6 +32,7 @@ class Event(Node):
 
     alert_uuids = association_proxy("alerts", "uuid")
 
+    # There isn't currently a way to automatically calculate this time
     contain_time = Column(DateTime(timezone=True), index=True)
 
     creation_time = Column(DateTime(timezone=True), server_default=utcnow(), index=True)
@@ -35,6 +40,13 @@ class Event(Node):
     disposition_time = Column(DateTime(timezone=True), index=True)
 
     event_time = Column(DateTime(timezone=True), index=True)
+
+    history = relationship(
+        "EventHistory",
+        primaryjoin="EventHistory.record_uuid == Event.uuid",
+        lazy="selectin",
+        order_by="EventHistory.action_time",
+    )
 
     name = Column(String, nullable=False)
 
@@ -50,6 +62,7 @@ class Event(Node):
 
     queue_uuid = Column(UUID(as_uuid=True), ForeignKey("event_queue.uuid"), nullable=False, index=True)
 
+    # There isn't currently a way to automatically calculate this time
     remediation_time = Column(DateTime(timezone=True), index=True)
 
     remediations = relationship("EventRemediation", secondary=event_remediation_mapping, lazy="selectin")
@@ -76,3 +89,35 @@ class Event(Node):
 
     def serialize_for_node_tree(self) -> EventRead:
         return EventRead(**self.__dict__)
+
+    @property
+    def auto_alert_time(self) -> Optional[datetime]:
+        """Returns the earliest time an alert in the event was created"""
+        if self.alerts:
+            return sorted(self.alerts, key=lambda x: x.insert_time)[0].insert_time
+        return None
+
+    @property
+    def auto_disposition_time(self) -> Optional[datetime]:
+        """Returns the earliest time an alert in the event was dispositioned"""
+        if self.alerts:
+            return sorted(
+                self.alerts, key=lambda x: (x.disposition_time_earliest is None, x.disposition_time_earliest)
+            )[0].disposition_time_earliest
+        return None
+
+    @property
+    def auto_event_time(self) -> Optional[datetime]:
+        """Returns the earliest event time from the alerts in the event"""
+        if self.alerts:
+            return sorted(self.alerts, key=lambda x: x.event_time)[0].event_time
+        return None
+
+    @property
+    def auto_ownership_time(self) -> Optional[datetime]:
+        """Returns the earliest time an analyst took ownership of an alert in the event"""
+        if self.alerts:
+            return sorted(self.alerts, key=lambda x: (x.ownership_time_earliest is None, x.ownership_time_earliest))[
+                0
+            ].ownership_time_earliest
+        return None

--- a/backend/app/db/schemas/history.py
+++ b/backend/app/db/schemas/history.py
@@ -1,23 +1,20 @@
-from sqlalchemy import Column, DateTime, func, String
+from sqlalchemy import Column, DateTime, ForeignKey, func, String
 from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.ext.declarative import declared_attr
+from sqlalchemy.orm import relationship
 
 from db.schemas.helpers import utcnow
 
 
 """
-NOTE: This is not actually a database table. It does not use table inheritance like the
-Node table does. It is used as normal Python class inheritance just so that all of the
-various history tables can have the same columns without needing the added overhead of
-table inheritance.
+NOTE: This is not actually a database table. See https://docs.sqlalchemy.org/en/14/orm/declarative_mixins.html
 """
 
 
-class History:
+class HistoryMixin:
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
 
     action = Column(String, nullable=False)
-
-    action_by = Column(String, nullable=False)
 
     action_time = Column(DateTime(timezone=True), server_default=utcnow(), nullable=False)
 
@@ -28,3 +25,11 @@ class History:
     diff = Column(JSONB)
 
     snapshot = Column(JSONB, nullable=False)
+
+    @declared_attr
+    def action_by_user_uuid(cls):
+        return Column(UUID(as_uuid=True), ForeignKey("user.uuid"), index=True, nullable=False)
+
+    @declared_attr
+    def action_by(cls):
+        return relationship("User", primaryjoin="User.uuid == %s.action_by_user_uuid" % cls.__name__)

--- a/backend/app/db/schemas/node.py
+++ b/backend/app/db/schemas/node.py
@@ -25,6 +25,7 @@ class Node(Base):
     # JOIN node_tag_mapping ON node_tag_mapping.tag_uuid = node_tag.uuid
     # JOIN node_tree ON node_tree.node_uuid = node_tag_mapping.node_uuid
     # WHERE node_tree.root_node_uuid = '02f8299b-2a24-400f-9751-7dd9164daf6a'
+    # AND node_tree.node_uuid != '02f8299b-2a24-400f-9751-7dd9164daf6a'
     #
     # While there is nothing complicated about this SQL query, SQLAlchemy does not have a
     # straightforward way to handle these types of relationships with intermediate tables.

--- a/backend/app/db/schemas/observable.py
+++ b/backend/app/db/schemas/observable.py
@@ -36,10 +36,10 @@ class Observable(Node):
 
     for_detection = Column(Boolean, default=False, nullable=False)
 
+    # History is lazy loaded and is not included by default when fetching an observable from the API.
     history = relationship(
         "ObservableHistory",
         primaryjoin="ObservableHistory.record_uuid == Observable.uuid",
-        lazy="selectin",
         order_by="ObservableHistory.action_time",
     )
 

--- a/backend/app/db/schemas/observable.py
+++ b/backend/app/db/schemas/observable.py
@@ -13,12 +13,14 @@ from sqlalchemy.orm import relationship
 from api.models.observable import ObservableNodeTreeRead
 from db.database import Base
 from db.schemas.helpers import utcnow
-from db.schemas.history import History
+from db.schemas.history import HistoryMixin
 from db.schemas.node import Node
 
 
-class ObservableHistory(Base, History):
+class ObservableHistory(Base, HistoryMixin):
     __tablename__ = "observable_history"
+
+    record_uuid = Column(UUID(as_uuid=True), ForeignKey("observable.uuid"), index=True, nullable=False)
 
 
 class Observable(Node):
@@ -33,6 +35,13 @@ class Observable(Node):
     expires_on = Column(DateTime(timezone=True))
 
     for_detection = Column(Boolean, default=False, nullable=False)
+
+    history = relationship(
+        "ObservableHistory",
+        primaryjoin="ObservableHistory.record_uuid == Observable.uuid",
+        lazy="selectin",
+        order_by="ObservableHistory.action_time",
+    )
 
     redirection_uuid = Column(UUID(as_uuid=True), ForeignKey("observable.uuid"))
 

--- a/backend/app/db/schemas/user.py
+++ b/backend/app/db/schemas/user.py
@@ -3,12 +3,14 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from db.database import Base
-from db.schemas.history import History
+from db.schemas.history import HistoryMixin
 from db.schemas.user_role_mapping import user_role_mapping
 
 
-class UserHistory(Base, History):
+class UserHistory(Base, HistoryMixin):
     __tablename__ = "user_history"
+
+    record_uuid = Column(UUID(as_uuid=True), ForeignKey("user.uuid"), index=True, nullable=False)
 
 
 class User(Base):
@@ -29,6 +31,13 @@ class User(Base):
     email = Column(String, unique=True, nullable=False)
 
     enabled = Column(Boolean, default=True, nullable=False)
+
+    history = relationship(
+        "UserHistory",
+        primaryjoin="UserHistory.record_uuid == User.uuid",
+        lazy="selectin",
+        order_by="UserHistory.action_time",
+    )
 
     password = Column(String, nullable=False)
 

--- a/backend/app/db/schemas/user.py
+++ b/backend/app/db/schemas/user.py
@@ -32,10 +32,10 @@ class User(Base):
 
     enabled = Column(Boolean, default=True, nullable=False)
 
+    # History is lazy loaded and is not included by default when fetching a user from the API.
     history = relationship(
         "UserHistory",
         primaryjoin="UserHistory.record_uuid == User.uuid",
-        lazy="selectin",
         order_by="UserHistory.action_time",
     )
 

--- a/backend/app/tests/api/alert/test_create.py
+++ b/backend/app/tests/api/alert/test_create.py
@@ -171,7 +171,7 @@ def test_create_nonexistent_queue(client_valid_access_token, db):
         "/api/alert/",
         json={
             "name": "test alert",
-            "queue": "test_queue",
+            "queue": "nonexistent_queue",
             "observables": [{"type": "o_type", "value": "o_value"}],
             "type": "test_type",
         },
@@ -288,7 +288,7 @@ def test_create_verify_history(client_valid_access_token, db):
     history = client_valid_access_token.get(f"/api/alert/{alert_uuid}/history")
     assert history.json()["total"] == 1
     assert history.json()["items"][0]["action"] == "CREATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
+    assert history.json()["items"][0]["action_by"]["username"] == "analyst"
     assert history.json()["items"][0]["record_uuid"] == alert_uuid
     assert history.json()["items"][0]["field"] is None
     assert history.json()["items"][0]["diff"] is None
@@ -298,7 +298,7 @@ def test_create_verify_history(client_valid_access_token, db):
     history = client_valid_access_token.get(f"/api/observable/{db_observable.uuid}/history")
     assert history.json()["total"] == 1
     assert history.json()["items"][0]["action"] == "CREATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
+    assert history.json()["items"][0]["action_by"]["username"] == "analyst"
     assert history.json()["items"][0]["record_uuid"] == str(db_observable.uuid)
     assert history.json()["items"][0]["field"] is None
     assert history.json()["items"][0]["diff"] is None

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -81,7 +81,7 @@ def test_get_filter_disposition(client_valid_access_token, db):
 
 def test_get_filter_disposition_user(client_valid_access_token, db):
     helpers.create_alert(db)
-    helpers.create_alert(db, disposition_user="analyst")
+    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE")
 
     # There should be 2 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -90,13 +90,44 @@ def test_get_filter_disposition_user(client_valid_access_token, db):
     # There should only be 1 alert when we filter by the disposition user
     get = client_valid_access_token.get("/api/alert/?disposition_user=analyst")
     assert get.json()["total"] == 1
-    assert get.json()["items"][0]["disposition_user"]["username"] == "analyst"
+    assert get.json()["items"][0]["uuid"] == str(alert_tree.node_uuid)
+
+
+def test_get_filter_disposition_user_multiple(client_valid_access_token, db):
+    helpers.create_alert_disposition(value="DELIVERY", rank=2, db=db)
+    helpers.create_alert(db)
+
+    # This alert was first dispositioned by alice
+    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="alice")
+
+    # This alert was first dispositioned by analyst
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="analyst")
+
+    # analyst re-dispositions alice's alert
+    update = client_valid_access_token.patch(
+        "/api/alert/", json=[{"disposition": "DELIVERY", "uuid": str(alert_tree.node_uuid)}]
+    )
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+
+    # Verify that the alert is no longer dispositioned by alice
+    get = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}")
+    assert get.json()["disposition_user"]["username"] == "analyst"
+
+    # There should be 3 total alerts
+    get = client_valid_access_token.get("/api/alert/")
+    assert get.json()["total"] == 3
+
+    # There should still be 1 alert when we filter by the disposition user alice
+    get = client_valid_access_token.get("/api/alert/?disposition_user=alice")
+    assert get.json()["total"] == 1
+    assert get.json()["items"][0]["uuid"] == str(alert_tree.node_uuid)
 
 
 def test_get_filter_dispositioned_after(client_valid_access_token, db):
+    now = datetime.utcnow()
     helpers.create_alert(db)
-    alert_tree2 = helpers.create_alert(db, disposition_time=datetime.utcnow())
-    helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now + timedelta(seconds=5))
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -105,15 +136,16 @@ def test_get_filter_dispositioned_after(client_valid_access_token, db):
     # There should only be 1 alert when we filter by dispositioned_after. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"dispositioned_after": alert_tree2.node.disposition_time}
+    params = {"dispositioned_after": now}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_dispositioned_before(client_valid_access_token, db):
+    now = datetime.utcnow()
     helpers.create_alert(db)
-    helpers.create_alert(db, disposition_time=datetime.utcnow() - timedelta(seconds=5))
-    alert_tree3 = helpers.create_alert(db, disposition_time=datetime.utcnow())
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now - timedelta(seconds=5))
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -122,15 +154,18 @@ def test_get_filter_dispositioned_before(client_valid_access_token, db):
     # There should only be 1 alert when we filter by dispositioned_before. But the timestamp
     # has a timezone specified, which uses the + symbol that needs to be urlencoded since it
     # is a reserved URL character.
-    params = {"dispositioned_before": alert_tree3.node.disposition_time}
+    params = {"dispositioned_before": now}
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
 
 
 def test_get_filter_dispositioned_after_and_before(client_valid_access_token, db):
-    alert_tree1 = helpers.create_alert(db, disposition_time=datetime.utcnow() - timedelta(days=1))
-    helpers.create_alert(db, disposition_time=datetime.utcnow())
-    alert_tree3 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(days=1))
+    now = datetime.utcnow()
+    after = now - timedelta(days=1)
+    before = now + timedelta(days=1)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=after)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=before)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -140,8 +175,8 @@ def test_get_filter_dispositioned_after_and_before(client_valid_access_token, db
     # But the timestamp has a timezone specified, which uses the + symbol that needs to be
     # urlencoded since it is a reserved URL character.
     params = {
-        "dispositioned_after": alert_tree1.node.disposition_time,
-        "dispositioned_before": alert_tree3.node.disposition_time,
+        "dispositioned_after": after,
+        "dispositioned_before": before,
     }
     get = client_valid_access_token.get(f"/api/alert/?{urlencode(params)}")
     assert get.json()["total"] == 1
@@ -567,8 +602,10 @@ def test_get_sort_by_disposition(client_valid_access_token, db):
 
 
 def test_get_sort_by_disposition_time(client_valid_access_token, db):
-    alert_tree1 = helpers.create_alert(db, disposition_time=datetime.utcnow())
-    alert_tree2 = helpers.create_alert(db, disposition_time=datetime.utcnow() + timedelta(seconds=5))
+    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=datetime.utcnow())
+    alert_tree2 = helpers.create_alert(
+        db, disposition="FALSE_POSITIVE", disposition_time=datetime.utcnow() + timedelta(seconds=5)
+    )
 
     # If you sort descending, the newest alert (alert2) should appear first
     get = client_valid_access_token.get("/api/alert/?sort=disposition_time|desc")
@@ -584,8 +621,8 @@ def test_get_sort_by_disposition_time(client_valid_access_token, db):
 
 
 def test_get_sort_by_disposition_user(client_valid_access_token, db):
-    alert_tree1 = helpers.create_alert(db, disposition_user="alice")
-    alert_tree2 = helpers.create_alert(db, disposition_user="bob")
+    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="alice")
+    alert_tree2 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="bob")
     alert_tree3 = helpers.create_alert(db)
 
     # If you sort descending: null user, bob, alice

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -81,7 +81,7 @@ def test_get_filter_disposition(client_valid_access_token, db):
 
 def test_get_filter_disposition_user(client_valid_access_token, db):
     helpers.create_alert(db)
-    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE")
+    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE", updated_by_user="analyst")
 
     # There should be 2 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -98,10 +98,10 @@ def test_get_filter_disposition_user_multiple(client_valid_access_token, db):
     helpers.create_alert(db)
 
     # This alert was first dispositioned by alice
-    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="alice")
+    alert_tree = helpers.create_alert(db, disposition="FALSE_POSITIVE", updated_by_user="alice")
 
     # This alert was first dispositioned by analyst
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="analyst")
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", updated_by_user="analyst")
 
     # analyst re-dispositions alice's alert
     update = client_valid_access_token.patch(
@@ -126,8 +126,8 @@ def test_get_filter_disposition_user_multiple(client_valid_access_token, db):
 def test_get_filter_dispositioned_after(client_valid_access_token, db):
     now = datetime.utcnow()
     helpers.create_alert(db)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now + timedelta(seconds=5))
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=now)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=now + timedelta(seconds=5))
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -144,8 +144,8 @@ def test_get_filter_dispositioned_after(client_valid_access_token, db):
 def test_get_filter_dispositioned_before(client_valid_access_token, db):
     now = datetime.utcnow()
     helpers.create_alert(db)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now - timedelta(seconds=5))
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=now - timedelta(seconds=5))
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=now)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -163,9 +163,9 @@ def test_get_filter_dispositioned_after_and_before(client_valid_access_token, db
     now = datetime.utcnow()
     after = now - timedelta(days=1)
     before = now + timedelta(days=1)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=after)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=now)
-    helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=before)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=after)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=now)
+    helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=before)
 
     # There should be 3 total alerts
     get = client_valid_access_token.get("/api/alert/")
@@ -602,9 +602,9 @@ def test_get_sort_by_disposition(client_valid_access_token, db):
 
 
 def test_get_sort_by_disposition_time(client_valid_access_token, db):
-    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_time=datetime.utcnow())
+    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", update_time=datetime.utcnow())
     alert_tree2 = helpers.create_alert(
-        db, disposition="FALSE_POSITIVE", disposition_time=datetime.utcnow() + timedelta(seconds=5)
+        db, disposition="FALSE_POSITIVE", update_time=datetime.utcnow() + timedelta(seconds=5)
     )
 
     # If you sort descending, the newest alert (alert2) should appear first
@@ -621,8 +621,8 @@ def test_get_sort_by_disposition_time(client_valid_access_token, db):
 
 
 def test_get_sort_by_disposition_user(client_valid_access_token, db):
-    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="alice")
-    alert_tree2 = helpers.create_alert(db, disposition="FALSE_POSITIVE", disposition_user="bob")
+    alert_tree1 = helpers.create_alert(db, disposition="FALSE_POSITIVE", updated_by_user="alice")
+    alert_tree2 = helpers.create_alert(db, disposition="FALSE_POSITIVE", updated_by_user="bob")
     alert_tree3 = helpers.create_alert(db)
 
     # If you sort descending: null user, bob, alice

--- a/backend/app/tests/api/alert/test_update.py
+++ b/backend/app/tests/api/alert/test_update.py
@@ -133,13 +133,13 @@ def test_update_disposition(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "disposition"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "test"
-    assert history.json()["items"][0]["snapshot"]["disposition"]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "disposition"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "test"
+    assert history.json()["items"][1]["snapshot"]["disposition"]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch(
@@ -150,13 +150,13 @@ def test_update_disposition(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "disposition"
-    assert history.json()["items"][1]["diff"]["old_value"] == "test"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["disposition"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "disposition"
+    assert history.json()["items"][2]["diff"]["old_value"] == "test"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["disposition"] is None
 
 
 def test_update_event_uuid(client_valid_access_token, db):
@@ -177,13 +177,13 @@ def test_update_event_uuid(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "event_uuid"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == str(event.uuid)
-    assert history.json()["items"][0]["snapshot"]["event_uuid"] == str(event.uuid)
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "event_uuid"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == str(event.uuid)
+    assert history.json()["items"][1]["snapshot"]["event_uuid"] == str(event.uuid)
 
     # By adding the alert to the event, you should be able to see the alert UUID in the event's
     # alert_uuids list even though it was not explicitly added.
@@ -201,13 +201,13 @@ def test_update_event_uuid(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "event_uuid"
-    assert history.json()["items"][1]["diff"]["old_value"] == str(event.uuid)
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["event_uuid"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "event_uuid"
+    assert history.json()["items"][2]["diff"]["old_value"] == str(event.uuid)
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["event_uuid"] is None
 
 
 def test_update_owner(client_valid_access_token, db):
@@ -227,13 +227,13 @@ def test_update_owner(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "owner"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "johndoe"
-    assert history.json()["items"][0]["snapshot"]["owner"]["username"] == "johndoe"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "owner"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "johndoe"
+    assert history.json()["items"][1]["snapshot"]["owner"]["username"] == "johndoe"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/alert/", json=[{"owner": None, "uuid": str(alert_tree.node_uuid)}])
@@ -242,13 +242,13 @@ def test_update_owner(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "owner"
-    assert history.json()["items"][1]["diff"]["old_value"] == "johndoe"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["owner"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "owner"
+    assert history.json()["items"][2]["diff"]["old_value"] == "johndoe"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["owner"] is None
 
 
 def test_update_queue(client_valid_access_token, db):
@@ -268,13 +268,13 @@ def test_update_queue(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "queue"
-    assert history.json()["items"][0]["diff"]["old_value"] == "test_queue"
-    assert history.json()["items"][0]["diff"]["new_value"] == "test_queue2"
-    assert history.json()["items"][0]["snapshot"]["queue"]["value"] == "test_queue2"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "queue"
+    assert history.json()["items"][1]["diff"]["old_value"] == "test_queue"
+    assert history.json()["items"][1]["diff"]["new_value"] == "test_queue2"
+    assert history.json()["items"][1]["snapshot"]["queue"]["value"] == "test_queue2"
 
 
 @pytest.mark.parametrize(
@@ -308,15 +308,15 @@ def test_update_valid_node_fields(client_valid_access_token, db, key, value_list
         # Verify the history
         if value_list:
             history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-            assert history.json()["total"] == 1
-            assert history.json()["items"][0]["action"] == "UPDATE"
-            assert history.json()["items"][0]["action_by"] == "Analyst"
-            assert history.json()["items"][0]["field"] == key
-            assert history.json()["items"][0]["diff"]["old_value"] is None
-            assert history.json()["items"][0]["diff"]["new_value"] is None
-            assert history.json()["items"][0]["diff"]["added_to_list"] == sorted(set(value_list))
-            assert history.json()["items"][0]["diff"]["removed_from_list"] == ["remove_me"]
-            assert len(history.json()["items"][0]["snapshot"][key]) == len(set(value_list))
+            assert history.json()["total"] == 2
+            assert history.json()["items"][1]["action"] == "UPDATE"
+            assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+            assert history.json()["items"][1]["field"] == key
+            assert history.json()["items"][1]["diff"]["old_value"] is None
+            assert history.json()["items"][1]["diff"]["new_value"] is None
+            assert history.json()["items"][1]["diff"]["added_to_list"] == sorted(set(value_list))
+            assert history.json()["items"][1]["diff"]["removed_from_list"] == ["remove_me"]
+            assert len(history.json()["items"][1]["snapshot"][key]) == len(set(value_list))
 
 
 @pytest.mark.parametrize(
@@ -351,19 +351,19 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == key
-    assert history.json()["items"][0]["diff"]["old_value"] == initial_value
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == key
+    assert history.json()["items"][1]["diff"]["old_value"] == initial_value
 
     if key == "event_time":
         assert alert_tree.node.event_time == parse("2022-01-01T00:00:00+00:00")
-        assert history.json()["items"][0]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
+        assert history.json()["items"][1]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
     else:
         assert getattr(alert_tree.node, key) == updated_value
-        assert history.json()["items"][0]["diff"]["new_value"] == updated_value
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+        assert history.json()["items"][1]["diff"]["new_value"] == updated_value
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
     assert alert_tree.node.version != initial_alert_version
 
@@ -403,31 +403,31 @@ def test_update_multiple_alerts(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree1.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "description"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "updated_description"
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "description"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "updated_description"
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
     history = client_valid_access_token.get(f"/api/alert/{alert_tree2.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "event_time"
-    assert history.json()["items"][0]["diff"]["old_value"] == initial_event_time
-    assert history.json()["items"][0]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "event_time"
+    assert history.json()["items"][1]["diff"]["old_value"] == initial_event_time
+    assert history.json()["items"][1]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
     history = client_valid_access_token.get(f"/api/alert/{alert_tree3.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "instructions"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "updated_instructions"
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "instructions"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "updated_instructions"
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
 
 def test_update_multiple_fields(client_valid_access_token, db):
@@ -450,19 +450,19 @@ def test_update_multiple_fields(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "description"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "updated_description"
-    assert history.json()["items"][0]["snapshot"]["description"] == "updated_description"
-    assert history.json()["items"][0]["snapshot"]["instructions"] == "updated_instructions"
-
+    assert history.json()["total"] == 3
     assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "instructions"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "description"
     assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] == "updated_instructions"
+    assert history.json()["items"][1]["diff"]["new_value"] == "updated_description"
     assert history.json()["items"][1]["snapshot"]["description"] == "updated_description"
     assert history.json()["items"][1]["snapshot"]["instructions"] == "updated_instructions"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "instructions"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] == "updated_instructions"
+    assert history.json()["items"][2]["snapshot"]["description"] == "updated_description"
+    assert history.json()["items"][2]["snapshot"]["instructions"] == "updated_instructions"

--- a/backend/app/tests/api/alert_queue/test_read.py
+++ b/backend/app/tests/api/alert_queue/test_read.py
@@ -33,10 +33,4 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/alert/queue/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 2
-
-
-def test_get_all_empty(client_valid_access_token):
-    get = client_valid_access_token.get("/api/alert/queue/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 0
+    assert get.json()["total"] == 3  # The default analyst user has a queue

--- a/backend/app/tests/api/event/test_create.py
+++ b/backend/app/tests/api/event/test_create.py
@@ -256,7 +256,7 @@ def test_create_verify_history(client_valid_access_token, db):
     history = client_valid_access_token.get(f"/api/event/{event_uuid}/history")
     assert history.json()["total"] == 1
     assert history.json()["items"][0]["action"] == "CREATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
+    assert history.json()["items"][0]["action_by"]["username"] == "analyst"
     assert str(history.json()["items"][0]["record_uuid"]) == event_uuid
     assert history.json()["items"][0]["field"] is None
     assert history.json()["items"][0]["diff"] is None

--- a/backend/app/tests/api/event/test_update.py
+++ b/backend/app/tests/api/event/test_update.py
@@ -172,13 +172,13 @@ def test_update_owner(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "owner"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "johndoe"
-    assert history.json()["items"][0]["snapshot"]["owner"]["username"] == "johndoe"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "owner"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "johndoe"
+    assert history.json()["items"][1]["snapshot"]["owner"]["username"] == "johndoe"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"owner": None, "uuid": str(event.uuid)}])
@@ -187,13 +187,13 @@ def test_update_owner(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "owner"
-    assert history.json()["items"][1]["diff"]["old_value"] == "johndoe"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["owner"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "owner"
+    assert history.json()["items"][2]["diff"]["old_value"] == "johndoe"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["owner"] is None
 
 
 def test_update_prevention_tools(client_valid_access_token, db):
@@ -215,15 +215,15 @@ def test_update_prevention_tools(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "prevention_tools"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == []
-    assert history.json()["items"][0]["snapshot"]["prevention_tools"][0]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "prevention_tools"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
+    assert history.json()["items"][1]["snapshot"]["prevention_tools"][0]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"prevention_tools": [], "uuid": str(event.uuid)}])
@@ -232,15 +232,15 @@ def test_update_prevention_tools(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "prevention_tools"
-    assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["diff"]["added_to_list"] == []
-    assert history.json()["items"][1]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][1]["snapshot"]["prevention_tools"] == []
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "prevention_tools"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["prevention_tools"] == []
 
 
 def test_update_queue(client_valid_access_token, db):
@@ -260,13 +260,13 @@ def test_update_queue(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "queue"
-    assert history.json()["items"][0]["diff"]["old_value"] == "default"
-    assert history.json()["items"][0]["diff"]["new_value"] == "updated_queue"
-    assert history.json()["items"][0]["snapshot"]["queue"]["value"] == "updated_queue"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "queue"
+    assert history.json()["items"][1]["diff"]["old_value"] == "default"
+    assert history.json()["items"][1]["diff"]["new_value"] == "updated_queue"
+    assert history.json()["items"][1]["snapshot"]["queue"]["value"] == "updated_queue"
 
 
 def test_update_remediations(client_valid_access_token, db):
@@ -286,15 +286,15 @@ def test_update_remediations(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "remediations"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == []
-    assert history.json()["items"][0]["snapshot"]["remediations"][0]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "remediations"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
+    assert history.json()["items"][1]["snapshot"]["remediations"][0]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"remediations": [], "uuid": str(event.uuid)}])
@@ -303,15 +303,15 @@ def test_update_remediations(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "remediations"
-    assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["diff"]["added_to_list"] == []
-    assert history.json()["items"][1]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][1]["snapshot"]["remediations"] == []
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "remediations"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["remediations"] == []
 
 
 def test_update_risk_level(client_valid_access_token, db):
@@ -330,13 +330,13 @@ def test_update_risk_level(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "risk_level"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "test"
-    assert history.json()["items"][0]["snapshot"]["risk_level"]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "risk_level"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "test"
+    assert history.json()["items"][1]["snapshot"]["risk_level"]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"risk_level": None, "uuid": str(event.uuid)}])
@@ -345,13 +345,13 @@ def test_update_risk_level(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "risk_level"
-    assert history.json()["items"][1]["diff"]["old_value"] == "test"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["risk_level"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "risk_level"
+    assert history.json()["items"][2]["diff"]["old_value"] == "test"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["risk_level"] is None
 
 
 def test_update_source(client_valid_access_token, db):
@@ -370,13 +370,13 @@ def test_update_source(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "source"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "test"
-    assert history.json()["items"][0]["snapshot"]["source"]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "source"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "test"
+    assert history.json()["items"][1]["snapshot"]["source"]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"source": None, "uuid": str(event.uuid)}])
@@ -385,13 +385,13 @@ def test_update_source(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "source"
-    assert history.json()["items"][1]["diff"]["old_value"] == "test"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["source"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "source"
+    assert history.json()["items"][2]["diff"]["old_value"] == "test"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["source"] is None
 
 
 def test_update_status(client_valid_access_token, db):
@@ -410,13 +410,13 @@ def test_update_status(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "status"
-    assert history.json()["items"][0]["diff"]["old_value"] == "OPEN"
-    assert history.json()["items"][0]["diff"]["new_value"] == "test"
-    assert history.json()["items"][0]["snapshot"]["status"]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "status"
+    assert history.json()["items"][1]["diff"]["old_value"] == "OPEN"
+    assert history.json()["items"][1]["diff"]["new_value"] == "test"
+    assert history.json()["items"][1]["snapshot"]["status"]["value"] == "test"
 
 
 def test_update_type(client_valid_access_token, db):
@@ -435,13 +435,13 @@ def test_update_type(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "type"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == "test"
-    assert history.json()["items"][0]["snapshot"]["type"]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "type"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == "test"
+    assert history.json()["items"][1]["snapshot"]["type"]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch("/api/event/", json=[{"type": None, "uuid": str(event.uuid)}])
@@ -450,13 +450,13 @@ def test_update_type(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "type"
-    assert history.json()["items"][1]["diff"]["old_value"] == "test"
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["type"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "type"
+    assert history.json()["items"][2]["diff"]["old_value"] == "test"
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["type"] is None
 
 
 def test_update_vectors(client_valid_access_token, db):
@@ -476,15 +476,15 @@ def test_update_vectors(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "vectors"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == []
-    assert history.json()["items"][0]["snapshot"]["vectors"][0]["value"] == "test"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "vectors"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
+    assert history.json()["items"][1]["snapshot"]["vectors"][0]["value"] == "test"
 
     # Set it back to None
     update = client_valid_access_token.patch(
@@ -496,15 +496,15 @@ def test_update_vectors(client_valid_access_token, db):
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
     print(history.json())
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "vectors"
-    assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["diff"]["added_to_list"] == []
-    assert history.json()["items"][1]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][1]["snapshot"]["vectors"] == []
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "vectors"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["vectors"] == []
 
 
 @pytest.mark.parametrize(
@@ -535,15 +535,15 @@ def test_update_valid_node_fields(client_valid_access_token, db, key, value_list
         # Verify the history
         if value_list:
             history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-            assert history.json()["total"] == 1
-            assert history.json()["items"][0]["action"] == "UPDATE"
-            assert history.json()["items"][0]["action_by"] == "Analyst"
-            assert history.json()["items"][0]["field"] == key
-            assert history.json()["items"][0]["diff"]["old_value"] is None
-            assert history.json()["items"][0]["diff"]["new_value"] is None
-            assert history.json()["items"][0]["diff"]["added_to_list"] == sorted(set(value_list))
-            assert history.json()["items"][0]["diff"]["removed_from_list"] == ["remove_me"]
-            assert len(history.json()["items"][0]["snapshot"][key]) == len(set(value_list))
+            assert history.json()["total"] == 2
+            assert history.json()["items"][1]["action"] == "UPDATE"
+            assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+            assert history.json()["items"][1]["field"] == key
+            assert history.json()["items"][1]["diff"]["old_value"] is None
+            assert history.json()["items"][1]["diff"]["new_value"] is None
+            assert history.json()["items"][1]["diff"]["added_to_list"] == sorted(set(value_list))
+            assert history.json()["items"][1]["diff"]["removed_from_list"] == ["remove_me"]
+            assert len(history.json()["items"][1]["snapshot"][key]) == len(set(value_list))
 
 
 @pytest.mark.parametrize(
@@ -603,19 +603,19 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == key
-    assert history.json()["items"][0]["diff"]["old_value"] == initial_value
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == key
+    assert history.json()["items"][1]["diff"]["old_value"] == initial_value
 
     # If the test is for one of the times, make sure that the retrieved value matches the proper UTC timestamp
     if key.endswith("_time") and updated_value:
         assert getattr(event, key) == parse("2022-01-01T00:00:00+00:00")
-        assert history.json()["items"][0]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
+        assert history.json()["items"][1]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
     else:
         assert getattr(event, key) == updated_value
-        assert history.json()["items"][0]["diff"]["new_value"] == updated_value
-    assert history.json()["items"][0]["snapshot"]["name"] == event.name
+        assert history.json()["items"][1]["diff"]["new_value"] == updated_value
+    assert history.json()["items"][1]["snapshot"]["name"] == event.name
 
     assert event.version != initial_event_version

--- a/backend/app/tests/api/event_queue/test_read.py
+++ b/backend/app/tests/api/event_queue/test_read.py
@@ -33,10 +33,4 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/event/queue/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 2
-
-
-def test_get_all_empty(client_valid_access_token):
-    get = client_valid_access_token.get("/api/event/queue/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 0
+    assert get.json()["total"] == 3  # The default analyst user has a queue

--- a/backend/app/tests/api/node_comment/test_create.py
+++ b/backend/app/tests/api/node_comment/test_create.py
@@ -34,7 +34,6 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
 
 def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
     alert_tree = helpers.create_alert(db=db)
-    helpers.create_user(username="analyst", db=db)
 
     # Create a comment
     create_json = {
@@ -63,7 +62,6 @@ def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
 )
 def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
     alert_tree = helpers.create_alert(db=db)
-    helpers.create_user(username="analyst", db=db)
 
     # Create a comment
     create1_json = {
@@ -85,8 +83,6 @@ def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
 
 
 def test_create_nonexistent_node_uuid(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
-
     # Create a comment
     create_json = {
         "node_uuid": str(uuid.uuid4()),
@@ -103,7 +99,6 @@ def test_create_nonexistent_node_uuid(client_valid_access_token, db):
 
 
 def test_create_verify_history_alerts(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
     alert_tree = helpers.create_alert(db=db)
 
     # Add a comment to the node
@@ -115,20 +110,19 @@ def test_create_verify_history_alerts(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(alert_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] is None
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
 
 def test_create_verify_history_events(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
     event = helpers.create_event(name="Test Event", db=db)
 
     # Add a comment to the node
@@ -140,20 +134,19 @@ def test_create_verify_history_events(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(event.uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] is None
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Event"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
 
 
 def test_create_verify_history_observables(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
     alert_tree = helpers.create_alert(db=db)
     observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
 
@@ -166,21 +159,19 @@ def test_create_verify_history_observables(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(observable_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] is None
-    assert history.json()["items"][0]["snapshot"]["value"] == "test_value"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
 
 
 def test_create_multiple(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
-
     alert_tree1 = helpers.create_alert(db=db)
     initial_alert1_version = alert_tree1.node.version
 
@@ -220,7 +211,6 @@ def test_create_multiple(client_valid_access_token, db):
 
 
 def test_create_valid_required_fields(client_valid_access_token, db):
-    helpers.create_user(username="analyst", db=db)
     alert_tree = helpers.create_alert(db=db)
     initial_node_version = alert_tree.node.version
 

--- a/backend/app/tests/api/node_comment/test_delete.py
+++ b/backend/app/tests/api/node_comment/test_delete.py
@@ -50,16 +50,16 @@ def test_delete_alerts(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(alert_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] is None
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
 
 
 def test_delete_events(client_valid_access_token, db):
@@ -81,16 +81,16 @@ def test_delete_events(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(event.uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] is None
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Event"
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
 
 
 def test_delete_observables(client_valid_access_token, db):
@@ -113,13 +113,13 @@ def test_delete_observables(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(observable_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] is None
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["value"] == "test_value"
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/node_comment/test_update.py
+++ b/backend/app/tests/api/node_comment/test_update.py
@@ -66,16 +66,27 @@ def test_update_alerts(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(alert_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["updated"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Alert"
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
 
 
 def test_update_events(client_valid_access_token, db):
@@ -91,16 +102,27 @@ def test_update_events(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(event.uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["updated"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["name"] == "Test Event"
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
 
 
 def test_update_observables(client_valid_access_token, db):
@@ -117,13 +139,24 @@ def test_update_observables(client_valid_access_token, db):
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["record_uuid"] == str(observable_tree.node_uuid)
-    assert history.json()["items"][0]["field"] == "comments"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == ["updated"]
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][0]["snapshot"]["value"] == "test_value"
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/observable/test_create.py
+++ b/backend/app/tests/api/observable/test_create.py
@@ -277,7 +277,7 @@ def test_create_verify_history(client_valid_access_token, db):
         history = client_valid_access_token.get(f"/api/observable/{observable['uuid']}/history")
         assert history.json()["total"] == 1
         assert history.json()["items"][0]["action"] == "CREATE"
-        assert history.json()["items"][0]["action_by"] == "Analyst"
+        assert history.json()["items"][0]["action_by"]["username"] == "analyst"
         assert history.json()["items"][0]["record_uuid"] == observable["uuid"]
         assert history.json()["items"][0]["field"] is None
         assert history.json()["items"][0]["diff"] is None

--- a/backend/app/tests/api/observable/test_update.py
+++ b/backend/app/tests/api/observable/test_update.py
@@ -150,13 +150,13 @@ def test_update_type(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "type"
-    assert history.json()["items"][0]["diff"]["old_value"] == "test_type"
-    assert history.json()["items"][0]["diff"]["new_value"] == "test_type2"
-    assert history.json()["items"][0]["snapshot"]["type"]["value"] == "test_type2"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "type"
+    assert history.json()["items"][1]["diff"]["old_value"] == "test_type"
+    assert history.json()["items"][1]["diff"]["new_value"] == "test_type2"
+    assert history.json()["items"][1]["snapshot"]["type"]["value"] == "test_type2"
 
 
 def test_update_redirection_uuid(client_valid_access_token, db):
@@ -178,13 +178,13 @@ def test_update_redirection_uuid(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/observable/{observable_tree1.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "redirection_uuid"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] == str(observable_tree2.node.uuid)
-    assert history.json()["items"][0]["snapshot"]["redirection_uuid"] == str(observable_tree2.node.uuid)
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "redirection_uuid"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] == str(observable_tree2.node.uuid)
+    assert history.json()["items"][1]["snapshot"]["redirection_uuid"] == str(observable_tree2.node.uuid)
 
     # Set it back to None
     update = client_valid_access_token.patch(
@@ -195,13 +195,13 @@ def test_update_redirection_uuid(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/observable/{observable_tree1.node_uuid}/history")
-    assert history.json()["total"] == 2
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"] == "Analyst"
-    assert history.json()["items"][1]["field"] == "redirection_uuid"
-    assert history.json()["items"][1]["diff"]["old_value"] == str(observable_tree2.node.uuid)
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["snapshot"]["redirection_uuid"] is None
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["field"] == "redirection_uuid"
+    assert history.json()["items"][2]["diff"]["old_value"] == str(observable_tree2.node.uuid)
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["snapshot"]["redirection_uuid"] is None
 
 
 @pytest.mark.parametrize(
@@ -242,15 +242,15 @@ def test_update_valid_node_fields(client_valid_access_token, db, key, value_list
         # Verify the history
         if value_list:
             history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-            assert history.json()["total"] == 1
-            assert history.json()["items"][0]["action"] == "UPDATE"
-            assert history.json()["items"][0]["action_by"] == "Analyst"
-            assert history.json()["items"][0]["field"] == key
-            assert history.json()["items"][0]["diff"]["old_value"] is None
-            assert history.json()["items"][0]["diff"]["new_value"] is None
-            assert history.json()["items"][0]["diff"]["added_to_list"] == sorted(set(value_list))
-            assert history.json()["items"][0]["diff"]["removed_from_list"] == ["remove_me"]
-            assert len(history.json()["items"][0]["snapshot"][key]) == len(set(value_list))
+            assert history.json()["total"] == 2
+            assert history.json()["items"][1]["action"] == "UPDATE"
+            assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+            assert history.json()["items"][1]["field"] == key
+            assert history.json()["items"][1]["diff"]["old_value"] is None
+            assert history.json()["items"][1]["diff"]["new_value"] is None
+            assert history.json()["items"][1]["diff"]["added_to_list"] == sorted(set(value_list))
+            assert history.json()["items"][1]["diff"]["removed_from_list"] == ["remove_me"]
+            assert len(history.json()["items"][1]["snapshot"][key]) == len(set(value_list))
 
 
 @pytest.mark.parametrize(
@@ -293,27 +293,27 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == key
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == key
 
     # If the test is for expires_on, make sure that the retrieved value matches the proper UTC timestamp
     if key == "expires_on" or key == "time":
         if initial_value:
-            assert history.json()["items"][0]["diff"]["old_value"] == parse("2021-01-01T00:00:00+00:00").isoformat()
+            assert history.json()["items"][1]["diff"]["old_value"] == parse("2021-01-01T00:00:00+00:00").isoformat()
         else:
-            assert history.json()["items"][0]["diff"]["old_value"] is None
+            assert history.json()["items"][1]["diff"]["old_value"] is None
 
         if updated_value:
             assert getattr(observable_tree.node, key) == parse("2022-01-01T00:00:00+00:00")
-            assert history.json()["items"][0]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
+            assert history.json()["items"][1]["diff"]["new_value"] == parse("2022-01-01T00:00:00+00:00").isoformat()
         else:
             assert getattr(observable_tree.node, key) is None
-            assert history.json()["items"][0]["diff"]["new_value"] is None
+            assert history.json()["items"][1]["diff"]["new_value"] is None
     else:
         assert getattr(observable_tree.node, key) == updated_value
-        assert history.json()["items"][0]["diff"]["old_value"] == initial_value
-        assert history.json()["items"][0]["diff"]["new_value"] == updated_value
+        assert history.json()["items"][1]["diff"]["old_value"] == initial_value
+        assert history.json()["items"][1]["diff"]["new_value"] == updated_value
 
-    assert history.json()["items"][0]["snapshot"]["value"] == observable_tree.node.value
+    assert history.json()["items"][1]["snapshot"]["value"] == observable_tree.node.value

--- a/backend/app/tests/api/test_auth_refresh.py
+++ b/backend/app/tests/api/test_auth_refresh.py
@@ -38,7 +38,7 @@ def test_disabled_user(client, db):
     assert refresh.json()["detail"] == "Invalid token"
 
 
-def test_expired_token(client, db, monkeypatch):
+def test_expired_token(client, monkeypatch):
     def mock_get_settings():
         settings = Settings()
         settings.jwt_refresh_expire_seconds = 1
@@ -47,10 +47,8 @@ def test_expired_token(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK
     assert auth.json()["token_type"] == "bearer"
@@ -72,11 +70,9 @@ def test_missing_token(client):
     assert refresh.json()["detail"] == "Not authenticated"
 
 
-def test_reused_token(client, db):
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
+def test_reused_token(client):
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK
     assert auth.json()["token_type"] == "bearer"
@@ -92,11 +88,9 @@ def test_reused_token(client, db):
     assert refresh.json()["detail"] == "Reused token"
 
 
-def test_wrong_token_type(client, db):
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
+def test_wrong_token_type(client):
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     access_token = auth.json()["access_token"]
     assert auth.status_code == status.HTTP_200_OK
     assert auth.json()["token_type"] == "bearer"
@@ -113,7 +107,7 @@ def test_wrong_token_type(client, db):
 #
 
 
-def test_auth_refresh_success(client, db, monkeypatch):
+def test_auth_refresh_success(client, monkeypatch):
     def mock_get_settings():
         settings = Settings()
         settings.jwt_access_expire_seconds = 1
@@ -122,10 +116,8 @@ def test_auth_refresh_success(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     access_token = auth.json()["access_token"]
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK

--- a/backend/app/tests/api/test_auth_validate.py
+++ b/backend/app/tests/api/test_auth_validate.py
@@ -3,7 +3,6 @@ import time
 from fastapi import status
 
 from core.config import Settings
-from tests import helpers
 
 
 #
@@ -16,7 +15,7 @@ def test_auth_validate_invalid_token(client):
     assert get.json()["detail"] == "Invalid token"
 
 
-def test_expired_token(client, db, monkeypatch):
+def test_expired_token(client, monkeypatch):
     def mock_get_settings():
         settings = Settings()
         settings.jwt_refresh_expire_seconds = 1
@@ -25,10 +24,8 @@ def test_expired_token(client, db, monkeypatch):
     # Patching __code__ works no matter how the function is imported
     monkeypatch.setattr("core.config.get_settings.__code__", mock_get_settings.__code__)
 
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     access_token = auth.json()["access_token"]
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK
@@ -56,11 +53,9 @@ def test_missing_token(client):
     assert get.json()["detail"] == "Not authenticated"
 
 
-def test_wrong_token_type(client, db):
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
+def test_wrong_token_type(client):
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     access_token = auth.json()["access_token"]
     assert auth.status_code == status.HTTP_200_OK
     assert auth.json()["token_type"] == "bearer"
@@ -77,11 +72,9 @@ def test_wrong_token_type(client, db):
 #
 
 
-def test_auth_validate_success(client, db):
-    helpers.create_user(username="johndoe", password="abcd1234", db=db)
-
+def test_auth_validate_success(client):
     # Attempt to authenticate
-    auth = client.post("/api/auth", data={"username": "johndoe", "password": "abcd1234"})
+    auth = client.post("/api/auth", data={"username": "analyst", "password": "asdfasdf"})
     access_token = auth.json()["access_token"]
     refresh_token = auth.json()["refresh_token"]
     assert auth.status_code == status.HTTP_200_OK

--- a/backend/app/tests/api/user/test_create.py
+++ b/backend/app/tests/api/user/test_create.py
@@ -171,7 +171,7 @@ def test_create_verify_history(client_valid_access_token, db):
     history = client_valid_access_token.get(f"/api/user/{user_uuid}/history")
     assert history.json()["total"] == 1
     assert history.json()["items"][0]["action"] == "CREATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
+    assert history.json()["items"][0]["action_by"]["username"] == "analyst"
     assert history.json()["items"][0]["record_uuid"] == user_uuid
     assert history.json()["items"][0]["field"] is None
     assert history.json()["items"][0]["diff"] is None

--- a/backend/app/tests/api/user/test_read.py
+++ b/backend/app/tests/api/user/test_read.py
@@ -33,10 +33,4 @@ def test_get_all(client_valid_access_token, db):
     # Read them back
     get = client_valid_access_token.get("/api/user/")
     assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 2
-
-
-def test_get_all_empty(client_valid_access_token):
-    get = client_valid_access_token.get("/api/user/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 0
+    assert get.json()["total"] == 3  # There is by default an "analyst" user

--- a/backend/app/tests/api/user/test_update.py
+++ b/backend/app/tests/api/user/test_update.py
@@ -107,13 +107,13 @@ def test_update_valid_alert_queue(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/user/{obj.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "default_alert_queue"
-    assert history.json()["items"][0]["diff"]["old_value"] == "test_queue"
-    assert history.json()["items"][0]["diff"]["new_value"] == "test_queue2"
-    assert history.json()["items"][0]["snapshot"]["default_alert_queue"]["value"] == "test_queue2"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "default_alert_queue"
+    assert history.json()["items"][1]["diff"]["old_value"] == "test_queue"
+    assert history.json()["items"][1]["diff"]["new_value"] == "test_queue2"
+    assert history.json()["items"][1]["snapshot"]["default_alert_queue"]["value"] == "test_queue2"
 
 
 def test_update_valid_event_queue(client_valid_access_token, db):
@@ -131,13 +131,13 @@ def test_update_valid_event_queue(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/user/{obj.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "default_event_queue"
-    assert history.json()["items"][0]["diff"]["old_value"] == "test_queue"
-    assert history.json()["items"][0]["diff"]["new_value"] == "test_queue2"
-    assert history.json()["items"][0]["snapshot"]["default_event_queue"]["value"] == "test_queue2"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "default_event_queue"
+    assert history.json()["items"][1]["diff"]["old_value"] == "test_queue"
+    assert history.json()["items"][1]["diff"]["new_value"] == "test_queue2"
+    assert history.json()["items"][1]["snapshot"]["default_event_queue"]["value"] == "test_queue2"
 
 
 @pytest.mark.parametrize(
@@ -164,15 +164,15 @@ def test_update_valid_roles(client_valid_access_token, db, values):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/user/{obj.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "roles"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["diff"]["added_to_list"] == values
-    assert history.json()["items"][0]["diff"]["removed_from_list"] == initial_roles
-    assert len(history.json()["items"][0]["snapshot"]["roles"]) == len(set(values))
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "roles"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == values
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == initial_roles
+    assert len(history.json()["items"][1]["snapshot"]["roles"]) == len(set(values))
 
 
 @pytest.mark.parametrize(
@@ -206,13 +206,13 @@ def test_update(client_valid_access_token, db, key, initial_value, updated_value
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/user/{obj.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == key
-    assert history.json()["items"][0]["diff"]["old_value"] == initial_value
-    assert history.json()["items"][0]["diff"]["new_value"] == updated_value
-    assert history.json()["items"][0]["snapshot"]["username"] == obj.username
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == key
+    assert history.json()["items"][1]["diff"]["old_value"] == initial_value
+    assert history.json()["items"][1]["diff"]["new_value"] == updated_value
+    assert history.json()["items"][1]["snapshot"]["username"] == obj.username
 
 
 @pytest.mark.parametrize(
@@ -238,10 +238,10 @@ def test_update_password(client_valid_access_token, db, initial_value, updated_v
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/user/{obj.uuid}/history")
-    assert history.json()["total"] == 1
-    assert history.json()["items"][0]["action"] == "UPDATE"
-    assert history.json()["items"][0]["action_by"] == "Analyst"
-    assert history.json()["items"][0]["field"] == "password"
-    assert history.json()["items"][0]["diff"]["old_value"] is None
-    assert history.json()["items"][0]["diff"]["new_value"] is None
-    assert history.json()["items"][0]["snapshot"]["username"] == "johndoe"
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["field"] == "password"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["snapshot"]["username"] == "johndoe"

--- a/backend/app/tests/api/user_role/test_delete.py
+++ b/backend/app/tests/api/user_role/test_delete.py
@@ -33,7 +33,7 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 
 def test_delete(client_valid_access_token, db):
     # Create the object
-    obj = helpers.create_user_role(value="test_role", db=db)
+    obj = helpers.create_user_role(value="test_role2", db=db)
 
     # Read it back
     get = client_valid_access_token.get(f"/api/user/role/{obj.uuid}")

--- a/backend/app/tests/api/user_role/test_read.py
+++ b/backend/app/tests/api/user_role/test_read.py
@@ -34,9 +34,3 @@ def test_get_all(client_valid_access_token, db):
     get = client_valid_access_token.get("/api/user/role/")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["total"] == 2
-
-
-def test_get_all_empty(client_valid_access_token):
-    get = client_valid_access_token.get("/api/user/role/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 0

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 
 from db.database import engine, get_db
 from main import app
+from tests import helpers
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -20,6 +21,11 @@ def apply_migrations():
 
     alembic.command.downgrade(config, "base")
     alembic.command.upgrade(config, "head")
+
+    # Add the analyst user so API calls that create history entries have a valid user to link to.
+    session_db = next(get_db())
+    helpers.create_user(username="analyst", db=session_db)
+
     yield
     alembic.command.downgrade(config, "base")
 

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -80,7 +80,7 @@ def client_valid_access_token(client, monkeypatch):
     """
 
     def mock_validate_access_token():
-        return {"sub": "analyst", "full_name": "Analyst"}
+        return {"sub": "analyst"}
 
     # Due to how imports work, patching __code__ accounts for all cases for how the function is imported and used.
     monkeypatch.setattr("core.auth.validate_access_token.__code__", mock_validate_access_token.__code__)

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -59,6 +59,10 @@ export interface eventCreate extends nodeCreate {
 export interface eventRead extends nodeRead {
   alertTime: Date | null;
   alertUuids: UUID[];
+  autoAlertTime: Date | null;
+  autoDispositionTime: Date | null;
+  autoEventTime: Date | null;
+  autoOwnershipTime: Date | null;
   comments: nodeCommentRead[];
   containTime: Date | null;
   creationTime: Date;

--- a/frontend/src/models/history.ts
+++ b/frontend/src/models/history.ts
@@ -1,0 +1,55 @@
+import { alertRead } from "./alert";
+import { UUID } from "./base";
+import { eventRead } from "./event";
+import { observableRead } from "./observable";
+import { readPage } from "./page";
+import { userRead } from "./user";
+
+interface diff {
+  oldValue: boolean | string | null;
+  newValue: boolean | string | null;
+  addedToList: string[] | null;
+  removedFromList: string[] | null;
+}
+
+interface historyBase {
+  uuid: UUID;
+  action: string;
+  actionBy: userRead;
+  actionTime: Date;
+  recordUuid: UUID;
+  field: string | null;
+  diff: diff | null;
+}
+
+interface alertHistoryRead extends historyBase {
+  snapshot: alertRead;
+}
+
+interface eventHistoryRead extends historyBase {
+  snapshot: eventRead;
+}
+
+interface observableHistoryRead extends historyBase {
+  snapshot: observableRead;
+}
+
+interface userHistoryRead extends historyBase {
+  snapshot: userRead;
+}
+
+export interface alertHistoryReadPage extends readPage {
+  items: alertHistoryRead[];
+}
+
+export interface eventHistoryReadPage extends readPage {
+  items: eventHistoryRead[];
+}
+
+export interface observableHistoryReadPage extends readPage {
+  items: observableHistoryRead[];
+}
+
+export interface userHistoryReadPage extends readPage {
+  items: userHistoryRead[];
+}

--- a/frontend/src/models/node.ts
+++ b/frontend/src/models/node.ts
@@ -1,4 +1,5 @@
 import { UUID } from "./base";
+import { readPage } from "./page";
 
 export interface nodeCreate {
   uuid?: UUID;
@@ -20,11 +21,8 @@ export interface nodeRead {
   version: UUID;
 }
 
-export interface nodeReadPage {
+export interface nodeReadPage extends readPage {
   items: nodeRead[];
-  limit: number;
-  offset: number;
-  total: number;
 }
 
 export interface nodeUpdate {

--- a/frontend/src/models/page.ts
+++ b/frontend/src/models/page.ts
@@ -1,0 +1,6 @@
+export interface readPage {
+  items: unknown[];
+  limit: number;
+  offset: number;
+  total: number;
+}

--- a/frontend/src/services/api/alert.ts
+++ b/frontend/src/services/api/alert.ts
@@ -9,6 +9,7 @@ import {
   alertUpdate,
 } from "@/models/alert";
 import { UUID } from "@/models/base";
+import { alertHistoryReadPage } from "@/models/history";
 import { BaseApi } from "./base";
 
 const api = new BaseApi();
@@ -20,6 +21,9 @@ export const Alert = {
 
   read: async (uuid: UUID): Promise<alertTreeRead> =>
     await api.read(`${endpoint}${uuid}`),
+
+  readHistory: async (uuid: UUID): Promise<alertHistoryReadPage> =>
+    await api.read(`${endpoint}${uuid}/history`),
 
   readPage: (params?: alertFilterParams): Promise<alertReadPage> => {
     let formattedParams = {} as alertFilterParams;

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -9,6 +9,7 @@ import {
 import { UUID } from "@/models/base";
 import { BaseApi } from "./base";
 import { eventFilters } from "@/etc/constants";
+import { eventHistoryReadPage } from "@/models/history";
 
 const api = new BaseApi();
 const endpoint = "/event/";
@@ -21,6 +22,9 @@ export const Event = {
   read: (uuid: UUID): Promise<eventRead> => {
     return api.read(`${endpoint}${uuid}`);
   },
+
+  readHistory: async (uuid: UUID): Promise<eventHistoryReadPage> =>
+    await api.read(`${endpoint}${uuid}/history`),
 
   readPage: (params?: eventFilterParams): Promise<eventReadPage> => {
     let formattedParams = {} as eventFilterParams;

--- a/frontend/src/services/api/observable.ts
+++ b/frontend/src/services/api/observable.ts
@@ -8,7 +8,7 @@ import { BaseApi } from "./base";
 import { observableHistoryReadPage } from "@/models/history";
 
 const api = new BaseApi();
-const endpoint = "/observable/instance/";
+const endpoint = "/observable/";
 
 export const ObservableInstance = {
   create: (data: observableCreate, getAfterCreate = false): Promise<void> =>

--- a/frontend/src/services/api/observableInstance.ts
+++ b/frontend/src/services/api/observableInstance.ts
@@ -1,23 +1,24 @@
 import {
-  observableInstanceCreate,
-  observableInstanceRead,
-  observableInstanceUpdate,
-} from "@/models/observableInstance";
+  observableCreate,
+  observableRead,
+  observableUpdate,
+} from "@/models/observable";
 import { UUID } from "@/models/base";
 import { BaseApi } from "./base";
+import { observableHistoryReadPage } from "@/models/history";
 
 const api = new BaseApi();
 const endpoint = "/observable/instance/";
 
 export const ObservableInstance = {
-  create: (
-    data: observableInstanceCreate,
-    getAfterCreate = false,
-  ): Promise<void> => api.create(endpoint, data, getAfterCreate),
+  create: (data: observableCreate, getAfterCreate = false): Promise<void> =>
+    api.create(endpoint, data, getAfterCreate),
 
-  read: (uuid: UUID): Promise<observableInstanceRead> =>
-    api.read(`${endpoint}${uuid}`),
+  read: (uuid: UUID): Promise<observableRead> => api.read(`${endpoint}${uuid}`),
 
-  update: (uuid: UUID, data: observableInstanceUpdate): Promise<void> =>
+  readHistory: async (uuid: UUID): Promise<observableHistoryReadPage> =>
+    await api.read(`${endpoint}${uuid}/history`),
+
+  update: (uuid: UUID, data: observableUpdate): Promise<void> =>
     api.update(`${endpoint}${uuid}`, data),
 };

--- a/frontend/src/services/api/user.ts
+++ b/frontend/src/services/api/user.ts
@@ -1,6 +1,7 @@
 import { userCreate, userRead, userReadPage, userUpdate } from "@/models/user";
 import { pageOptionParams, UUID } from "@/models/base";
 import { BaseApi } from "./base";
+import { userHistoryReadPage } from "@/models/history";
 
 const api = new BaseApi();
 const endpoint = "/user/";
@@ -10,6 +11,9 @@ export const User = {
     api.create(endpoint, data, getAfterCreate),
 
   read: (uuid: UUID): Promise<userRead> => api.read(`${endpoint}${uuid}`),
+
+  readHistory: async (uuid: UUID): Promise<userHistoryReadPage> =>
+    await api.read(`${endpoint}${uuid}/history`),
 
   readAll: (): Promise<userRead[]> => api.readAll(endpoint),
 

--- a/frontend/tests/mocks/events.ts
+++ b/frontend/tests/mocks/events.ts
@@ -50,6 +50,10 @@ export const eventCreateFactory = ({
 });
 
 export const eventReadFactory = ({
+  autoAlertTime = null,
+  autoDispositionTime = null,
+  autoEventTime = null,
+  autoOwnershipTime = null,
   alertTime = null,
   alertUuids = [],
   comments = [],
@@ -76,6 +80,10 @@ export const eventReadFactory = ({
   vectors = [],
   version = "testEventVersion1",
 }: Partial<eventRead> = {}): eventRead => ({
+  autoAlertTime: autoAlertTime,
+  autoDispositionTime: autoDispositionTime,
+  autoEventTime: autoEventTime,
+  autoOwnershipTime: autoOwnershipTime,
   alertTime: alertTime,
   alertUuids: alertUuids,
   comments: comments,


### PR DESCRIPTION
### Overview

Now that we are tracking alert, event, observable, and user history, the main purpose of this PR is to automatically calculate various times for events:

- Alert time (earliest time an alert in the event was created) 
- Disposition time (earliest time an alert in the event was dispositioned)
- Event time (earliest event time from the alerts in the event)
- Ownership time (earliest time an analyst took ownership of an alert in the event)

The disposition time and ownership time calculations are based on the alert history table. So even if someone were to re-disposition an alert (which would overwrite the disposition_time value in the alert table), the event's disposition time calculation remains unaffected.

The event database table still has columns for all of these same times so that, in an unlikely event, they can be manually overridden.

NOTE: Eventually the remediation time will be calculated for events, but we have not built remediation capabilities into 2.0 yet.

### Alert/Event filtering changes

When filtering alerts, you can use the `disposition_user` and `dispositioned_before`/`dispositioned_after` options. The API endpoint is updated so that it now returns any alerts based on their history. So if analyst A dispositions an alert, and later analyst B dispositions the same alert to something else, if you filter alters that were dispositioned by analyst A, that alert would still be included in the results since there is a history record of analyst A dispositioning it.

The same logic applies for the dispositioned before/after filters.

For event filters, the same logic applies when filtering events by their disposition_time. The filter will consider the alert history times of the alerts inside of the event, but it will also consider the disposition_time column in the event database table, which is used if someone wanted to manually override the event's disposition time instead of relying on the automatically calculated time.

### History changes

The history tracking feature introduced in #123 had some small flaws. It originally held just a string value for the username of who performed the action. However, usernames are often not very helpful in the GUI since they might just be a random employee ID. Because the API does not let you actually delete user from the database, this PR changes the history tables to use a foreign key to the users table so that we can pull out all of the user's information, including their full name for display.

### Frontend updates

This PR adds TypeScript models and API service functions for fetching alert, event, observable, and user history (but tests have not been written yet for the new readHistory API service functions).