### PR TITLE
Fix overwriting tags bug

### DIFF
--- a/frontend/src/components/Alerts/AlertTree.vue
+++ b/frontend/src/components/Alerts/AlertTree.vue
@@ -61,7 +61,7 @@
   import { onBeforeMount, defineProps, ref } from "vue";
   import { useAlertStore } from "@/stores/alert";
   const alertStore = useAlertStore();
-  const openAlertId = ref(alertStore.openAlert.uuid);
+  const openAlertId = ref(alertStore.open.uuid);
 
   const props = defineProps({
     items: { type: Array, required: true },

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -385,7 +385,7 @@
   };
 
   const routeToNewAlert = () => {
-    router.push({ path: `/alert/${alertStore.openAlert.uuid}` });
+    router.push({ path: `/alert/${alertStore.open.uuid}` });
   };
 
   // Given a multi-observable object, expand into a list of single observable objects for each sub-value

--- a/frontend/src/components/Alerts/TheAlertDetails.vue
+++ b/frontend/src/components/Alerts/TheAlertDetails.vue
@@ -3,14 +3,14 @@
 <template>
   <Card>
     <template #title>
-      {{ alertStore.openAlert.name }}
+      {{ alertStore.open.name }}
       <Button
         icon="pi pi-link"
         class="p-button-secondary p-button-outlined p-button-sm"
         @click="copyLink"
       />
       <NodeTagVue
-        v-for="tag in getAllAlertTags(alertStore.openAlert)"
+        v-for="tag in getAllAlertTags(alertStore.open)"
         :key="tag.uuid"
         :tag="tag"
       ></NodeTagVue>

--- a/frontend/src/components/Modals/TagModal.vue
+++ b/frontend/src/components/Modals/TagModal.vue
@@ -67,6 +67,7 @@
 
   const props = defineProps({
     name: { type: String, required: true },
+    reloadObject: { type: String, required: true },
   });
 
   const newTags = ref([]);
@@ -102,8 +103,13 @@
   }
 
   function newNodeTags(uuid, tags) {
-    const node = tableStore.visibleQueriedItemById(uuid);
-    const nodeTags = node ? node.tags : [];
+    let nodeTags = [];
+    if (props.reloadObject == "table") {
+      const node = tableStore.visibleQueriedItemById(uuid);
+      nodeTags = node ? node.tags : [];
+    } else if (props.reloadObject == "node") {
+      nodeTags = nodeStore.open.tags;
+    }
     return tagValues(nodeTags).concat(tags);
   }
 

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -50,10 +50,11 @@
           class="p-m-1 p-button-sm"
           icon="pi pi-tags"
           label="Tag"
+          
           @click="open('TagModal')"
           @requestReload="requestReload"
         />
-        <TagModal name="TagModal" @requestReload="requestReload" />
+        <TagModal name="TagModal" @requestReload="requestReload" :reload-object="props.reloadObject"/>
       </div>
     </template>
     <template #end>

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -50,11 +50,14 @@
           class="p-m-1 p-button-sm"
           icon="pi pi-tags"
           label="Tag"
-          
           @click="open('TagModal')"
           @requestReload="requestReload"
         />
-        <TagModal name="TagModal" @requestReload="requestReload" :reload-object="props.reloadObject"/>
+        <TagModal
+          name="TagModal"
+          @requestReload="requestReload"
+          :reload-object="props.reloadObject"
+        />
       </div>
     </template>
     <template #end>

--- a/frontend/src/pages/Alerts/ViewAlert.vue
+++ b/frontend/src/pages/Alerts/ViewAlert.vue
@@ -2,13 +2,13 @@
 
 <template>
   <TheAlertActionToolbar reload-object="node" />
-  <div v-if="alertStore.openAlert">
+  <div v-if="alertStore.open">
     <TheAlertDetails />
     <br />
     <Card>
       <template #content>
         <div class="p-tree p-component p-tree-wrapper" style="border: none">
-          <AlertTree id="alert-tree" :items="alertStore.openAlert.children" />
+          <AlertTree id="alert-tree" :items="alertStore.open.children" />
         </div>
       </template>
     </Card>

--- a/frontend/src/pages/Alerts/ViewAnalysis.vue
+++ b/frontend/src/pages/Alerts/ViewAnalysis.vue
@@ -30,14 +30,14 @@
 
   async function initPage(analysisID, alertID) {
     analysis.value = await Analysis.read(analysisID);
-    if (!alertStore.openAlert) {
+    if (!alertStore.open) {
       await alertStore.read(alertID);
     }
   }
 
   const alertName = computed(() => {
-    if (alertStore.openAlert) {
-      return alertStore.openAlert.name;
+    if (alertStore.open) {
+      return alertStore.open.name;
     }
     return "Unknown Alert";
   });

--- a/frontend/src/stores/alert.ts
+++ b/frontend/src/stores/alert.ts
@@ -14,7 +14,7 @@ export const useAlertStore = defineStore({
   id: "alertStore",
 
   state: () => ({
-    openAlert: null as unknown as alertTreeRead,
+    open: null as unknown as alertTreeRead,
 
     // whether the alert should be reloaded
     requestReload: false,
@@ -22,8 +22,8 @@ export const useAlertStore = defineStore({
 
   getters: {
     openAlertSummary(): alertSummary | null {
-      if (this.openAlert) {
-        return parseAlertSummary(this.openAlert);
+      if (this.open) {
+        return parseAlertSummary(this.open);
       }
       return null;
     },
@@ -33,7 +33,7 @@ export const useAlertStore = defineStore({
     async create(newAlert: alertCreate) {
       await Alert.createAndRead(newAlert)
         .then((alert) => {
-          this.openAlert = alert;
+          this.open = alert;
         })
         .catch((error) => {
           throw error;
@@ -43,7 +43,7 @@ export const useAlertStore = defineStore({
     async read(uuid: UUID) {
       await Alert.read(uuid)
         .then((alert) => {
-          this.openAlert = alert;
+          this.open = alert;
         })
         .catch((error) => {
           throw error;

--- a/frontend/src/stores/event.ts
+++ b/frontend/src/stores/event.ts
@@ -7,7 +7,7 @@ export const useEventStore = defineStore({
   id: "eventStore",
 
   state: () => ({
-    openEvent: null as unknown as eventRead,
+    open: null as unknown as eventRead,
 
     // whether the event should be reloaded
     requestReload: false,
@@ -17,7 +17,7 @@ export const useEventStore = defineStore({
     async read(uuid: UUID) {
       await Event.read(uuid)
         .then((event) => {
-          this.openEvent = event;
+          this.open = event;
         })
         .catch((error) => {
           throw error;

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -230,13 +230,32 @@ describe("ViewAlert.vue", () => {
   });
 
   // Tag
-  it("should make a request to update tags and get updated alert when owner is set", () => {
+  it("should make a request to update tags and get updated alert when tag added through modal", () => {
     cy.intercept("PATCH", "/api/alert/").as("updateAlert");
     cy.intercept("GET", "/api/alert/02f8299b-2a24-400f-9751-7dd9164daf6a").as(
       "getAlert",
     );
     cy.intercept("GET", "/api/node/tag/?offset=0").as("getNodeTags");
 
+    // Open tag modal
+    cy.get("[data-cy=tag-button]").click();
+
+    cy.get(".p-dialog-content").should("be.visible");
+    cy.wait("@getNodeTags").its("state").should("eq", "Complete");
+    // Type a tag
+    cy.get(".p-chips > .p-inputtext").click().type("TestTag").type("{enter}");
+    // Select a tag from the dropdown
+    cy.get(".p-fluid > .p-dropdown > .p-dropdown-label").click();
+    cy.get('[aria-label="scan_me"]').click();
+    // Submit
+    cy.get(".p-dialog-footer > :nth-child(2)").should("be.visible");
+    cy.get(".p-dialog-footer > :nth-child(2)").click();
+    cy.get(".p-dialog-content").should("not.exist");
+
+    cy.wait("@updateAlert").its("state").should("eq", "Complete");
+    cy.wait("@getAlert").its("state").should("eq", "Complete");
+
+    // Add another tag, make sure that any existing tags are not overwritten
     // Open tag modal
     cy.get("[data-cy=tag-button]").click();
 

--- a/frontend/tests/unit/src/components/Alerts/AlertTree.spec.ts
+++ b/frontend/tests/unit/src/components/Alerts/AlertTree.spec.ts
@@ -13,7 +13,7 @@ describe("AlertTree.vue", () => {
 
     const pinia = createCustomPinia(options);
     const alertStore = useAlertStore();
-    alertStore.openAlert = mockAlert;
+    alertStore.open = mockAlert;
 
     const wrapper: VueWrapper<any> = mount(AlertTree, {
       props: {

--- a/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
@@ -16,7 +16,7 @@ function factory(options?: TestingOptions) {
       plugins: [createCustomPinia(options), PrimeVue],
       provide: { nodeType: "alerts" },
     },
-    props: { name: "TagModal" },
+    props: { name: "TagModal", reloadObject: "table" },
   });
 
   const modalStore = useModalStore();

--- a/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/unit/src/components/Modals/TagModal.spec.ts
@@ -171,8 +171,7 @@ describe("TagModal.vue", () => {
       .reply(200, { items: [{ value: "tag1" }, { value: "tag3" }] });
     const { wrapper } = factory({ stubActions: false }, "node");
 
-    wrapper.vm.nodeStore.open = 
-      { uuid: "uuid1", tags: [{ value: "tag1" }] };
+    wrapper.vm.nodeStore.open = { uuid: "uuid1", tags: [{ value: "tag1" }] };
 
     const res2 = wrapper.vm.newNodeTags("uuid1", ["tag2", "tag3"]);
 

--- a/frontend/tests/unit/src/pages/Alerts/ViewAlert.spec.ts
+++ b/frontend/tests/unit/src/pages/Alerts/ViewAlert.spec.ts
@@ -61,7 +61,7 @@ describe("ViewAlert.vue", () => {
     const alertStore = useAlertStore();
     await wrapper.vm.initPage("uuid1");
     expect(selectedAlertStore.selected).toEqual(["uuid1"]);
-    expect(alertStore.openAlert).toEqual(mockAlertReadDateStrings);
+    expect(alertStore.open).toEqual(mockAlertReadDateStrings);
   });
   it("unselects all selected alerts when umounted", async () => {
     const { wrapper } = factory({ stubActions: false });

--- a/frontend/tests/unit/src/pages/Alerts/ViewAnalysis.spec.ts
+++ b/frontend/tests/unit/src/pages/Alerts/ViewAnalysis.spec.ts
@@ -42,7 +42,7 @@ describe("ViewAnalysis.vue", () => {
     const alertStore = useAlertStore();
     await wrapper.vm.initPage("uuid2", "uuid1");
     expect(wrapper.vm.analysis).toEqual(mockAnalysisRead);
-    expect(alertStore.openAlert).toEqual(mockAlertReadDateStrings);
+    expect(alertStore.open).toEqual(mockAlertReadDateStrings);
   });
   it("correctly computes alertName", async () => {
     await wrapper.vm.initPage("uuid2", "uuid1");

--- a/frontend/tests/unit/src/store/alert.spec.ts
+++ b/frontend/tests/unit/src/store/alert.spec.ts
@@ -47,13 +47,13 @@ describe("alert Actions", () => {
     store.$reset();
   });
 
-  it("will have openAlertSummary return the current openAlert summary if there is one, otherwise it will return null", () => {
+  it("will have openAlertSummary return the current opensummary if there is one, otherwise it will return null", () => {
     expect(store.openAlertSummary).toBeNull();
-    store.openAlert = mockAlertTreeReadA;
+    store.open= mockAlertTreeReadA;
     expect(store.openAlertSummary).toEqual(mockAlertReadASummary);
   });
 
-  it("will request to create an alert with a given AlertCreate object, and set the openAlert to result on success", async () => {
+  it("will request to create an alert with a given AlertCreate object, and set the opento result on success", async () => {
     const mockRequest = myNock
       .post("/alert/", JSON.stringify(snakecaseKeys(mockAlertCreate)))
       .reply(200, mockAlert);
@@ -61,7 +61,7 @@ describe("alert Actions", () => {
     await store.create(mockAlertCreate);
 
     expect(mockRequest.isDone()).toEqual(true);
-    expect(store.openAlert).toEqual(mockAlert);
+    expect(store.open).toEqual(mockAlert);
   });
 
   it("will fetch alert data given an alert ID", async () => {
@@ -70,7 +70,7 @@ describe("alert Actions", () => {
 
     expect(mockRequest.isDone()).toEqual(true);
 
-    expect(store.openAlert).toEqual(mockAlert);
+    expect(store.open).toEqual(mockAlert);
   });
 
   it("will make a request to update an alert given the UUID and update data upon the updateAlert action", async () => {
@@ -79,7 +79,7 @@ describe("alert Actions", () => {
 
     expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.openAlert).toBeNull();
+    expect(store.open).toBeNull();
   });
 
   it("will throw an error when a request fails in any action", async () => {

--- a/frontend/tests/unit/src/store/alert.spec.ts
+++ b/frontend/tests/unit/src/store/alert.spec.ts
@@ -49,7 +49,7 @@ describe("alert Actions", () => {
 
   it("will have openAlertSummary return the current opensummary if there is one, otherwise it will return null", () => {
     expect(store.openAlertSummary).toBeNull();
-    store.open= mockAlertTreeReadA;
+    store.open = mockAlertTreeReadA;
     expect(store.openAlertSummary).toEqual(mockAlertReadASummary);
   });
 

--- a/frontend/tests/unit/src/store/event.spec.ts
+++ b/frontend/tests/unit/src/store/event.spec.ts
@@ -24,8 +24,8 @@ describe("event Actions", () => {
 
     expect(mockRequest.isDone()).toEqual(true);
 
-    // The openEvent is not parsed at all when received, so any dates will be in string format
-    expect(store.openEvent).toEqual(JSON.parse(JSON.stringify(mockEvent)));
+    // The open is not parsed at all when received, so any dates will be in string format
+    expect(store.open).toEqual(JSON.parse(JSON.stringify(mockEvent)));
   });
 
   it("will throw an error if read fails", async () => {
@@ -41,7 +41,7 @@ describe("event Actions", () => {
 
     expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.openEvent).toBeNull();
+    expect(store.open).toBeNull();
   });
 
   it("will throw an error if update fails", async () => {
@@ -52,6 +52,6 @@ describe("event Actions", () => {
 
     expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.openEvent).toBeNull();
+    expect(store.open).toBeNull();
   });
 });


### PR DESCRIPTION
This updates the tag modal to use the 'nodeStore' rather than 'tableStore' to create list of existing of existing and new tags. This will make sure that the existing list of tags is updated when viewing a single alert/event/etc.

Also includes updated tests for the bug (unit and e2e).

Closes #120 