### PR TITLE
Adds the analysis_types field when fetching an event

### DIFF
--- a/backend/app/api/models/event.py
+++ b/backend/app/api/models/event.py
@@ -85,6 +85,10 @@ class EventCreate(NodeCreate, EventBase):
 class EventRead(NodeRead, EventBase):
     alert_uuids: List[UUID4] = Field(default_factory=list, description="A list of alert UUIDs contained in the event")
 
+    analysis_types: List[str] = Field(
+        description="A deduplicated list of analysis module types that exist within the event", default_factory=list
+    )
+
     auto_alert_time: Optional[datetime] = Field(
         description="The automatically calculated time of the earliest insert time from the alerts in the event"
     )


### PR DESCRIPTION
This PR adds the `analysis_types` field when fetching an event from the API. This is a deduplicated list of all the analysis module type values that exist in the event.

The purpose of this is in preparation of building the event details page so that the GUI can adjust what is displayed (or not displayed) based on the types of analyses present in the event. For example, if there is no "Email Analysis" present in the event, then there will not be an Email Summary section shown on the event details page.