### PR TITLE
Check for .only frontend test restrictions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,6 +40,7 @@ jobs:
 
       - name: Test
         run: docker-compose run -e TESTING=1 api pytest -vv
+
   frontend:
     name: Frontend
     runs-on: ubuntu-latest
@@ -50,6 +51,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Check for .only test restrictions
+        run: bin/frontend-check-for-only.sh
 
       - name: Setup Node
         uses: actions/setup-node@v2

--- a/bin/frontend-check-for-only.sh
+++ b/bin/frontend-check-for-only.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+matches="$(grep -R '\.only(' frontend/tests)"
+if [ -z "$matches" ]
+then
+    exit 0
+else
+    echo "$matches"
+    exit 1
+fi

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -317,7 +317,7 @@ describe("Manage Alerts Filter Actions", () => {
     cy.get(".flex").children().should("have.length", 0);
   });
 
-  it.only("will change the input box depending on the selected filter", () => {
+  it("will change the input box depending on the selected filter", () => {
     cy.get(".p-splitbutton-menubutton").click();
     cy.get(".p-menuitem:nth-child(1) > .p-menuitem-link").click();
     cy.get(".p-dialog-footer > :nth-child(2)").click();

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -317,7 +317,7 @@ describe("Manage Alerts Filter Actions", () => {
     cy.get(".flex").children().should("have.length", 0);
   });
 
-  it("will change the input box depending on the selected filter", () => {
+  it.only("will change the input box depending on the selected filter", () => {
     cy.get(".p-splitbutton-menubutton").click();
     cy.get(".p-menuitem:nth-child(1) > .p-menuitem-link").click();
     cy.get(".p-dialog-footer > :nth-child(2)").click();


### PR DESCRIPTION
As part of the #132 PR, I discovered that we had accidentally left some of the frontend tests restricted with `.only`. This meant that we were unintentionally skipping large portions of our test suite.

This PR adds a helper script that is used by GitHub Actions to check if there are any tests with `.only` on them. If there are, the workflow will fail and will output the matches so that you can quickly identify which tests need to be fixed.