### PR TITLE
Adds dummy analysis details

### DIFF
--- a/backend/app/tests/alerts/small.json
+++ b/backend/app/tests/alerts/small.json
@@ -10,6 +10,15 @@
       "analyses": [
         {
           "type": "Email Analysis",
+          "details": {
+            "from": "badguy@evil.com",
+            "to": "goodguy@company.com",
+            "subject": "Hello",
+            "message_id": "<123abc@evil.com>",
+            "attachments": [],
+            "headers": "blah",
+            "body_text": "Here, download this malware."
+          },
           "observable_types": ["file"],
           "required_directives": ["email"],
           "required_tags": ["scan_me"],

--- a/backend/app/tests/alerts/small_template.json
+++ b/backend/app/tests/alerts/small_template.json
@@ -7,7 +7,16 @@
       "tags": ["<TAG>", "<TAG>", "<TAG>"],
       "analyses": [
         {
-          "type": "<A_TYPE> Analysis",
+          "type": "Email Analysis",
+          "details": {
+            "from": "<O_VALUE>@evil.com",
+            "to": "<O_VALUE>@company.com",
+            "subject": "<O_VALUE>",
+            "message_id": "<O_VALUE>@evil.com",
+            "attachments": [],
+            "headers": "blah",
+            "body_text": "Here, download this malware."
+          },
           "observables": [
             {
               "type": "<O_TYPE>",

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -211,6 +211,7 @@ def create_analysis(
     amt_required_directives: List[str] = None,
     amt_required_tags: List[str] = None,
     amt_version: str = "1.0.0",
+    details: Optional[dict] = None,
     node_metadata: Optional[Dict[str, object]] = None,
 ) -> NodeTree:
     if amt_value:
@@ -228,11 +229,12 @@ def create_analysis(
 
         obj = Analysis(
             analysis_module_type=analysis_module_type,
+            details=details,
             uuid=uuid.uuid4(),
             version=uuid.uuid4(),
         )
     else:
-        obj = Analysis(uuid=uuid.uuid4(), version=uuid.uuid4())
+        obj = Analysis(details=details, uuid=uuid.uuid4(), version=uuid.uuid4())
 
     db.add(obj)
     crud.commit(db)
@@ -658,6 +660,10 @@ def create_user_role(value: str, db: Session) -> UserRole:
 
 def create_alert_from_json_file(db: Session, json_path: str, alert_name: str) -> NodeTree:
     def _create_analysis(a, parent_tree: NodeTree):
+        details = None
+        if "details" in a:
+            details = a["details"]
+
         observable_types = None
         if "observable_types" in a:
             observable_types = a["observable_types"]
@@ -682,6 +688,7 @@ def create_alert_from_json_file(db: Session, json_path: str, alert_name: str) ->
             amt_observable_types=observable_types,
             amt_required_directives=required_directives,
             amt_required_tags=required_tags,
+            details=details,
         )
 
         if "observables" in a:

--- a/bin/insert-alerts.sh
+++ b/bin/insert-alerts.sh
@@ -4,7 +4,6 @@
 ACE2_ENV_PATH="$HOME/.ace2.env"
 set -a
 source "$ACE2_ENV_PATH"
-export TESTING=yes
 set +a
 
 docker-compose up -d

--- a/bin/insert-event.sh
+++ b/bin/insert-event.sh
@@ -4,7 +4,6 @@
 ACE2_ENV_PATH="$HOME/.ace2.env"
 set -a
 source "$ACE2_ENV_PATH"
-export TESTING=yes
 set +a
 
 docker-compose up -d


### PR DESCRIPTION
This PR adds the ability to have analysis details in the `backend/app/tests/alerts/*.json` files. This is in preparation for working on the event details page.