### PR TITLE
Associate items with queues in backend seed script

### DIFF
--- a/backend/app/etc/defaults.yml
+++ b/backend/app/etc/defaults.yml
@@ -20,62 +20,105 @@ alert_disposition:
 alert_type:
   - manual
 event_prevention_tool:
-  - antivirus
-  - application whitelisting
-  - edr
-  - email filter
-  - fw
-  - ips
-  - proxy
-  - response team
-  - user
+  external:
+    - antivirus
+    - application whitelisting
+    - edr
+    - email filter
+    - fw
+    - ips
+    - proxy
+    - response team
+    - user
 event_remediation:
-  - cleaned manually
-  - cleaned with antivirus
-  - credentials reset
-  - domain takedown
-  - escalated
-  - network block
-  - not remediated
-  - reimaged
-  - removed from mailbox
+  external:
+    - cleaned manually
+    - cleaned with antivirus
+    - credentials reset
+    - domain takedown
+    - escalated
+    - network block
+    - not remediated
+    - reimaged
+    - removed from mailbox
+  internal:
+    - cleaned manually
+    - cleaned with antivirus
+    - credentials reset
+    - domain takedown
+    - escalated
+    - network block
+    - not remediated
+    - reimaged
+    - removed from mailbox
 event_risk_level:
-  - 0
-  - 1
-  - 2
-  - 3
+  external:
+    - 0
+    - 1
+    - 2
+    - 3
 event_source:
-  - internal
-  - osint
+  external:
+    - internal
+    - osint
+  internal:
+    - internal
+    - osint
 event_status:
-  - OPEN
-  - IGNORE
-  - CLOSED
+  external:
+    - OPEN
+    - IGNORE
+    - CLOSED
+  internal:
+    - OPEN
+    - IGNORE
+    - CLOSED
 event_type:
-  - credential compromise
-  - host compromise
-  - pentest
-  - phish
-  - recon
-  - third party
-  - web browsing
+  external:
+    - credential compromise
+    - host compromise
+    - pentest
+    - phish
+    - recon
+    - third party
+    - web browsing
+  internal:
+    - credential compromise
+    - host compromise
+    - pentest
+    - phish
+    - recon
+    - third party
+    - web browsing
 event_vector:
-  - business application
-  - compromised website
-  - corporate email
-  - unknown
-  - usb
-  - webmail
+  external:
+    - business application
+    - compromised website
+    - corporate email
+    - unknown
+    - usb
+    - webmail
 node_threat_type:
-  - botnet
-  - customer threat
-  - downloader
-  - fraud
-  - infostealer
-  - keylogger
-  - ransomware
-  - rat
-  - rootkit
+  external:
+    - botnet
+    - customer threat
+    - downloader
+    - fraud
+    - infostealer
+    - keylogger
+    - ransomware
+    - rat
+    - rootkit
+  internal:
+    - botnet
+    - customer threat
+    - downloader
+    - fraud
+    - infostealer
+    - keylogger
+    - ransomware
+    - rat
+    - rootkit
 observable_type:
   - file
   - ipv4

--- a/backend/app/etc/defaults.yml
+++ b/backend/app/etc/defaults.yml
@@ -80,8 +80,9 @@ observable_type:
   - file
   - ipv4
 queue:
-  - default
-  - secondary_queue
+  - external
+  - internal
+  - intel
 user_role:
   - admin
   - analyst

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -3,6 +3,7 @@ import sys
 import yaml
 
 from sqlalchemy.orm import Session
+from sqlalchemy.orm.decl_api import DeclarativeMeta
 
 from core.auth import hash_password
 from core.config import is_in_testing_mode
@@ -28,6 +29,24 @@ from db.schemas.user_role import UserRole
 # docker logs ace2-gui-backend
 
 
+def add_queueable_values(db_table: DeclarativeMeta, data: dict, key: str, print_value: str):
+    created = []
+    for queue in data[key]:
+        db_queue = crud.read_by_value(value=queue, db_table=Queue, db=db)
+        for value in data[key][queue]:
+            # Add the value to the database if it is new
+            if value not in created:
+                db.add(db_table(value=str(value)))
+                created.append(value)
+                crud.commit(db)
+                print(f"Adding {print_value}: {value}")
+
+            # Associate it with its queue
+            db_value = crud.read_by_value(value=str(value), db_table=db_table, db=db)
+            if db_value:
+                db_value.queues.append(db_queue)
+
+
 def seed(db: Session):
     # Quit early if the config file does not exist
     if not os.path.exists("etc/defaults.yml"):
@@ -43,12 +62,7 @@ def seed(db: Session):
         print("etc/defaults.yml is empty!")
         sys.exit()
 
-    # Add the objects to the database but only if their respective tables do not have any items already.
-    if "alert_disposition" in data and not crud.read_all(db_table=AlertDisposition, db=db):
-        for rank, value in enumerate(data["alert_disposition"]):
-            db.add(AlertDisposition(rank=rank, value=value))
-            print(f"Adding alert disposition: {rank}:{value}")
-
+    # Add the queues to the database
     if not crud.read_all(db_table=Queue, db=db):
         if "queue" in data:
             # Make sure there is always an "external" queue
@@ -63,50 +77,46 @@ def seed(db: Session):
             db.add(Queue(value="external"))
             print("Adding queue: external")
 
+        crud.commit(db)
+
+    # Add the objects to the database but only if their respective tables do not have any items already.
+    if "alert_disposition" in data and not crud.read_all(db_table=AlertDisposition, db=db):
+        for rank, value in enumerate(data["alert_disposition"]):
+            db.add(AlertDisposition(rank=rank, value=value))
+            print(f"Adding alert disposition: {rank}:{value}")
+
     if "alert_type" in data and not crud.read_all(db_table=AlertType, db=db):
         for value in data["alert_type"]:
             db.add(AlertType(value=value))
             print(f"Adding alert type: {value}")
 
     if "event_prevention_tool" in data and not crud.read_all(db_table=EventPreventionTool, db=db):
-        for value in data["event_prevention_tool"]:
-            db.add(EventPreventionTool(value=value))
-            print(f"Adding event prevention tool: {value}")
+        add_queueable_values(
+            db_table=EventPreventionTool, data=data, key="event_prevention_tool", print_value="event prevention tool"
+        )
 
     if "event_remediation" in data and not crud.read_all(db_table=EventRemediation, db=db):
-        for value in data["event_remediation"]:
-            db.add(EventRemediation(value=value))
-            print(f"Adding event remediation: {value}")
+        add_queueable_values(
+            db_table=EventRemediation, data=data, key="event_remediation", print_value="event remediation"
+        )
 
     if "event_risk_level" in data and not crud.read_all(db_table=EventRiskLevel, db=db):
-        for value in data["event_risk_level"]:
-            db.add(EventRiskLevel(value=value))
-            print(f"Adding event risk level: {value}")
+        add_queueable_values(db_table=EventRiskLevel, data=data, key="event_risk_level", print_value="event risk level")
 
     if "event_source" in data and not crud.read_all(db_table=EventSource, db=db):
-        for value in data["event_source"]:
-            db.add(EventSource(value=value))
-            print(f"Adding event source: {value}")
+        add_queueable_values(db_table=EventSource, data=data, key="event_source", print_value="event source")
 
     if "event_status" in data and not crud.read_all(db_table=EventStatus, db=db):
-        for value in data["event_status"]:
-            db.add(EventStatus(value=value))
-            print(f"Adding event status: {value}")
+        add_queueable_values(db_table=EventStatus, data=data, key="event_status", print_value="event status")
 
     if "event_type" in data and not crud.read_all(db_table=EventType, db=db):
-        for value in data["event_type"]:
-            db.add(EventType(value=value))
-            print(f"Adding event type: {value}")
+        add_queueable_values(db_table=EventType, data=data, key="event_type", print_value="event type")
 
     if "event_vector" in data and not crud.read_all(db_table=EventVector, db=db):
-        for value in data["event_vector"]:
-            db.add(EventVector(value=value))
-            print(f"Adding event vector: {value}")
+        add_queueable_values(db_table=EventVector, data=data, key="event_vector", print_value="event vector")
 
     if "node_threat_type" in data and not crud.read_all(db_table=NodeThreatType, db=db):
-        for value in data["node_threat_type"]:
-            db.add(NodeThreatType(value=value))
-            print(f"Adding node threat type: {value}")
+        add_queueable_values(db_table=NodeThreatType, data=data, key="node_threat_type", print_value="node threat type")
 
     if "observable_type" in data and not crud.read_all(db_table=ObservableType, db=db):
         for value in data["observable_type"]:

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -29,7 +29,7 @@ from db.schemas.user_role import UserRole
 # docker logs ace2-gui-backend
 
 
-def add_queueable_values(db_table: DeclarativeMeta, data: dict, key: str, print_value: str):
+def add_queueable_values(db: Session, db_table: DeclarativeMeta, data: dict, key: str, print_value: str):
     created = []
     for queue in data[key]:
         db_queue = crud.read_by_value(value=queue, db_table=Queue, db=db)
@@ -92,31 +92,39 @@ def seed(db: Session):
 
     if "event_prevention_tool" in data and not crud.read_all(db_table=EventPreventionTool, db=db):
         add_queueable_values(
-            db_table=EventPreventionTool, data=data, key="event_prevention_tool", print_value="event prevention tool"
+            db=db,
+            db_table=EventPreventionTool,
+            data=data,
+            key="event_prevention_tool",
+            print_value="event prevention tool",
         )
 
     if "event_remediation" in data and not crud.read_all(db_table=EventRemediation, db=db):
         add_queueable_values(
-            db_table=EventRemediation, data=data, key="event_remediation", print_value="event remediation"
+            db=db, db_table=EventRemediation, data=data, key="event_remediation", print_value="event remediation"
         )
 
     if "event_risk_level" in data and not crud.read_all(db_table=EventRiskLevel, db=db):
-        add_queueable_values(db_table=EventRiskLevel, data=data, key="event_risk_level", print_value="event risk level")
+        add_queueable_values(
+            db=db, db_table=EventRiskLevel, data=data, key="event_risk_level", print_value="event risk level"
+        )
 
     if "event_source" in data and not crud.read_all(db_table=EventSource, db=db):
-        add_queueable_values(db_table=EventSource, data=data, key="event_source", print_value="event source")
+        add_queueable_values(db=db, db_table=EventSource, data=data, key="event_source", print_value="event source")
 
     if "event_status" in data and not crud.read_all(db_table=EventStatus, db=db):
-        add_queueable_values(db_table=EventStatus, data=data, key="event_status", print_value="event status")
+        add_queueable_values(db=db, db_table=EventStatus, data=data, key="event_status", print_value="event status")
 
     if "event_type" in data and not crud.read_all(db_table=EventType, db=db):
-        add_queueable_values(db_table=EventType, data=data, key="event_type", print_value="event type")
+        add_queueable_values(db=db, db_table=EventType, data=data, key="event_type", print_value="event type")
 
     if "event_vector" in data and not crud.read_all(db_table=EventVector, db=db):
-        add_queueable_values(db_table=EventVector, data=data, key="event_vector", print_value="event vector")
+        add_queueable_values(db=db, db_table=EventVector, data=data, key="event_vector", print_value="event vector")
 
     if "node_threat_type" in data and not crud.read_all(db_table=NodeThreatType, db=db):
-        add_queueable_values(db_table=NodeThreatType, data=data, key="node_threat_type", print_value="node threat type")
+        add_queueable_values(
+            db=db, db_table=NodeThreatType, data=data, key="node_threat_type", print_value="node threat type"
+        )
 
     if "observable_type" in data and not crud.read_all(db_table=ObservableType, db=db):
         for value in data["observable_type"]:

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -134,8 +134,8 @@ def seed(db: Session):
 
         db.add(
             User(
-                default_alert_queue=crud.read_by_value(value="default", db_table=Queue, db=db),
-                default_event_queue=crud.read_by_value(value="default", db_table=Queue, db=db),
+                default_alert_queue=crud.read_by_value(value="external", db_table=Queue, db=db),
+                default_event_queue=crud.read_by_value(value="external", db_table=Queue, db=db),
                 display_name="Analyst",
                 email="analyst@fake.com",
                 password=hash_password("analyst"),
@@ -145,8 +145,8 @@ def seed(db: Session):
         )
         db.add(
             User(
-                default_alert_queue=crud.read_by_value(value="default", db_table=Queue, db=db),
-                default_event_queue=crud.read_by_value(value="secondary_queue", db_table=Queue, db=db),
+                default_alert_queue=crud.read_by_value(value="external", db_table=Queue, db=db),
+                default_event_queue=crud.read_by_value(value="internal", db_table=Queue, db=db),
                 display_name="Analyst Alice",
                 email="alice@alice.com",
                 password=hash_password("analyst"),
@@ -156,8 +156,8 @@ def seed(db: Session):
         )
         db.add(
             User(
-                default_alert_queue=crud.read_by_value(value="default", db_table=Queue, db=db),
-                default_event_queue=crud.read_by_value(value="default", db_table=Queue, db=db),
+                default_alert_queue=crud.read_by_value(value="external", db_table=Queue, db=db),
+                default_event_queue=crud.read_by_value(value="external", db_table=Queue, db=db),
                 display_name="Analyst Bob",
                 email="bob@bob.com",
                 password=hash_password("analyst"),

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -51,17 +51,17 @@ def seed(db: Session):
 
     if not crud.read_all(db_table=Queue, db=db):
         if "queue" in data:
-            # Make sure there is always a "default" queue
-            if "default" not in data["queue"]:
-                data["queue"].append("default")
+            # Make sure there is always an "external" queue
+            if "external" not in data["queue"]:
+                data["queue"].append("external")
 
             for value in data["queue"]:
                 db.add(Queue(value=value))
                 print(f"Adding queue: {value}")
         else:
-            # Make sure there is always a "default" queue
-            db.add(Queue(value="default"))
-            print("Adding queue: default")
+            # Make sure there is always a "external" queue
+            db.add(Queue(value="external"))
+            print("Adding queue: external")
 
     if "alert_type" in data and not crud.read_all(db_table=AlertType, db=db):
         for value in data["alert_type"]:

--- a/backend/app/tests/api/alert/test_update.py
+++ b/backend/app/tests/api/alert/test_update.py
@@ -252,18 +252,18 @@ def test_update_owner(client_valid_access_token, db):
 
 
 def test_update_queue(client_valid_access_token, db):
-    alert_tree = helpers.create_alert(db=db)
+    alert_tree = helpers.create_alert(alert_queue="external", db=db)
     initial_alert_version = alert_tree.node.version
 
     # Create a new alert queue
-    helpers.create_queue(value="test_queue2", db=db)
+    helpers.create_queue(value="updated_queue", db=db)
 
     # Update the queue
     update = client_valid_access_token.patch(
-        "/api/alert/", json=[{"queue": "test_queue2", "uuid": str(alert_tree.node_uuid)}]
+        "/api/alert/", json=[{"queue": "updated_queue", "uuid": str(alert_tree.node_uuid)}]
     )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-    assert alert_tree.node.queue.value == "test_queue2"
+    assert alert_tree.node.queue.value == "updated_queue"
     assert alert_tree.node.version != initial_alert_version
 
     # Verify the history
@@ -272,9 +272,9 @@ def test_update_queue(client_valid_access_token, db):
     assert history.json()["items"][1]["action"] == "UPDATE"
     assert history.json()["items"][1]["action_by"]["username"] == "analyst"
     assert history.json()["items"][1]["field"] == "queue"
-    assert history.json()["items"][1]["diff"]["old_value"] == "test_queue"
-    assert history.json()["items"][1]["diff"]["new_value"] == "test_queue2"
-    assert history.json()["items"][1]["snapshot"]["queue"]["value"] == "test_queue2"
+    assert history.json()["items"][1]["diff"]["old_value"] == "external"
+    assert history.json()["items"][1]["diff"]["new_value"] == "updated_queue"
+    assert history.json()["items"][1]["snapshot"]["queue"]["value"] == "updated_queue"
 
 
 @pytest.mark.parametrize(

--- a/backend/app/tests/api/event/test_create.py
+++ b/backend/app/tests/api/event/test_create.py
@@ -93,7 +93,7 @@ def test_create_invalid_fields(client_valid_access_token, key, value):
 def test_create_invalid_node_fields(client_valid_access_token, key, values):
     for value in values:
         create = client_valid_access_token.post(
-            "/api/event/", json={key: value, "name": "test", "queue": "default", "status": "OPEN"}
+            "/api/event/", json={key: value, "name": "test", "queue": "external", "status": "OPEN"}
         )
         assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert key in create.json()["detail"][0]["loc"]
@@ -106,39 +106,39 @@ def test_create_invalid_node_fields(client_valid_access_token, key, values):
     ],
 )
 def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
-    create1_json = {"uuid": str(uuid.uuid4()), "name": "test", "queue": "default", "status": "OPEN"}
+    create1_json = {"uuid": str(uuid.uuid4()), "name": "test", "queue": "external", "status": "OPEN"}
     client_valid_access_token.post("/api/event/", json=create1_json)
 
     # Ensure you cannot create another object with the same unique field value
-    create2_json = {"name": "test2", "queue": "default", "status": "OPEN"}
+    create2_json = {"name": "test2", "queue": "external", "status": "OPEN"}
     create2_json[key] = create1_json[key]
     create2 = client_valid_access_token.post("/api/event/", json=create2_json)
     assert create2.status_code == status.HTTP_409_CONFLICT
 
 
 def test_create_nonexistent_owner(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"owner": "johndoe", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"owner": "johndoe", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "user" in create.text
 
 
 def test_create_nonexistent_prevention_tools(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"prevention_tools": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"prevention_tools": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_prevention_tool" in create.text
@@ -156,69 +156,69 @@ def test_create_nonexistent_queue(client_valid_access_token, db):
 
 
 def test_create_nonexistent_remediations(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"remediations": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"remediations": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_remediation" in create.text
 
 
 def test_create_nonexistent_risk_level(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"risk_level": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"risk_level": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_risk_level" in create.text
 
 
 def test_create_nonexistent_source(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"source": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"source": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_source" in create.text
 
 
 def test_create_nonexistent_status(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
 
     # Create an object
-    create = client_valid_access_token.post("/api/event/", json={"name": "test", "queue": "default", "status": "OPEN"})
+    create = client_valid_access_token.post("/api/event/", json={"name": "test", "queue": "external", "status": "OPEN"})
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_status" in create.text
 
 
 def test_create_nonexistent_type(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"type": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"type": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_type" in create.text
 
 
 def test_create_nonexistent_vectors(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create an object
     create = client_valid_access_token.post(
-        "/api/event/", json={"vectors": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"vectors": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "event_vector" in create.text
@@ -229,11 +229,11 @@ def test_create_nonexistent_vectors(client_valid_access_token, db):
     [("tags"), ("threat_actors"), ("threats")],
 )
 def test_create_nonexistent_node_fields(client_valid_access_token, db, key):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     create = client_valid_access_token.post(
-        "/api/event/", json={key: ["abc"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={key: ["abc"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
     assert "abc" in create.text
@@ -245,12 +245,12 @@ def test_create_nonexistent_node_fields(client_valid_access_token, db, key):
 
 
 def test_create_verify_history(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     event_uuid = str(uuid.uuid4())
     create = client_valid_access_token.post(
-        "/api/event/", json={"uuid": event_uuid, "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"uuid": event_uuid, "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -308,12 +308,12 @@ def test_create_verify_history(client_valid_access_token, db):
     ],
 )
 def test_create_valid_optional_fields(client_valid_access_token, db, key, value):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create the object
     create = client_valid_access_token.post(
-        "/api/event/", json={key: value, "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={key: value, "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -333,7 +333,7 @@ def test_create_valid_owner(client_valid_access_token, db):
 
     # Use the user to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"owner": "johndoe", "name": "test", "queue": "test_queue", "status": "OPEN"}
+        "/api/event/", json={"owner": "johndoe", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -344,12 +344,12 @@ def test_create_valid_owner(client_valid_access_token, db):
 
 def test_create_valid_prevention_tools(client_valid_access_token, db):
     helpers.create_event_prevention_tool(value="test", db=db)
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Use the prevention tool to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"prevention_tools": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"prevention_tools": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -359,13 +359,13 @@ def test_create_valid_prevention_tools(client_valid_access_token, db):
 
 
 def test_create_valid_remediations(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_remediation(value="test", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Use the remediation to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"remediations": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"remediations": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -375,13 +375,13 @@ def test_create_valid_remediations(client_valid_access_token, db):
 
 
 def test_create_valid_risk_level(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_risk_level(value="test", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Use the risk level to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"risk_level": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"risk_level": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -391,13 +391,13 @@ def test_create_valid_risk_level(client_valid_access_token, db):
 
 
 def test_create_valid_source(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_source(value="test", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Use the source to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"source": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"source": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -407,13 +407,13 @@ def test_create_valid_source(client_valid_access_token, db):
 
 
 def test_create_valid_type(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
     helpers.create_event_type(value="test", db=db)
 
     # Use the type to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"type": "test", "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"type": "test", "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -423,13 +423,13 @@ def test_create_valid_type(client_valid_access_token, db):
 
 
 def test_create_valid_vectors(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
     helpers.create_event_vector(value="test", db=db)
 
     # Use the vector to create a new event
     create = client_valid_access_token.post(
-        "/api/event/", json={"vectors": ["test"], "name": "test", "queue": "default", "status": "OPEN"}
+        "/api/event/", json={"vectors": ["test"], "name": "test", "queue": "external", "status": "OPEN"}
     )
     assert create.status_code == status.HTTP_201_CREATED
 
@@ -439,11 +439,11 @@ def test_create_valid_vectors(client_valid_access_token, db):
 
 
 def test_create_valid_required_fields(client_valid_access_token, db):
-    helpers.create_queue(value="default", db=db)
+    helpers.create_queue(value="external", db=db)
     helpers.create_event_status(value="OPEN", db=db)
 
     # Create the object
-    create = client_valid_access_token.post("/api/event/", json={"name": "test", "queue": "default", "status": "OPEN"})
+    create = client_valid_access_token.post("/api/event/", json={"name": "test", "queue": "external", "status": "OPEN"})
     assert create.status_code == status.HTTP_201_CREATED
 
     # Read it back
@@ -466,11 +466,11 @@ def test_create_valid_node_fields(client_valid_access_token, db, key, value_list
         for value in value_list:
             helper_create_func(value=value, db=db)
 
-        helpers.create_queue(value="default", db=db)
+        helpers.create_queue(value="external", db=db)
         helpers.create_event_status(value="OPEN", db=db)
 
         create = client_valid_access_token.post(
-            "/api/event/", json={key: value_list, "name": "test", "queue": "default", "status": "OPEN"}
+            "/api/event/", json={key: value_list, "name": "test", "queue": "external", "status": "OPEN"}
         )
         assert create.status_code == status.HTTP_201_CREATED
 

--- a/backend/app/tests/api/event/test_update.py
+++ b/backend/app/tests/api/event/test_update.py
@@ -245,9 +245,9 @@ def test_update_prevention_tools(client_valid_access_token, db):
 
 def test_update_queue(client_valid_access_token, db):
     # Create an event
-    event = helpers.create_event(name="test", db=db)
+    event = helpers.create_event(name="test", queue="external", db=db)
     initial_event_version = event.version
-    assert event.queue.value == "default"
+    assert event.queue.value == "external"
 
     # Create an event queue
     helpers.create_queue(value="updated_queue", db=db)
@@ -264,7 +264,7 @@ def test_update_queue(client_valid_access_token, db):
     assert history.json()["items"][1]["action"] == "UPDATE"
     assert history.json()["items"][1]["action_by"]["username"] == "analyst"
     assert history.json()["items"][1]["field"] == "queue"
-    assert history.json()["items"][1]["diff"]["old_value"] == "default"
+    assert history.json()["items"][1]["diff"]["old_value"] == "external"
     assert history.json()["items"][1]["diff"]["new_value"] == "updated_queue"
     assert history.json()["items"][1]["snapshot"]["queue"]["value"] == "updated_queue"
 

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -87,7 +87,7 @@ def create_alert_type(value: str, db: Session) -> AlertType:
 
 def create_alert(
     db: Session,
-    alert_queue: str = "test_queue",
+    alert_queue: str = "external",
     alert_type: str = "test_type",
     alert_uuid: Optional[Union[str, UUID]] = None,
     disposition: Optional[str] = None,
@@ -305,7 +305,7 @@ def create_event(
     disposition_time: Optional[datetime] = None,
     owner: Optional[str] = None,
     prevention_tools: Optional[List[str]] = None,
-    queue: str = "default",
+    queue: str = "external",
     remediation_time: Optional[datetime] = None,
     remediations: Optional[List[str]] = None,
     risk_level: Optional[str] = None,
@@ -387,7 +387,7 @@ def create_event(
 
 def create_event_prevention_tool(value: str, db: Session, queues: List[str] = None) -> EventPreventionTool:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventPreventionTool = _create_basic_object(db_table=EventPreventionTool, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -397,7 +397,7 @@ def create_event_prevention_tool(value: str, db: Session, queues: List[str] = No
 
 def create_event_remediation(value: str, db: Session, queues: List[str] = None) -> EventRemediation:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventRemediation = _create_basic_object(db_table=EventRemediation, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -407,7 +407,7 @@ def create_event_remediation(value: str, db: Session, queues: List[str] = None) 
 
 def create_event_risk_level(value: str, db: Session, queues: List[str] = None) -> EventRiskLevel:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventRiskLevel = _create_basic_object(db_table=EventRiskLevel, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -417,7 +417,7 @@ def create_event_risk_level(value: str, db: Session, queues: List[str] = None) -
 
 def create_event_source(value: str, db: Session, queues: List[str] = None) -> EventSource:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventSource = _create_basic_object(db_table=EventSource, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -427,7 +427,7 @@ def create_event_source(value: str, db: Session, queues: List[str] = None) -> Ev
 
 def create_event_status(value: str, db: Session, queues: List[str] = None) -> EventStatus:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventStatus = _create_basic_object(db_table=EventStatus, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -437,7 +437,7 @@ def create_event_status(value: str, db: Session, queues: List[str] = None) -> Ev
 
 def create_event_type(value: str, db: Session, queues: List[str] = None) -> EventType:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventType = _create_basic_object(db_table=EventType, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -447,7 +447,7 @@ def create_event_type(value: str, db: Session, queues: List[str] = None) -> Even
 
 def create_event_vector(value: str, db: Session, queues: List[str] = None) -> EventVector:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: EventVector = _create_basic_object(db_table=EventVector, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -487,7 +487,7 @@ def create_node_tag(value: str, db: Session) -> NodeTag:
 
 def create_node_threat_actor(value: str, db: Session, queues: List[str] = None) -> NodeThreatActor:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: NodeThreatActor = _create_basic_object(db_table=NodeThreatActor, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -501,7 +501,7 @@ def create_node_threat(value: str, db: Session, queues: List[str] = None, types:
         return existing
 
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     if types is None:
         types = ["test_type"]
@@ -519,7 +519,7 @@ def create_node_threat(value: str, db: Session, queues: List[str] = None, types:
 
 def create_node_threat_type(value: str, db: Session, queues: List[str] = None) -> NodeThreatType:
     if queues is None:
-        queues = ["default"]
+        queues = ["external"]
 
     obj: NodeThreatType = _create_basic_object(db_table=NodeThreatType, value=value, db=db)
     obj.queues = [create_queue(value=queue, db=db) for queue in queues]
@@ -608,10 +608,10 @@ def create_queue(value: str, db: Session) -> Queue:
 def create_user(
     username: str,
     db: Session,
-    alert_queue: str = "test_queue",
+    alert_queue: str = "external",
     display_name: str = "Analyst",
     email: Optional[str] = None,
-    event_queue: str = "test_queue",
+    event_queue: str = "external",
     password: str = "asdfasdf",
     roles: List[str] = None,
 ) -> User:

--- a/bin/test-backend.sh
+++ b/bin/test-backend.sh
@@ -12,3 +12,5 @@ new_path=${1#backend/app/}
 
 docker-compose up -d
 docker exec -e SQL_ECHO=no ace2-ams-api pytest "$new_path" -vv
+
+bin/disable-test-mode.sh

--- a/bin/test-e2e.sh
+++ b/bin/test-e2e.sh
@@ -18,3 +18,5 @@ docker exec ace2-ams-gui bin/wait-for-gui.sh
 
 # Run Cypress
 docker exec ace2-ams-gui xvfb-run cypress run --headed --browser chrome
+
+bin/disable-test-mode.sh

--- a/bin/test-frontend-unit.sh
+++ b/bin/test-frontend-unit.sh
@@ -4,6 +4,7 @@
 ACE2_ENV_PATH="$HOME/.ace2.env"
 set -a
 source "$ACE2_ENV_PATH"
+export TESTING=yes
 set +a
 
 # Remove the leading frontend/ from the command line argument so the path works inside of the container.
@@ -12,3 +13,5 @@ TEST_FILE=${1#frontend/}
 docker-compose up -d
 # docker exec ace2-ams-gui npm run test:unit "$TEST_FILE" -- --coverage
 docker exec -e VITE_TESTING=yes ace2-ams-gui npm run test:unit "$TEST_FILE"
+
+bin/disable-test-mode.sh

--- a/bin/test-interactive-e2e.sh
+++ b/bin/test-interactive-e2e.sh
@@ -11,5 +11,4 @@ set +a
 docker-compose -f docker-compose.yml up -d
 
 printf "\nYou can now open Cypress on your host system\n"
-printf "You can optionally exit test mode when you are finished\n"
-printf "Example: bin/disable-test-mode.sh\n"
+printf "Exit test mode when you are finished: bin/disable-test-mode.sh\n"

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -374,7 +374,8 @@
     alertDescription.value = "Manual Alert";
     alertDescriptionAppendString.value = "";
     alertType.value = "manual";
-    queue.value = currentUserSettingsStore.preferredAlertQueue.value;
+    // TODO: This needs to be based on the current user's preferred queue
+    queue.value = "external";
     errors.value = [];
     timezone.value = moment.tz.guess();
     observables.value = [];

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -251,6 +251,7 @@
   import { useQueueStore } from "@/stores/queue";
   import { useAlertTypeStore } from "@/stores/alertType";
   import { useAuthStore } from "@/stores/auth";
+  import { useCurrentUserSettingsStore } from "@/stores/currentUserSettings";
   import { useNodeDirectiveStore } from "@/stores/nodeDirective";
   import { useObservableTypeStore } from "@/stores/observableType";
 
@@ -259,6 +260,7 @@
   const alertStore = useAlertStore();
   const alertTypeStore = useAlertTypeStore();
   const authStore = useAuthStore();
+  const currentUserSettingsStore = useCurrentUserSettingsStore();
   const nodeDirectiveStore = useNodeDirectiveStore();
   const observableTypeStore = useObservableTypeStore();
   const queueStore = useQueueStore();
@@ -372,7 +374,7 @@
     alertDescription.value = "Manual Alert";
     alertDescriptionAppendString.value = "";
     alertType.value = "manual";
-    queue.value = "default";
+    queue.value = currentUserSettingsStore.preferredAlertQueue.value;
     errors.value = [];
     timezone.value = moment.tz.guess();
     observables.value = [];

--- a/frontend/src/components/Node/NodeThreatSelector.vue
+++ b/frontend/src/components/Node/NodeThreatSelector.vue
@@ -147,7 +147,8 @@
     } else {
       await nodeThreatStore.create({
         value: newThreatName.value,
-        queues: ["default"],
+        // TODO: This needs to be based on the current user's preferred queue
+        queues: ["external"],
         types: newThreatTypes.value.map((x) => x.value),
       });
     }

--- a/frontend/src/etc/configuration/events.ts
+++ b/frontend/src/etc/configuration/events.ts
@@ -80,7 +80,7 @@ export const eventRangeFilters = {
 };
 
 export const eventQueueColumnMappings: Record<string, columnOption[]> = {
-  default: [
+  external: [
     {
       field: "edit",
       header: "",
@@ -120,7 +120,7 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
     { field: "owner", header: "Owner", sortable: true, default: true },
     { field: "vectors", header: "Vectors", sortable: false, default: false },
   ],
-  secondary_queue: [
+  internal: [
     {
       field: "edit",
       header: "",
@@ -158,6 +158,46 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
     },
     { field: "status", header: "Status", sortable: true, default: true },
     { field: "owner", header: "Owner", sortable: true, default: false },
+    { field: "vectors", header: "Vectors", sortable: false, default: false },
+  ],
+  intel: [
+    {
+      field: "edit",
+      header: "",
+      sortable: false,
+      required: true,
+    },
+    { field: "createdTime", header: "Created", sortable: true, default: true },
+    { field: "name", header: "Name", sortable: true, default: true },
+    {
+      field: "threatActors",
+      header: "Threat Actors",
+      sortable: false,
+      default: false,
+    },
+    { field: "threats", header: "Threats", sortable: false, default: true },
+    { field: "type", header: "Type", sortable: true, default: false },
+    {
+      field: "riskLevel",
+      header: "Risk Level",
+      sortable: true,
+      default: true,
+    },
+    // dispo?
+    {
+      field: "preventionTools",
+      header: "Prevention Tools",
+      sortable: false,
+      default: true,
+    },
+    {
+      field: "remediations",
+      header: "Remediation",
+      sortable: true,
+      default: true,
+    },
+    { field: "status", header: "Status", sortable: true, default: true },
+    { field: "owner", header: "Owner", sortable: true, default: true },
     { field: "vectors", header: "Vectors", sortable: false, default: false },
   ],
 };

--- a/frontend/src/etc/configuration/test/alerts.ts
+++ b/frontend/src/etc/configuration/test/alerts.ts
@@ -12,6 +12,7 @@ import {
   observableProperty,
   observableTypesProperty,
   nodeTagsProperty,
+  nodeThreatsProperty,
   queueProperty,
   ownerProperty,
 } from "@/etc/constants/base";
@@ -28,6 +29,7 @@ export const alertFilters: readonly propertyOption[] = [
   ownerProperty,
   queueProperty,
   nodeTagsProperty,
+  nodeThreatsProperty,
 ] as const;
 
 export const alertRangeFilters = {

--- a/frontend/src/etc/configuration/test/events.ts
+++ b/frontend/src/etc/configuration/test/events.ts
@@ -46,7 +46,7 @@ export const eventRangeFilters = {
 };
 
 export const eventQueueColumnMappings: Record<string, columnOption[]> = {
-  default: [
+  external: [
     {
       field: "edit",
       header: "",
@@ -87,7 +87,7 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
     { field: "vectors", header: "Vectors", sortable: false, default: false },
     { field: "queue", header: "Queue", sortable: true, default: false },
   ],
-  secondary_queue: [
+  internal: [
     {
       field: "edit",
       header: "",
@@ -128,7 +128,7 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
     { field: "vectors", header: "Vectors", sortable: false, default: false },
     { field: "queue", header: "Queue", sortable: true, default: false },
   ],
-  test_queue: [
+  intel: [
     {
       field: "edit",
       header: "",
@@ -143,13 +143,13 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
       sortable: false,
       default: false,
     },
-    { field: "threats", header: "Threats", sortable: false, default: false },
-    { field: "type", header: "Type", sortable: true, default: true },
+    { field: "threats", header: "Threats", sortable: false, default: true },
+    { field: "type", header: "Type", sortable: true, default: false },
     {
       field: "riskLevel",
       header: "Risk Level",
-      sortable: true,
-      default: false,
+      sortable: false,
+      default: true,
     },
     // dispo?
     {
@@ -164,8 +164,8 @@ export const eventQueueColumnMappings: Record<string, columnOption[]> = {
       sortable: true,
       default: false,
     },
-    { field: "status", header: "Status", sortable: true, default: false },
-    { field: "owner", header: "Owner", sortable: true, default: false },
+    { field: "status", header: "Status", sortable: true, default: true },
+    { field: "owner", header: "Owner", sortable: true, default: true },
     { field: "vectors", header: "Vectors", sortable: false, default: false },
     { field: "queue", header: "Queue", sortable: true, default: false },
   ],

--- a/frontend/src/stores/currentUserSettings.ts
+++ b/frontend/src/stores/currentUserSettings.ts
@@ -1,11 +1,14 @@
-import { queueRead } from "@/models/queue";
+import { useAuthStore } from "./auth";
 import { defineStore } from "pinia";
 
 export const useCurrentUserSettingsStore = defineStore({
   id: "currentUserSettingsStore",
 
-  state: () => ({
-    preferredEventQueue: null as unknown as queueRead,
-    preferredAlertQueue: null as unknown as queueRead,
-  }),
+  state: () => {
+    const authStore = useAuthStore();
+    return {
+      preferredEventQueue: authStore.user.defaultEventQueue,
+      preferredAlertQueue: authStore.user.defaultAlertQueue,
+    };
+  },
 });

--- a/frontend/src/stores/currentUserSettings.ts
+++ b/frontend/src/stores/currentUserSettings.ts
@@ -1,14 +1,11 @@
-import { useAuthStore } from "./auth";
+import { queueRead } from "@/models/queue";
 import { defineStore } from "pinia";
 
 export const useCurrentUserSettingsStore = defineStore({
   id: "currentUserSettingsStore",
 
-  state: () => {
-    const authStore = useAuthStore();
-    return {
-      preferredEventQueue: authStore.user.defaultEventQueue,
-      preferredAlertQueue: authStore.user.defaultAlertQueue,
-    };
-  },
+  state: () => ({
+    preferredEventQueue: null as unknown as queueRead,
+    preferredAlertQueue: null as unknown as queueRead,
+  }),
 });

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -11,8 +11,8 @@ describe("ManageAlerts.vue", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -20,7 +20,10 @@ describe("ManageAlerts.vue", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: [
+        "@getAlertsDefaultRowsExternalQueue",
+        "@getAlertsDefaultRows",
+      ],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -286,8 +289,8 @@ describe("Manage Alerts Filter Actions", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -295,7 +298,7 @@ describe("Manage Alerts Filter Actions", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -522,7 +525,7 @@ describe("Manage Alerts Filter Actions", () => {
     cy.get(":nth-child(1) > .p-dropdown").eq(0).should("have.text", "Name");
     cy.get(".inputfield").should("have.value", "hello world");
     cy.get(":nth-child(1) > .p-dropdown").eq(1).should("have.text", "Queue");
-    cy.get(":nth-child(1) > .p-dropdown").eq(2).should("have.text", "default");
+    cy.get(":nth-child(1) > .p-dropdown").eq(2).should("have.text", "external");
 
     // Exit modal for end of test
     cy.get(".p-dialog-header-close-icon").click();
@@ -588,8 +591,8 @@ describe("Manage Alerts Comment", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -597,7 +600,7 @@ describe("Manage Alerts Comment", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -645,8 +648,8 @@ describe("Manage Alerts Tags", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -654,7 +657,7 @@ describe("Manage Alerts Tags", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -714,8 +717,8 @@ describe("Manage Alerts Take Ownership", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -723,7 +726,7 @@ describe("Manage Alerts Take Ownership", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -773,8 +776,8 @@ describe("Manage Alerts Assign", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -782,7 +785,7 @@ describe("Manage Alerts Assign", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -838,8 +841,8 @@ describe("Manage Alerts Disposition", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -847,7 +850,7 @@ describe("Manage Alerts Disposition", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -934,8 +937,8 @@ describe("Manage Alerts - Save to Event", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -943,7 +946,7 @@ describe("Manage Alerts - Save to Event", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -1425,8 +1428,8 @@ describe("Manage Alerts URL Param Filters", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -1434,7 +1437,7 @@ describe("Manage Alerts URL Param Filters", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally
@@ -1562,8 +1565,8 @@ describe("Manage Alerts Filters Chips", () => {
     // Intercept the API call that loads the default alert table view
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getAlertsDefaultRowsDefaultQueue");
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getAlertsDefaultRowsExternalQueue");
     cy.intercept(
       "GET",
       "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0",
@@ -1571,7 +1574,7 @@ describe("Manage Alerts Filters Chips", () => {
 
     visitUrl({
       url: "/manage_alerts",
-      extraIntercepts: ["@getAlertsDefaultRowsDefaultQueue"],
+      extraIntercepts: ["@getAlertsDefaultRowsExternalQueue"],
     });
 
     // Remove the default queue filter so tests can complete normally

--- a/frontend/tests/e2e/specs/ManageEvents.spec.js
+++ b/frontend/tests/e2e/specs/ManageEvents.spec.js
@@ -11,11 +11,11 @@ describe("ManageEvents.vue UI Elements", () => {
     cy.intercept(
       "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
+    ).as("getEventsDefaultRowsExternalQueue");
 
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultRows"],
+      extraIntercepts: ["@getEventsDefaultRowsExternalQueue"],
     });
 
     // Remove default queue filter (irrelevant to this test suite)
@@ -78,11 +78,11 @@ describe("ManageEvents.vue table functionality", () => {
     cy.intercept(
       "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
+    ).as("getEventsDefaultRowsExternalQueue");
 
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultRows"],
+      extraIntercepts: ["@getEventsDefaultRowsExternalQueue"],
     });
 
     // Remove default queue filter (irrelevant to this test suite)
@@ -231,7 +231,7 @@ describe("ManageEvents.vue table functionality", () => {
     cy.intercept(
       "GET",
       "/api/event/?sort=created_time%7Casc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
+    ).as("getEventsDefaultRowsExternalQueue");
     cy.intercept("GET", "/api/event/?sort=name%7Casc&limit=10&offset=0").as(
       "getEventsNameAscending",
     );
@@ -249,7 +249,9 @@ describe("ManageEvents.vue table functionality", () => {
 
     // Click reset
     cy.get('[data-cy="reset-table-button"]').click();
-    cy.wait("@getEventsDefaultRows").its("state").should("eq", "Complete");
+    cy.wait("@getEventsDefaultRowsExternalQueue")
+      .its("state")
+      .should("eq", "Complete");
 
     // Check columns
     // Check default columns in column select
@@ -299,12 +301,19 @@ describe("ManageEvents.vue Filtering", () => {
     // Intercept the API call that loads the default event table view
     cy.intercept(
       "GET",
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getEventsDefaultRowsExternalQueue");
+    cy.intercept(
+      "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
     ).as("getEventsDefaultRows");
 
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultRows"],
+      extraIntercepts: [
+        "@getEventsDefaultRowsExternalQueue",
+        "@getEventsDefaultRows",
+      ],
     });
 
     // Remove default queue filter (irrelevant to this test suite)
@@ -565,8 +574,6 @@ describe("ManageEvents.vue Filtering", () => {
       .click()
       .type("2020-01-01")
       .type("{enter}");
-    // Click away from panel
-    cy.get("#FilterToolbar > .p-toolbar").click();
     cy.wait("@getEventsCreatedBeforeFilter")
       .its("state")
       .should("eq", "Complete");
@@ -607,11 +614,11 @@ describe("ManageEvents.vue Actions", () => {
     cy.intercept(
       "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
+    ).as("getEventsDefaultRowsExternalQueue");
 
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultRows"],
+      extraIntercepts: ["@getEventsDefaultRowsExternalQueue"],
     });
 
     // Remove default queue filter (irrelevant to this test suite)
@@ -721,7 +728,9 @@ describe("ManageEvents.vue Actions", () => {
     cy.get(".p-inputtextarea").click().type("Test comment");
     cy.get(".p-dialog-footer > button ").eq(1).click();
     cy.wait("@createComment").its("state").should("eq", "Complete");
-    cy.wait("@getEventsDefaultRows").its("state").should("eq", "Complete");
+    cy.wait("@getEventsDefaultRowsExternalQueue")
+      .its("state")
+      .should("eq", "Complete");
 
     // Check for comment displayed
     cy.get('[data-cy="comments"]').should(
@@ -737,7 +746,9 @@ describe("ManageEvents.vue Actions", () => {
     cy.get(".p-selection-column > .p-checkbox ").click();
     cy.get('[data-cy="take-ownership-button"]').click();
     cy.wait("@takeOwnership").its("state").should("eq", "Complete");
-    cy.wait("@getEventsDefaultRows").its("state").should("eq", "Complete");
+    cy.wait("@getEventsDefaultRowsExternalQueue")
+      .its("state")
+      .should("eq", "Complete");
 
     // Check owner
     cy.get(".p-datatable-tbody > tr > :nth-child(9) > span").should(
@@ -757,7 +768,9 @@ describe("ManageEvents.vue Actions", () => {
     cy.get(".p-dropdown-item").eq(0).click();
     cy.get(".p-dialog-footer > button ").eq(1).click();
     cy.wait("@assign").its("state").should("eq", "Complete");
-    cy.wait("@getEventsDefaultRows").its("state").should("eq", "Complete");
+    cy.wait("@getEventsDefaultRowsExternalQueue")
+      .its("state")
+      .should("eq", "Complete");
 
     // Check owner
     cy.get(".p-datatable-tbody > tr > :nth-child(9) > span").should(
@@ -771,7 +784,7 @@ describe("ManageEvents.vue Actions", () => {
     cy.intercept(
       "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
+    ).as("getEventsDefaultRowsExternalQueue");
 
     // Select an event
     cy.get(".p-selection-column > .p-checkbox ").click();
@@ -790,7 +803,9 @@ describe("ManageEvents.vue Actions", () => {
 
     cy.wait("@createTag").its("state").should("eq", "Complete");
     cy.wait("@createTag").its("state").should("eq", "Complete");
-    cy.wait("@getEventsDefaultRows").its("state").should("eq", "Complete");
+    cy.wait("@getEventsDefaultRowsExternalQueue")
+      .its("state")
+      .should("eq", "Complete");
 
     // Check for tags
     cy.get(" .p-tag").eq(0).should("have.text", "TestTag");

--- a/frontend/tests/e2e/specs/TheEventsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheEventsTable.spec.js
@@ -711,63 +711,60 @@ describe("TheEventsTable.vue - Queue Settings", () => {
     ).as("getEventsDefaultRows");
     cy.intercept(
       "GET",
-      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=default",
-    ).as("getEventsDefaultQueueFilter");
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=external",
+    ).as("getEventsExternalQueueFilter");
     cy.intercept(
       "GET",
-      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=secondary_queue",
-    ).as("getEventsSecondaryQueueFilter");
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=internal",
+    ).as("getEventsInternalQueueFilter");
 
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultQueueFilter"],
+      extraIntercepts: ["@getEventsExternalQueueFilter"],
     });
   });
 
   it("will auto-set the event queue filter and event table columns based on the auth'd users preferredEventQueue", () => {
-    //  Default queue filter should be there (check filter chip)
+    //  External queue filter should be there (check filter chip)
     cy.get(".p-chip .filter-name-text").should("have.text", "Queue:");
-    cy.get('[data-cy="filter-chip-content"]').should("have.text", "default");
+    cy.get('[data-cy="filter-chip-content"]').should("have.text", "external");
     // Queue selector should have right value
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-label',
-    ).should("have.text", "default");
+    ).should("have.text", "external");
     // Correct columns should be showing
     cy.get(".p-multiselect-label").should(
       "have.text",
       "Created, Name, Threats, Risk Level, Status, Owner",
     );
 
-    // log out and log back in as 'alice', whose default event queue is 'secondary_queue'
+    // log out and log back in as 'alice', whose default event queue is 'internal'
     cy.logout();
     cy.login("alice");
     // go to manage events
     visitUrl({
       url: "/manage_events",
-      extraIntercepts: ["@getEventsSecondaryQueueFilter"],
+      extraIntercepts: ["@getEventsInternalQueueFilter"],
     });
 
     //  Default queue filter should be there (check filter chip)
     cy.get(".p-chip .filter-name-text").should("have.text", "Queue:");
-    cy.get('[data-cy="filter-chip-content"]').should(
-      "have.text",
-      "secondary_queue",
-    );
+    cy.get('[data-cy="filter-chip-content"]').should("have.text", "internal");
     // Queue selector should have right value
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-label',
-    ).should("have.text", "secondary_queue");
+    ).should("have.text", "internal");
     // Correct columns should be showing
     cy.get(".p-multiselect-label").should("have.text", "Created, Name, Type");
   });
   it("will update the event queue filter and event table columns when preferred event queue is changed", () => {
     //  Default queue filter should be there (check filter chip)
     cy.get(".p-chip .filter-name-text").should("have.text", "Queue:");
-    cy.get('[data-cy="filter-chip-content"]').should("have.text", "default");
+    cy.get('[data-cy="filter-chip-content"]').should("have.text", "external");
     // Queue selector should have right value
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-label',
-    ).should("have.text", "default");
+    ).should("have.text", "external");
     // Correct columns should be showing
     cy.get(".p-multiselect-label").should(
       "have.text",
@@ -779,43 +776,40 @@ describe("TheEventsTable.vue - Queue Settings", () => {
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-trigger',
     ).click();
     cy.get(".p-dropdown-items").should("be.visible");
-    cy.get('[aria-label="default"]').should("be.visible");
-    cy.get('[aria-label="secondary_queue"]').should("be.visible");
-    cy.get('[aria-label="test_queue"]').should("be.visible");
+    cy.get('[aria-label="external"]').should("be.visible");
+    cy.get('[aria-label="internal"]').should("be.visible");
+    cy.get('[aria-label="intel"]').should("be.visible");
 
-    // Switch to secondary queue and check data
-    cy.get('[aria-label="secondary_queue"]').click();
-    cy.wait("@getEventsSecondaryQueueFilter")
+    // Switch to internal queue and check data
+    cy.get('[aria-label="internal"]').click();
+    cy.wait("@getEventsInternalQueueFilter")
       .its("state")
       .should("eq", "Complete");
-    //  secondary queue filter should be there (check filter chip)
+    // internal queue filter should be there (check filter chip)
     cy.get(".p-chip .filter-name-text").should("have.text", "Queue:");
-    cy.get('[data-cy="filter-chip-content"]').should(
-      "have.text",
-      "secondary_queue",
-    );
+    cy.get('[data-cy="filter-chip-content"]').should("have.text", "internal");
     // Queue selector should have right value
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-label',
-    ).should("have.text", "secondary_queue");
+    ).should("have.text", "internal");
     // Correct columns should be showing
     cy.get(".p-multiselect-label").should("have.text", "Created, Name, Type");
 
-    // Switch back to default queue
+    // Switch back to external queue
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-trigger',
     ).click();
-    cy.get('[aria-label="default"]').click();
-    cy.wait("@getEventsDefaultQueueFilter")
+    cy.get('[aria-label="external"]').click();
+    cy.wait("@getEventsExternalQueueFilter")
       .its("state")
       .should("eq", "Complete");
-    //  Default queue filter should be there (check filter chip)
+    // External queue filter should be there (check filter chip)
     cy.get(".p-chip .filter-name-text").should("have.text", "Queue:");
-    cy.get('[data-cy="filter-chip-content"]').should("have.text", "default");
+    cy.get('[data-cy="filter-chip-content"]').should("have.text", "external");
     // Queue selector should have right value
     cy.get(
       '[data-cy="event-queue-selector"] > .p-dropdown > .p-dropdown-label',
-    ).should("have.text", "default");
+    ).should("have.text", "external");
     // Correct columns should be showing
     cy.get(".p-multiselect-label").should(
       "have.text",

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -366,7 +366,7 @@ describe("ViewAlert.vue", () => {
     cy.get(":nth-child(8) > .header-cell").should("contain.text", "Queue");
     cy.get(":nth-child(8) > .content-cell > span").should(
       "contain.text",
-      "test_queue",
+      "external",
     );
     cy.get(":nth-child(9) > .header-cell").should("contain.text", "Owner");
     cy.get(":nth-child(9) > .content-cell > span").should(

--- a/frontend/tests/e2e/specs/ViewAnalysis.spec.js
+++ b/frontend/tests/e2e/specs/ViewAnalysis.spec.js
@@ -52,7 +52,7 @@ describe("ViewAnalysis.vue", () => {
   it("Will route to home (Manage Alerts) when home breadcrumb is clicked", () => {
     cy.intercept(
       "GET",
-      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=default",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&queue=external",
     ).as("getAlerts");
 
     cy.get(".p-breadcrumb-home > .p-menuitem-link").click();

--- a/frontend/tests/mocks/alert.ts
+++ b/frontend/tests/mocks/alert.ts
@@ -465,18 +465,18 @@ export const mockAlert: alertTreeRead = {
   instructions: null,
   queue: {
     description: null,
-    value: "test_queue",
+    value: "external",
     uuid: "a7adcd83-5c0e-4185-874a-c548fe8116e9",
   },
   owner: {
     defaultAlertQueue: {
       description: null,
-      value: "test_queue",
+      value: "external",
       uuid: "a7adcd83-5c0e-4185-874a-c548fe8116e9",
     },
     defaultEventQueue: {
       description: null,
-      value: "test_queue",
+      value: "external",
       uuid: "167b7210-f7d2-46eb-8c7a-61ce6c7e9ece",
     },
     displayName: "Analyst",
@@ -502,12 +502,12 @@ export const mockAlert: alertTreeRead = {
   dispositionUser: {
     defaultAlertQueue: {
       description: null,
-      value: "test_queue",
+      value: "external",
       uuid: "a7adcd83-5c0e-4185-874a-c548fe8116e9",
     },
     defaultEventQueue: {
       description: null,
-      value: "test_queue",
+      value: "external",
       uuid: "167b7210-f7d2-46eb-8c7a-61ce6c7e9ece",
     },
     displayName: "Analyst",
@@ -552,7 +552,7 @@ export const mockAlertReadA: alertRead = {
   instructions: null,
   queue: {
     description: null,
-    value: "test_queue",
+    value: "external",
     uuid: "5e490c53-9d48-434f-9acf-4f3b91e1de74",
   },
   owner: null,
@@ -631,7 +631,7 @@ export const mockAlertReadB: alertRead = {
   instructions: null,
   queue: {
     description: null,
-    value: "test_queue",
+    value: "external",
     uuid: "5e490c53-9d48-434f-9acf-4f3b91e1de74",
   },
   owner: null,
@@ -710,7 +710,7 @@ export const mockAlertReadC: alertRead = {
   instructions: null,
   queue: {
     description: null,
-    value: "test_queue",
+    value: "external",
     uuid: "5e490c53-9d48-434f-9acf-4f3b91e1de74",
   },
   owner: null,
@@ -817,7 +817,7 @@ export const mockAlertReadASummary: alertSummary = {
   insertTime: new Date("2021-12-18T00:59:43.570343+00:00"),
   name: "Small Alert",
   owner: "Analyst",
-  queue: "test_queue",
+  queue: "external",
   tags: [],
   tool: "test_tool",
   toolInstance: "test_tool_instance",

--- a/frontend/tests/unit/src/components/Alerts/AlertTableCell.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AlertTableCell.spec.ts
@@ -63,7 +63,7 @@ const mockAlertReadASummary: alertSummary = {
   insertTime: new Date("2021-12-18T00:59:43.570343+00:00"),
   name: "Small Alert",
   owner: "Analyst",
-  queue: "test_queue",
+  queue: "external",
   tags: [],
   tool: "test_tool",
   toolInstance: "test_tool_instance",

--- a/frontend/tests/unit/src/components/Alerts/AnalyzeAlertForm.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AnalyzeAlertForm.spec.ts
@@ -145,7 +145,7 @@ describe("AnalyzeAlertForm non-async methods", () => {
     expect(wrapper.vm.alertDate).toBeInstanceOf(Date);
     expect(wrapper.vm.alertDescription).toEqual("Manual Alert");
     expect(wrapper.vm.alertDescriptionAppendString).toEqual("");
-    expect(wrapper.vm.queue).toEqual("default");
+    expect(wrapper.vm.queue).toEqual("external");
     expect(wrapper.vm.alertType).toBe("manual");
     expect(wrapper.vm.errors).toStrictEqual([]);
     expect(wrapper.vm.observables).toStrictEqual([
@@ -283,7 +283,7 @@ describe("AnalyzeAlertForm async methods", () => {
     name: "Manual Alert",
     observables: [expectedObservableCreate],
     owner: "analyst",
-    queue: "default",
+    queue: "external",
     type: "manual",
   };
 

--- a/frontend/tests/unit/src/components/Events/TheEventsTable.spec.ts
+++ b/frontend/tests/unit/src/components/Events/TheEventsTable.spec.ts
@@ -12,7 +12,7 @@ import { useFilterStore } from "../../../../../src/stores/filter";
 
 import { testConfiguration } from "@/etc/configuration/test/index";
 
-import { vitest, expect } from "vitest";
+import { expect } from "vitest";
 
 function factory(options?: TestingOptions) {
   const router = createRouterMock();
@@ -49,7 +49,7 @@ describe("TheEventsTable data/creation", () => {
 
   it("will set columns and filter based on current user's preferred queue and increase the table key", async () => {
     const { wrapper, currentUserSettingsStore, filterStore } = factory();
-    const defaultQueue = genericObjectReadFactory({ value: "default" });
+    const defaultQueue = genericObjectReadFactory({ value: "external" });
 
     currentUserSettingsStore.preferredEventQueue = defaultQueue;
     wrapper.vm.setColumns();
@@ -67,7 +67,7 @@ describe("TheEventsTable data/creation", () => {
   });
   it("will call setColumns when currentUserSettingsStore.preferredEventQueue changes", async () => {
     const { wrapper, currentUserSettingsStore, filterStore } = factory();
-    const defaultQueue = genericObjectReadFactory({ value: "default" });
+    const defaultQueue = genericObjectReadFactory({ value: "external" });
 
     currentUserSettingsStore.preferredEventQueue = defaultQueue;
 
@@ -84,7 +84,7 @@ describe("TheEventsTable data/creation", () => {
   });
   it("will not update anything if currentUserSettingsStore updates, but doesn't include preferredEventQueue", async () => {
     const { wrapper, currentUserSettingsStore, filterStore } = factory();
-    const defaultQueue = genericObjectReadFactory({ value: "default" });
+    const defaultQueue = genericObjectReadFactory({ value: "external" });
 
     currentUserSettingsStore.preferredAlertQueue = defaultQueue;
 

--- a/frontend/tests/unit/src/components/Node/NodeThreatSelector.spec.ts
+++ b/frontend/tests/unit/src/components/Node/NodeThreatSelector.spec.ts
@@ -112,7 +112,7 @@ describe("NodeThreatSelector.vue", () => {
 
     await wrapper.vm.submitNewThreat();
     expect(nodeThreatStore.create).toHaveBeenCalledWith({
-      queues: ["default"],
+      queues: ["external"],
       types: ["testThreatType"],
       value: "threatName",
     });

--- a/frontend/tests/unit/src/store/alertTable.spec.ts
+++ b/frontend/tests/unit/src/store/alertTable.spec.ts
@@ -80,7 +80,7 @@ const mockAlertReadBSummary: alertSummary = {
   insertTime: new Date("2021-12-18T00:59:43.570343+00:00"),
   name: "Small Alert",
   owner: "Analyst",
-  queue: "test_queue",
+  queue: "external",
   tags: [],
   tool: "test_tool",
   toolInstance: "test_tool_instance",


### PR DESCRIPTION
This PR updates the backend seed script so that it associates various items with their queues. It also:

* Removes the "default" queue and instead uses "external", "internal", and "intel"
* Uses the currentUserSettingsStore to set the alert queue when creating a manual alert