### PR TITLE
Event Details - Event Summary Section

### DIFF
--- a/frontend/src/components/Events/EventSummary.vue
+++ b/frontend/src/components/Events/EventSummary.vue
@@ -3,6 +3,23 @@
 
 <template>
   <h3>Event Summary</h3>
+  <!-- Event Timeline -->
+  <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
+    <template #marker="slotProps">
+      <span class="custom-marker">
+        <i :class="slotProps.item.icon"></i>
+      </span>
+    </template>
+    <template #opposite="slotProps">
+      <small class="p-text-secondary">{{
+        formatDatetime(slotProps.item.datetime)
+      }}</small>
+    </template>
+    <template #content="slotProps">
+      {{ slotProps.item.label }}
+    </template>
+  </Timeline>
+  <!-- Event Details Table -->
   <DataTable
     :value="[parseEventSummary(eventStore.open)]"
     :resizable-columns="true"
@@ -52,19 +69,69 @@
 </template>
 
 <script setup>
-  import { ref, inject } from "vue";
+  import { ref, inject, computed } from "vue";
 
+  import { useEventStore } from "@/stores/event";
   import Button from "primevue/button";
   import Column from "primevue/column";
   import DataTable from "primevue/datatable";
+  import EventTableCell from "./EventTableCell.vue";
   import MultiSelect from "primevue/multiselect";
   import Toolbar from "primevue/toolbar";
-  import EventTableCell from "./EventTableCell.vue";
-  import { useEventStore } from "@/stores/event";
+  import Timeline from "primevue/timeline";
 
   import { parseEventSummary } from "@/stores/eventTable";
 
   const eventStore = useEventStore();
+
+  const eventTimes = [
+    {
+      label: "Event",
+      datetime: eventStore.open.eventTime || eventStore.open.autoEventTime,
+      icon: "pi pi-map-marker",
+    },
+    {
+      label: "Alert",
+      datetime: eventStore.open.alertTime || eventStore.open.autoAlertTime,
+      icon: "pi pi-exclamation-triangle",
+    },
+    {
+      label: "Ownership",
+      datetime:
+        eventStore.open.ownershipTime || eventStore.open.autoOwnershipTime,
+      icon: "pi pi-user-plus",
+    },
+    {
+      label: "Disposition",
+      datetime:
+        eventStore.open.dispositionTime ||
+        eventStore.open.autoDispositionTime ||
+        "TBD",
+      icon: "pi pi-flag",
+    },
+    {
+      label: "Contain",
+      datetime: eventStore.open.containTime || "TBD",
+      icon: "pi pi-shield",
+    },
+    {
+      label: "Remediation",
+      datetime: eventStore.open.remediationTime || "TBD",
+      icon: "pi pi-check-circle",
+    },
+  ];
+
+  const formatDatetime = (datetime) => {
+    if (datetime != "TBD") {
+      const d = new Date(datetime);
+      return d.toLocaleString("en-US");
+    }
+    return datetime;
+  };
+
+  const timelineEvents = computed(() => {
+    return [...eventTimes.filter((event) => event.datetime)];
+  });
 
   const config = inject("config");
   const columns = ref(

--- a/frontend/src/components/Events/EventSummary.vue
+++ b/frontend/src/components/Events/EventSummary.vue
@@ -2,67 +2,75 @@
 <!-- "Event Summary" section on Event Details page -->
 
 <template>
-  <h3>Event Summary</h3>
+  <h3 id="event-section-title">Event Summary</h3>
   <!-- Event Timeline -->
-  <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
-    <template #marker="slotProps">
-      <span class="custom-marker">
-        <i :class="slotProps.item.icon"></i>
-      </span>
-    </template>
-    <template #opposite="slotProps">
-      <small class="p-text-secondary">{{
-        formatDatetime(slotProps.item.datetime)
-      }}</small>
-    </template>
-    <template #content="slotProps">
-      {{ slotProps.item.label }}
-    </template>
-  </Timeline>
-  <!-- Event Details Table -->
-  <DataTable :value="eventTableData" :resizable-columns="true">
-    <!-- TABLE TOOLBAR-->
-    <template #header>
-      <Toolbar style="border: none">
-        <template #start>
-          <!-- COLUMN SELECT -->
-          <MultiSelect
-            :model-value="selectedColumns"
-            :options="columnOptions"
-            data-cy="table-column-select"
-            option-label="header"
-            placeholder="Select Columns"
-            @update:model-value="onColumnToggle"
-          />
-        </template>
-        <template #end>
-          <Button
-            data-cy="reset-table-button"
-            icon="pi pi-refresh"
-            class="p-button-rounded p-m-1"
-            @click="resetColumns()"
-          />
-        </template>
-      </Toolbar>
-    </template>
-
-    <!-- DATA COLUMNS -->
-    <Column
-      v-for="(col, index) of selectedColumns"
-      :key="col.field + '_' + index"
-      :field="col.field"
-      :header="col.header"
-    >
-      <!-- DATA COLUMN CELL BODIES-->
-      <template #body="{ data, field }">
-        <EventTableCell
-          :data="data"
-          :field="field"
-          :show-tags="false"
-        ></EventTableCell>
+  <div id="event-summary-timeline">
+    <Timeline :value="timelineEvents" layout="horizontal" align="bottom">
+      <template #marker="slotProps">
+        <span class="custom-marker" data-cy="event-summary-timeline-icon">
+          <i :class="slotProps.item.icon"></i>
+        </span>
       </template>
-    </Column>
-  </DataTable>
+      <template #opposite="slotProps">
+        <small
+          class="p-text-secondary"
+          data-cy="event-summary-timeline-datetime"
+          >{{ formatDatetime(slotProps.item.datetime) }}</small
+        >
+      </template>
+      <template #content="slotProps">
+        <span data-cy="event-summary-timeline-label">{{
+          slotProps.item.label
+        }}</span>
+      </template>
+    </Timeline>
+  </div>
+  <!-- Event Details Table -->
+  <div id="event-summary-table">
+    <DataTable :value="eventTableData" :resizable-columns="true">
+      <!-- TABLE TOOLBAR-->
+      <template #header>
+        <Toolbar style="border: none">
+          <template #start>
+            <!-- COLUMN SELECT -->
+            <MultiSelect
+              :model-value="selectedColumns"
+              :options="columnOptions"
+              data-cy="table-column-select"
+              option-label="header"
+              placeholder="Select Columns"
+              @update:model-value="onColumnToggle"
+            />
+          </template>
+          <template #end>
+            <Button
+              data-cy="reset-table-button"
+              icon="pi pi-refresh"
+              class="p-button-rounded p-m-1"
+              @click="resetColumns()"
+            />
+          </template>
+        </Toolbar>
+      </template>
+
+      <!-- DATA COLUMNS -->
+      <Column
+        v-for="(col, index) of selectedColumns"
+        :key="col.field + '_' + index"
+        :field="col.field"
+        :header="col.header"
+      >
+        <!-- DATA COLUMN CELL BODIES-->
+        <template #body="{ data, field }">
+          <EventTableCell
+            :data="data"
+            :field="field"
+            :show-tags="false"
+          ></EventTableCell>
+        </template>
+      </Column>
+    </DataTable>
+  </div>
 </template>
 
 <script setup>

--- a/frontend/src/components/Events/EventSummary.vue
+++ b/frontend/src/components/Events/EventSummary.vue
@@ -2,5 +2,84 @@
 <!-- "Event Summary" section on Event Details page -->
 
 <template>
-  <span> Event Summary </span>
+  <h3>Event Summary</h3>
+  <DataTable
+    :value="[parseEventSummary(eventStore.open)]"
+    :resizable-columns="true"
+  >
+    <!-- TABLE TOOLBAR-->
+    <template #header>
+      <Toolbar style="border: none">
+        <template #start>
+          <!-- COLUMN SELECT -->
+          <MultiSelect
+            :model-value="selectedColumns"
+            :options="columnOptions"
+            data-cy="table-column-select"
+            option-label="header"
+            placeholder="Select Columns"
+            @update:model-value="onColumnToggle"
+          />
+        </template>
+        <template #end>
+          <Button
+            data-cy="reset-table-button"
+            icon="pi pi-refresh"
+            class="p-button-rounded p-m-1"
+            @click="reset()"
+          />
+        </template>
+      </Toolbar>
+    </template>
+
+    <!-- DATA COLUMNS -->
+    <Column
+      v-for="(col, index) of selectedColumns"
+      :key="col.field + '_' + index"
+      :field="col.field"
+      :header="col.header"
+    >
+      <!-- DATA COLUMN CELL BODIES-->
+      <template #body="{ data, field }">
+        <EventTableCell
+          :data="data"
+          :field="field"
+          :show-tags="false"
+        ></EventTableCell>
+      </template>
+    </Column>
+  </DataTable>
 </template>
+
+<script setup>
+  import { ref, inject } from "vue";
+
+  import Button from "primevue/button";
+  import Column from "primevue/column";
+  import DataTable from "primevue/datatable";
+  import MultiSelect from "primevue/multiselect";
+  import Toolbar from "primevue/toolbar";
+  import EventTableCell from "./EventTableCell.vue";
+  import { useEventStore } from "@/stores/event";
+
+  import { parseEventSummary } from "@/stores/eventTable";
+
+  const eventStore = useEventStore();
+
+  const config = inject("config");
+  const columns = ref(
+    config.events.eventQueueColumnMappings[eventStore.open.queue.value],
+  );
+  const columnOptions = columns.value.filter((col) => !col.required);
+  const selectedColumns = ref(columns.value.filter((col) => col.default));
+
+  const onColumnToggle = (val) => {
+    // Toggles selected columns to display
+    // This method required/provided by Primevue 'ColToggle' docs
+    selectedColumns.value = columns.value.filter((col) => val.includes(col));
+  };
+
+  const reset = () => {
+    selectedColumns.value = columns.value.filter((col) => col.default);
+  };
+</script>

--- a/frontend/src/components/Events/EventTableCell.vue
+++ b/frontend/src/components/Events/EventTableCell.vue
@@ -10,7 +10,7 @@
       }}</router-link></span
     >
     <!-- Event Tags -->
-    <span data-cy="tags">
+    <span v-if="props.showTags" data-cy="tags">
       <NodeTagVue
         v-for="tag in props.data.tags"
         :key="tag.uuid"
@@ -33,7 +33,10 @@
   >
   <!-- Any event property that uses a list -->
   <span v-else-if="Array.isArray(props.data[props.field])">
-    {{ joinStringArray(props.data[props.field]) }}
+    <span v-if="props.data[props.field].length">
+      {{ joinStringArray(props.data[props.field]) }}
+    </span>
+    <span v-else> None </span>
   </span>
   <!-- Edit event cell -->
   <span v-else-if="props.field === 'edit'">
@@ -71,6 +74,7 @@
   const props = defineProps({
     data: { type: Object, required: true },
     field: { type: String, required: true },
+    showTags: { type: Boolean, required: true, default: true },
   });
 
   const formatDateTime = (dateTime) => {

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -33,6 +33,7 @@ export interface eventSummary {
   uuid: UUID;
   vectors: string[];
   queue: string;
+  remediations: string[];
 }
 
 export interface eventCreate extends nodeCreate {

--- a/frontend/src/pages/Events/ViewEvent.vue
+++ b/frontend/src/pages/Events/ViewEvent.vue
@@ -27,11 +27,12 @@
         </div>
       </template>
       <template #content>
-        <component
-          :is="currentComponent"
-          :section="currentSection"
-          data-cy="event-details-content"
-        ></component>
+        <div data-cy="event-details-content">
+          <component
+            :is="currentComponent"
+            :section="currentSection"
+          ></component>
+        </div>
       </template>
     </Card>
   </div>

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -9,8 +9,6 @@ import {
 import { UUID } from "@/models/base";
 import { BaseApi } from "./base";
 import { eventHistoryReadPage } from "@/models/history";
-import { configuration } from "@/etc/configuration";
-import { testConfiguration } from "@/etc/configuration/test";
 
 const api = new BaseApi();
 const endpoint = "/event/";

--- a/frontend/src/stores/eventTable.ts
+++ b/frontend/src/stores/eventTable.ts
@@ -21,6 +21,7 @@ export function parseEventSummary(event: eventRead): eventSummary {
     uuid: event.uuid,
     vectors: event.vectors.map((x) => x.value),
     queue: event.queue ? event.queue.value : "None",
+    remediations: event.remediations.map((x) => x.value),
   };
 }
 

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -1,216 +1,216 @@
 import { visitUrl } from "./helpers";
 
-// describe("ViewEvent.vue", () => {
-//   before(() => {
-//     cy.resetDatabase();
-//     cy.login();
+describe("ViewEvent.vue", () => {
+  before(() => {
+    cy.resetDatabase();
+    cy.login();
 
-//     // Intercept the API call that loads the event data
-//     cy.intercept("GET", "/api/event/*").as("getEvent");
+    // Intercept the API call that loads the event data
+    cy.intercept("GET", "/api/event/*").as("getEvent");
 
-//     cy.intercept(
-//       "GET",
-//       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-//     ).as("getEventsDefaultRows");
+    cy.intercept(
+      "GET",
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
+    ).as("getEventsDefaultRows");
 
-//     // Add the test event to the database
-//     cy.request({
-//       method: "POST",
-//       url: "/api/test/add_event",
-//       body: {
-//         alert_template: "small_template.json",
-//         alert_count: 1,
-//         name: "Test Event",
-//       },
-//     });
+    // Add the test event to the database
+    cy.request({
+      method: "POST",
+      url: "/api/test/add_event",
+      body: {
+        alert_template: "small_template.json",
+        alert_count: 1,
+        name: "Test Event",
+      },
+    });
 
-//     visitUrl({
-//       url: "/manage_events",
-//       extraIntercepts: ["@getEventsDefaultRows"],
-//     });
-//     cy.get('[data-cy="eventName"] > a').click();
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//   });
+    visitUrl({
+      url: "/manage_events",
+      extraIntercepts: ["@getEventsDefaultRows"],
+    });
+    cy.get('[data-cy="eventName"] > a').click();
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+  });
 
-//   it("View Event page renders", () => {
-//     cy.get('[data-cy="event-details-menu"]').should("be.visible");
-//     cy.get('[aria-haspopup="true"]').eq(0).should("have.text", "Actions");
-//     cy.get('[aria-haspopup="true"]').eq(1).should("have.text", "Information");
-//     cy.get('[aria-haspopup="true"]').eq(2).should("have.text", "Analysis");
-//     cy.get('[data-cy="event-details-card"]').should("be.visible");
-//     cy.get('[data-cy="event-details-header"]').should("be.visible");
-//     cy.get('[data-cy="event-title"]').should("have.text", "Test Event");
-//     cy.get('[data-cy="event-details-link"]').should("be.visible");
-//     cy.get('[data-cy="event-details-content"]').should("be.visible");
-//     cy.get('#event-section-title').should(
-//       "contain.text",
-//       "Event Summary",
-//     );
-//   });
+  it("View Event page renders", () => {
+    cy.get('[data-cy="event-details-menu"]').should("be.visible");
+    cy.get('[aria-haspopup="true"]').eq(0).should("have.text", "Actions");
+    cy.get('[aria-haspopup="true"]').eq(1).should("have.text", "Information");
+    cy.get('[aria-haspopup="true"]').eq(2).should("have.text", "Analysis");
+    cy.get('[data-cy="event-details-card"]').should("be.visible");
+    cy.get('[data-cy="event-details-header"]').should("be.visible");
+    cy.get('[data-cy="event-title"]').should("have.text", "Test Event");
+    cy.get('[data-cy="event-details-link"]').should("be.visible");
+    cy.get('[data-cy="event-details-content"]').should("be.visible");
+    cy.get('#event-section-title').should(
+      "contain.text",
+      "Event Summary",
+    );
+  });
 
-//   it("Switches the component / details section when selected from dropdown", () => {
-//     // Click on the Analysis dropdown
-//     cy.get('[aria-haspopup="true"]').eq(2).click();
-//     // Select first available analysis type
-//     cy.get("span").contains("a_type0 Analysis").click();
-//     // Check that basic analysis showed up
-//     cy.get('[data-cy="event-details-content"]')
-//       .contains("Basic Analysis")
-//       .should("be.visible");
-//     cy.get('[data-cy="event-details-content"]')
-//       .contains("a_type0 Analysis")
-//       .should("be.visible");
-//     // Switch back to the event summary section and check content
-//     cy.get('[aria-haspopup="true"]').eq(1).click();
-//     cy.get("span").contains("Event Summary").click();
-//     cy.get('#event-section-title').should(
-//       "contain.text",
-//       "Event Summary",
-//     );
-//   });
-// });
+  it("Switches the component / details section when selected from dropdown", () => {
+    // Click on the Analysis dropdown
+    cy.get('[aria-haspopup="true"]').eq(2).click();
+    // Select first available analysis type
+    cy.get("span").contains("a_type0 Analysis").click();
+    // Check that basic analysis showed up
+    cy.get('[data-cy="event-details-content"]')
+      .contains("Basic Analysis")
+      .should("be.visible");
+    cy.get('[data-cy="event-details-content"]')
+      .contains("a_type0 Analysis")
+      .should("be.visible");
+    // Switch back to the event summary section and check content
+    cy.get('[aria-haspopup="true"]').eq(1).click();
+    cy.get("span").contains("Event Summary").click();
+    cy.get('#event-section-title').should(
+      "contain.text",
+      "Event Summary",
+    );
+  });
+});
 
-// describe("ViewEvent.vue actions", () => {
-//   beforeEach(() => {
-//     cy.resetDatabase();
-//     cy.login();
+describe("ViewEvent.vue actions", () => {
+  beforeEach(() => {
+    cy.resetDatabase();
+    cy.login();
 
-//     // Intercept the API call that loads the event data
-//     cy.intercept("GET", "/api/event/*").as("getEvent");
+    // Intercept the API call that loads the event data
+    cy.intercept("GET", "/api/event/*").as("getEvent");
 
-//     cy.intercept(
-//       "GET",
-//       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-//     ).as("getEventsDefaultRows");
+    cy.intercept(
+      "GET",
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
+    ).as("getEventsDefaultRows");
 
-//     // Add the test event to the database
-//     cy.request({
-//       method: "POST",
-//       url: "/api/test/add_event",
-//       body: {
-//         alert_template: "small_template.json",
-//         alert_count: 1,
-//         name: "Test Event",
-//       },
-//     });
+    // Add the test event to the database
+    cy.request({
+      method: "POST",
+      url: "/api/test/add_event",
+      body: {
+        alert_template: "small_template.json",
+        alert_count: 1,
+        name: "Test Event",
+      },
+    });
 
-//     visitUrl({
-//       url: "/manage_events",
-//       extraIntercepts: ["@getEventsDefaultRows"],
-//     });
-//     cy.get('[data-cy="eventName"] > a').click();
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//   });
+    visitUrl({
+      url: "/manage_events",
+      extraIntercepts: ["@getEventsDefaultRows"],
+    });
+    cy.get('[data-cy="eventName"] > a').click();
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+  });
 
-//   // Have to log out and manually leave event page
-//   // BC when database resets it will try to get the old event with old uuid
-//   // And will cause an error
-//   afterEach(() => {
-//     cy.logout();
-//     cy.visit("/login");
-//   });
+  // Have to log out and manually leave event page
+  // BC when database resets it will try to get the old event with old uuid
+  // And will cause an error
+  afterEach(() => {
+    cy.logout();
+    cy.visit("/login");
+  });
 
-//   it("Correctly adds comment via comment modal and reloads page", () => {
-//     cy.intercept("POST", "/api/node/comment/").as("addComment");
+  it("Correctly adds comment via comment modal and reloads page", () => {
+    cy.intercept("POST", "/api/node/comment/").as("addComment");
 
-//     // Click on the Actions dropdown
-//     cy.get('[aria-haspopup="true"]').eq(0).click();
-//     cy.get("span").contains("Comment").click();
-//     // Add test data and submit
-//     cy.get(".p-inputtextarea").click().type("Test comment");
-//     cy.get(".p-dialog-footer > Button").last().click();
-//     cy.wait("@addComment").its("state").should("eq", "Complete");
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//   });
-//   it("Correctly takes ownership via take ownership item and reloads page", () => {
-//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+    // Click on the Actions dropdown
+    cy.get('[aria-haspopup="true"]').eq(0).click();
+    cy.get("span").contains("Comment").click();
+    // Add test data and submit
+    cy.get(".p-inputtextarea").click().type("Test comment");
+    cy.get(".p-dialog-footer > Button").last().click();
+    cy.wait("@addComment").its("state").should("eq", "Complete");
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+  });
+  it("Correctly takes ownership via take ownership item and reloads page", () => {
+    cy.intercept("PATCH", "/api/event/").as("updateEvent");
 
-//     // Click on the Actions dropdown
-//     cy.get('[aria-haspopup="true"]').eq(0).click();
-//     cy.get("span").contains("Take Ownership").click();
-//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//   });
-//   it("Correctly assigns owner via assign modal and reloads page", () => {
-//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+    // Click on the Actions dropdown
+    cy.get('[aria-haspopup="true"]').eq(0).click();
+    cy.get("span").contains("Take Ownership").click();
+    cy.wait("@updateEvent").its("state").should("eq", "Complete");
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+  });
+  it("Correctly assigns owner via assign modal and reloads page", () => {
+    cy.intercept("PATCH", "/api/event/").as("updateEvent");
 
-//     // Click on the Actions dropdown
-//     cy.get('[aria-haspopup="true"]').eq(0).click();
-//     cy.get("span").contains("Assign").click();
-//     cy.get(".p-dropdown-trigger").click();
-//     cy.get('[aria-label="Analyst Alice"]').click();
-//     cy.get(".p-dialog-footer > Button").last().click();
-//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//   });
-//   it("Correctly adds tags via add tags modal and reloads page", () => {
-//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
-//     cy.intercept("POST", "/api/node/tag/").as("addTag");
+    // Click on the Actions dropdown
+    cy.get('[aria-haspopup="true"]').eq(0).click();
+    cy.get("span").contains("Assign").click();
+    cy.get(".p-dropdown-trigger").click();
+    cy.get('[aria-label="Analyst Alice"]').click();
+    cy.get(".p-dialog-footer > Button").last().click();
+    cy.wait("@updateEvent").its("state").should("eq", "Complete");
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+  });
+  it("Correctly adds tags via add tags modal and reloads page", () => {
+    cy.intercept("PATCH", "/api/event/").as("updateEvent");
+    cy.intercept("POST", "/api/node/tag/").as("addTag");
 
-//     // Click on the Actions dropdown
-//     cy.get('[aria-haspopup="true"]').eq(0).click();
-//     cy.get("span").contains("Add Tags").click();
-//     cy.get(".p-chips > .p-inputtext").click().type("TestTag").type("{enter}");
-//     cy.get(".p-dialog-footer > Button").last().click();
-//     cy.wait("@addTag").its("state").should("eq", "Complete");
-//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//     cy.get(".p-tag").should("be.visible");
-//     cy.get(".p-tag > .tag").should("have.text", "TestTag");
-//   });
-//   it("Correctly edits event via edit event modal and reloads page", () => {
-//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
-//     cy.intercept("GET", "/api/event/prevention_tool/?offset=0").as(
-//       "eventPreventionTool",
-//     );
-//     cy.intercept("GET", "/api/event/remediation/?offset=0").as(
-//       "eventRemediation",
-//     );
-//     cy.intercept("GET", "/api/event/risk_level/?offset=0").as("eventRiskLevel");
-//     cy.intercept("GET", "/api/event/status/?offset=0").as("eventStatus");
-//     cy.intercept("GET", "/api/event/type/?offset=0").as("eventType");
-//     cy.intercept("GET", "/api/event/vector/?offset=0").as("eventVector");
-//     cy.intercept("GET", "/api/node/threat_actor/?offset=0").as(
-//       "nodeThreatActor",
-//     );
-//     cy.intercept("GET", "/api/node/threat/?offset=0").as("nodeThreat");
-//     cy.intercept("GET", "/api/node/threat/type/?offset=0").as("nodeThreatType");
-//     cy.intercept("GET", "/api/user/?offset=0").as("user");
-//     cy.intercept("GET", "/api/event/*").as("event");
+    // Click on the Actions dropdown
+    cy.get('[aria-haspopup="true"]').eq(0).click();
+    cy.get("span").contains("Add Tags").click();
+    cy.get(".p-chips > .p-inputtext").click().type("TestTag").type("{enter}");
+    cy.get(".p-dialog-footer > Button").last().click();
+    cy.wait("@addTag").its("state").should("eq", "Complete");
+    cy.wait("@updateEvent").its("state").should("eq", "Complete");
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+    cy.get(".p-tag").should("be.visible");
+    cy.get(".p-tag > .tag").should("have.text", "TestTag");
+  });
+  it("Correctly edits event via edit event modal and reloads page", () => {
+    cy.intercept("PATCH", "/api/event/").as("updateEvent");
+    cy.intercept("GET", "/api/event/prevention_tool/?offset=0").as(
+      "eventPreventionTool",
+    );
+    cy.intercept("GET", "/api/event/remediation/?offset=0").as(
+      "eventRemediation",
+    );
+    cy.intercept("GET", "/api/event/risk_level/?offset=0").as("eventRiskLevel");
+    cy.intercept("GET", "/api/event/status/?offset=0").as("eventStatus");
+    cy.intercept("GET", "/api/event/type/?offset=0").as("eventType");
+    cy.intercept("GET", "/api/event/vector/?offset=0").as("eventVector");
+    cy.intercept("GET", "/api/node/threat_actor/?offset=0").as(
+      "nodeThreatActor",
+    );
+    cy.intercept("GET", "/api/node/threat/?offset=0").as("nodeThreat");
+    cy.intercept("GET", "/api/node/threat/type/?offset=0").as("nodeThreatType");
+    cy.intercept("GET", "/api/user/?offset=0").as("user");
+    cy.intercept("GET", "/api/event/*").as("event");
 
-//     // Wait for all of the intercepted calls to complete
-//     const intercepts = [
-//       "@eventPreventionTool",
-//       "@eventRemediation",
-//       "@eventRiskLevel",
-//       "@eventStatus",
-//       "@eventType",
-//       "@eventVector",
-//       "@nodeThreatActor",
-//       "@nodeThreat",
-//       "@nodeThreatType",
-//       "@user",
-//     ];
+    // Wait for all of the intercepted calls to complete
+    const intercepts = [
+      "@eventPreventionTool",
+      "@eventRemediation",
+      "@eventRiskLevel",
+      "@eventStatus",
+      "@eventType",
+      "@eventVector",
+      "@nodeThreatActor",
+      "@nodeThreat",
+      "@nodeThreatType",
+      "@user",
+    ];
 
-//     // Click on the Actions dropdown
-//     cy.get('[aria-haspopup="true"]').eq(0).click();
-//     cy.get("span").contains("Edit Event").click();
+    // Click on the Actions dropdown
+    cy.get('[aria-haspopup="true"]').eq(0).click();
+    cy.get("span").contains("Edit Event").click();
 
-//     cy.wait(intercepts).then((interceptions) => {
-//       for (let i = 0; i < interceptions.length; i++) {
-//         cy.wrap(interceptions[i]).its("state").should("eq", "Complete");
-//       }
-//     });
-//     cy.get('[data-cy="event-name-field"] [data-cy="property-input-value"]')
-//       .click()
-//       .clear()
-//       .type("New Name");
-//     cy.get('[data-cy="save-edit-event-button"]').click();
-//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
-//     cy.wait("@getEvent").its("state").should("eq", "Complete");
-//     cy.get('[data-cy="event-title"]').should("have.text", "New Name");
-//   });
-// });
+    cy.wait(intercepts).then((interceptions) => {
+      for (let i = 0; i < interceptions.length; i++) {
+        cy.wrap(interceptions[i]).its("state").should("eq", "Complete");
+      }
+    });
+    cy.get('[data-cy="event-name-field"] [data-cy="property-input-value"]')
+      .click()
+      .clear()
+      .type("New Name");
+    cy.get('[data-cy="save-edit-event-button"]').click();
+    cy.wait("@updateEvent").its("state").should("eq", "Complete");
+    cy.wait("@getEvent").its("state").should("eq", "Complete");
+    cy.get('[data-cy="event-title"]').should("have.text", "New Name");
+  });
+});
 
 describe("Event Summary Details", () => {
   let now;

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -42,10 +42,7 @@ describe("ViewEvent.vue", () => {
     cy.get('[data-cy="event-title"]').should("have.text", "Test Event");
     cy.get('[data-cy="event-details-link"]').should("be.visible");
     cy.get('[data-cy="event-details-content"]').should("be.visible");
-    cy.get('#event-section-title').should(
-      "contain.text",
-      "Event Summary",
-    );
+    cy.get("#event-section-title").should("contain.text", "Event Summary");
   });
 
   it("Switches the component / details section when selected from dropdown", () => {
@@ -63,10 +60,7 @@ describe("ViewEvent.vue", () => {
     // Switch back to the event summary section and check content
     cy.get('[aria-haspopup="true"]').eq(1).click();
     cy.get("span").contains("Event Summary").click();
-    cy.get('#event-section-title').should(
-      "contain.text",
-      "Event Summary",
-    );
+    cy.get("#event-section-title").should("contain.text", "Event Summary");
   });
 });
 

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -1,6 +1,221 @@
 import { visitUrl } from "./helpers";
 
-describe("ViewEvent.vue", () => {
+// describe("ViewEvent.vue", () => {
+//   before(() => {
+//     cy.resetDatabase();
+//     cy.login();
+
+//     // Intercept the API call that loads the event data
+//     cy.intercept("GET", "/api/event/*").as("getEvent");
+
+//     cy.intercept(
+//       "GET",
+//       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
+//     ).as("getEventsDefaultRows");
+
+//     // Add the test event to the database
+//     cy.request({
+//       method: "POST",
+//       url: "/api/test/add_event",
+//       body: {
+//         alert_template: "small_template.json",
+//         alert_count: 1,
+//         name: "Test Event",
+//       },
+//     });
+
+//     visitUrl({
+//       url: "/manage_events",
+//       extraIntercepts: ["@getEventsDefaultRows"],
+//     });
+//     cy.get('[data-cy="eventName"] > a').click();
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//   });
+
+//   it("View Event page renders", () => {
+//     cy.get('[data-cy="event-details-menu"]').should("be.visible");
+//     cy.get('[aria-haspopup="true"]').eq(0).should("have.text", "Actions");
+//     cy.get('[aria-haspopup="true"]').eq(1).should("have.text", "Information");
+//     cy.get('[aria-haspopup="true"]').eq(2).should("have.text", "Analysis");
+//     cy.get('[data-cy="event-details-card"]').should("be.visible");
+//     cy.get('[data-cy="event-details-header"]').should("be.visible");
+//     cy.get('[data-cy="event-title"]').should("have.text", "Test Event");
+//     cy.get('[data-cy="event-details-link"]').should("be.visible");
+//     cy.get('[data-cy="event-details-content"]').should("be.visible");
+//     cy.get('#event-section-title').should(
+//       "contain.text",
+//       "Event Summary",
+//     );
+//   });
+
+//   it("Switches the component / details section when selected from dropdown", () => {
+//     // Click on the Analysis dropdown
+//     cy.get('[aria-haspopup="true"]').eq(2).click();
+//     // Select first available analysis type
+//     cy.get("span").contains("a_type0 Analysis").click();
+//     // Check that basic analysis showed up
+//     cy.get('[data-cy="event-details-content"]')
+//       .contains("Basic Analysis")
+//       .should("be.visible");
+//     cy.get('[data-cy="event-details-content"]')
+//       .contains("a_type0 Analysis")
+//       .should("be.visible");
+//     // Switch back to the event summary section and check content
+//     cy.get('[aria-haspopup="true"]').eq(1).click();
+//     cy.get("span").contains("Event Summary").click();
+//     cy.get('#event-section-title').should(
+//       "contain.text",
+//       "Event Summary",
+//     );
+//   });
+// });
+
+// describe("ViewEvent.vue actions", () => {
+//   beforeEach(() => {
+//     cy.resetDatabase();
+//     cy.login();
+
+//     // Intercept the API call that loads the event data
+//     cy.intercept("GET", "/api/event/*").as("getEvent");
+
+//     cy.intercept(
+//       "GET",
+//       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
+//     ).as("getEventsDefaultRows");
+
+//     // Add the test event to the database
+//     cy.request({
+//       method: "POST",
+//       url: "/api/test/add_event",
+//       body: {
+//         alert_template: "small_template.json",
+//         alert_count: 1,
+//         name: "Test Event",
+//       },
+//     });
+
+//     visitUrl({
+//       url: "/manage_events",
+//       extraIntercepts: ["@getEventsDefaultRows"],
+//     });
+//     cy.get('[data-cy="eventName"] > a').click();
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//   });
+
+//   // Have to log out and manually leave event page
+//   // BC when database resets it will try to get the old event with old uuid
+//   // And will cause an error
+//   afterEach(() => {
+//     cy.logout();
+//     cy.visit("/login");
+//   });
+
+//   it("Correctly adds comment via comment modal and reloads page", () => {
+//     cy.intercept("POST", "/api/node/comment/").as("addComment");
+
+//     // Click on the Actions dropdown
+//     cy.get('[aria-haspopup="true"]').eq(0).click();
+//     cy.get("span").contains("Comment").click();
+//     // Add test data and submit
+//     cy.get(".p-inputtextarea").click().type("Test comment");
+//     cy.get(".p-dialog-footer > Button").last().click();
+//     cy.wait("@addComment").its("state").should("eq", "Complete");
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//   });
+//   it("Correctly takes ownership via take ownership item and reloads page", () => {
+//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+
+//     // Click on the Actions dropdown
+//     cy.get('[aria-haspopup="true"]').eq(0).click();
+//     cy.get("span").contains("Take Ownership").click();
+//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//   });
+//   it("Correctly assigns owner via assign modal and reloads page", () => {
+//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+
+//     // Click on the Actions dropdown
+//     cy.get('[aria-haspopup="true"]').eq(0).click();
+//     cy.get("span").contains("Assign").click();
+//     cy.get(".p-dropdown-trigger").click();
+//     cy.get('[aria-label="Analyst Alice"]').click();
+//     cy.get(".p-dialog-footer > Button").last().click();
+//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//   });
+//   it("Correctly adds tags via add tags modal and reloads page", () => {
+//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+//     cy.intercept("POST", "/api/node/tag/").as("addTag");
+
+//     // Click on the Actions dropdown
+//     cy.get('[aria-haspopup="true"]').eq(0).click();
+//     cy.get("span").contains("Add Tags").click();
+//     cy.get(".p-chips > .p-inputtext").click().type("TestTag").type("{enter}");
+//     cy.get(".p-dialog-footer > Button").last().click();
+//     cy.wait("@addTag").its("state").should("eq", "Complete");
+//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//     cy.get(".p-tag").should("be.visible");
+//     cy.get(".p-tag > .tag").should("have.text", "TestTag");
+//   });
+//   it("Correctly edits event via edit event modal and reloads page", () => {
+//     cy.intercept("PATCH", "/api/event/").as("updateEvent");
+//     cy.intercept("GET", "/api/event/prevention_tool/?offset=0").as(
+//       "eventPreventionTool",
+//     );
+//     cy.intercept("GET", "/api/event/remediation/?offset=0").as(
+//       "eventRemediation",
+//     );
+//     cy.intercept("GET", "/api/event/risk_level/?offset=0").as("eventRiskLevel");
+//     cy.intercept("GET", "/api/event/status/?offset=0").as("eventStatus");
+//     cy.intercept("GET", "/api/event/type/?offset=0").as("eventType");
+//     cy.intercept("GET", "/api/event/vector/?offset=0").as("eventVector");
+//     cy.intercept("GET", "/api/node/threat_actor/?offset=0").as(
+//       "nodeThreatActor",
+//     );
+//     cy.intercept("GET", "/api/node/threat/?offset=0").as("nodeThreat");
+//     cy.intercept("GET", "/api/node/threat/type/?offset=0").as("nodeThreatType");
+//     cy.intercept("GET", "/api/user/?offset=0").as("user");
+//     cy.intercept("GET", "/api/event/*").as("event");
+
+//     // Wait for all of the intercepted calls to complete
+//     const intercepts = [
+//       "@eventPreventionTool",
+//       "@eventRemediation",
+//       "@eventRiskLevel",
+//       "@eventStatus",
+//       "@eventType",
+//       "@eventVector",
+//       "@nodeThreatActor",
+//       "@nodeThreat",
+//       "@nodeThreatType",
+//       "@user",
+//     ];
+
+//     // Click on the Actions dropdown
+//     cy.get('[aria-haspopup="true"]').eq(0).click();
+//     cy.get("span").contains("Edit Event").click();
+
+//     cy.wait(intercepts).then((interceptions) => {
+//       for (let i = 0; i < interceptions.length; i++) {
+//         cy.wrap(interceptions[i]).its("state").should("eq", "Complete");
+//       }
+//     });
+//     cy.get('[data-cy="event-name-field"] [data-cy="property-input-value"]')
+//       .click()
+//       .clear()
+//       .type("New Name");
+//     cy.get('[data-cy="save-edit-event-button"]').click();
+//     cy.wait("@updateEvent").its("state").should("eq", "Complete");
+//     cy.wait("@getEvent").its("state").should("eq", "Complete");
+//     cy.get('[data-cy="event-title"]').should("have.text", "New Name");
+//   });
+// });
+
+describe("Event Summary Details", () => {
+  let now;
+  let nowString;
+
   before(() => {
     cy.resetDatabase();
     cy.login();
@@ -13,6 +228,8 @@ describe("ViewEvent.vue", () => {
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
     ).as("getEventsDefaultRows");
 
+    now = new Date();
+    nowString = now.toLocaleString("en-US", { timeZone: "UTC" }).slice(0, -9);
     // Add the test event to the database
     cy.request({
       method: "POST",
@@ -32,182 +249,184 @@ describe("ViewEvent.vue", () => {
     cy.wait("@getEvent").its("state").should("eq", "Complete");
   });
 
-  it("View Event page renders", () => {
-    cy.get('[data-cy="event-details-menu"]').should("be.visible");
-    cy.get('[aria-haspopup="true"]').eq(0).should("have.text", "Actions");
-    cy.get('[aria-haspopup="true"]').eq(1).should("have.text", "Information");
-    cy.get('[aria-haspopup="true"]').eq(2).should("have.text", "Analysis");
-    cy.get('[data-cy="event-details-card"]').should("be.visible");
-    cy.get('[data-cy="event-details-header"]').should("be.visible");
-    cy.get('[data-cy="event-title"]').should("have.text", "Test Event");
-    cy.get('[data-cy="event-details-link"]').should("be.visible");
-    cy.get('[data-cy="event-details-content"]').should("be.visible");
-    cy.get('[data-cy="event-details-content"]').should(
-      "have.text",
-      " Event Summary ",
+  it("renders main elements correctly", () => {
+    cy.get("#event-summary-timeline").should("be.visible");
+    cy.get("#event-summary-table").should("be.visible");
+    cy.get("#event-section-title").should("contain.text", "Event Summary");
+  });
+  it("renders timeline correctly", () => {
+    cy.get("#event-summary-timeline").should("be.visible");
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(0)
+      .should("have.text", "Event");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(0)
+      .should("contains.text", nowString);
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(1)
+      .should("have.text", "Alert");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(1)
+      .should("contains.text", nowString);
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(2)
+      .should("have.text", "Ownership");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(2)
+      .should("have.text", "TBD");
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(3)
+      .should("have.text", "Disposition");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(3)
+      .should("have.text", "TBD");
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(4)
+      .should("have.text", "Contain");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(4)
+      .should("have.text", "TBD");
+    cy.get('[data-cy="event-summary-timeline-label"]')
+      .eq(5)
+      .should("have.text", "Remediation");
+    cy.get('[data-cy="event-summary-timeline-datetime"]')
+      .eq(5)
+      .should("have.text", "TBD");
+  });
+  it("renders table correctly", () => {
+    cy.get("#event-summary-table").should("be.visible");
+    cy.get('[data-cy="table-column-select"]').should("be.visible");
+    cy.get(".p-multiselect-label").should(
+      "contain.text",
+      "Created, Name, Threats, Risk Level, Status, Owner",
     );
+    cy.get('[data-cy="reset-table-button"]').should("be.visible");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(0)
+      .should("have.text", "Created");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(0)
+      .should("contain.text", nowString);
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(1)
+      .should("have.text", "Name");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(1)
+      .should("have.text", "Test Event");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(2)
+      .should("have.text", "Threats");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(2)
+      .should("contain.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(3)
+      .should("have.text", "Risk Level");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(3)
+      .should("have.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(4)
+      .should("have.text", "Status");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(4)
+      .should("have.text", "OPEN");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(5)
+      .should("have.text", "Owner");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(5)
+      .should("have.text", "None");
   });
-
-  it("Switches the component / details section when selected from dropdown", () => {
-    // Click on the Analysis dropdown
-    cy.get('[aria-haspopup="true"]').eq(2).click();
-    // Select first available analysis type
-    cy.get("span").contains("a_type0 Analysis").click();
-    // Check that basic analysis showed up
-    cy.get(".p-card-content > span")
-      .contains("Basic Analysis")
-      .should("be.visible");
-    cy.get(".p-card-content > span")
-      .contains("a_type0 Analysis")
-      .should("be.visible");
-    // Switch back to the event summary section and check content
-    cy.get('[aria-haspopup="true"]').eq(1).click();
-    cy.get("span").contains("Event Summary").click();
-    cy.get('[data-cy="event-details-content"]').should(
-      "have.text",
-      " Event Summary ",
+  it("allows user to change and reset columns in details table", () => {
+    // Open columns selector and select a new column
+    cy.get(".p-multiselect-label").click();
+    cy.get('[aria-label="Threat Actors"]').click();
+    cy.get(".p-menubar").click(); // Click away from column selector
+    cy.get(".p-multiselect-label").should(
+      "contain.text",
+      "Created, Name, Threat Actors, Threats, Risk Level, Status, Owner",
     );
-  });
-});
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(0)
+      .should("have.text", "Created");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(0)
+      .should("contain.text", nowString);
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(1)
+      .should("have.text", "Name");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(1)
+      .should("have.text", "Test Event");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(2)
+      .should("have.text", "Threat Actors");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(2)
+      .should("contain.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(3)
+      .should("have.text", "Threats");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(3)
+      .should("contain.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(4)
+      .should("have.text", "Risk Level");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(4)
+      .should("have.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(5)
+      .should("have.text", "Status");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(5)
+      .should("have.text", "OPEN");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(6)
+      .should("have.text", "Owner");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(6)
+      .should("have.text", "None");
 
-describe("ViewEvent.vue actions", () => {
-  beforeEach(() => {
-    cy.resetDatabase();
-    cy.login();
-
-    // Intercept the API call that loads the event data
-    cy.intercept("GET", "/api/event/*").as("getEvent");
-
-    cy.intercept(
-      "GET",
-      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
-    ).as("getEventsDefaultRows");
-
-    // Add the test event to the database
-    cy.request({
-      method: "POST",
-      url: "/api/test/add_event",
-      body: {
-        alert_template: "small_template.json",
-        alert_count: 1,
-        name: "Test Event",
-      },
-    });
-
-    visitUrl({
-      url: "/manage_events",
-      extraIntercepts: ["@getEventsDefaultRows"],
-    });
-    cy.get('[data-cy="eventName"] > a').click();
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-  });
-
-  // Have to log out and manually leave event page
-  // BC when database resets it will try to get the old event with old uuid
-  // And will cause an error
-  afterEach(() => {
-    cy.logout();
-    cy.visit("/login");
-  });
-
-  it("Correctly adds comment via comment modal and reloads page", () => {
-    cy.intercept("POST", "/api/node/comment/").as("addComment");
-
-    // Click on the Actions dropdown
-    cy.get('[aria-haspopup="true"]').eq(0).click();
-    cy.get("span").contains("Comment").click();
-    // Add test data and submit
-    cy.get(".p-inputtextarea").click().type("Test comment");
-    cy.get(".p-dialog-footer > Button").last().click();
-    cy.wait("@addComment").its("state").should("eq", "Complete");
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-  });
-  it("Correctly takes ownership via take ownership item and reloads page", () => {
-    cy.intercept("PATCH", "/api/event/").as("updateEvent");
-
-    // Click on the Actions dropdown
-    cy.get('[aria-haspopup="true"]').eq(0).click();
-    cy.get("span").contains("Take Ownership").click();
-    cy.wait("@updateEvent").its("state").should("eq", "Complete");
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-  });
-  it("Correctly assigns owner via assign modal and reloads page", () => {
-    cy.intercept("PATCH", "/api/event/").as("updateEvent");
-
-    // Click on the Actions dropdown
-    cy.get('[aria-haspopup="true"]').eq(0).click();
-    cy.get("span").contains("Assign").click();
-    cy.get(".p-dropdown-trigger").click();
-    cy.get('[aria-label="Analyst Alice"]').click();
-    cy.get(".p-dialog-footer > Button").last().click();
-    cy.wait("@updateEvent").its("state").should("eq", "Complete");
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-  });
-  it("Correctly adds tags via add tags modal and reloads page", () => {
-    cy.intercept("PATCH", "/api/event/").as("updateEvent");
-    cy.intercept("POST", "/api/node/tag/").as("addTag");
-
-    // Click on the Actions dropdown
-    cy.get('[aria-haspopup="true"]').eq(0).click();
-    cy.get("span").contains("Add Tags").click();
-    cy.get(".p-chips > .p-inputtext").click().type("TestTag").type("{enter}");
-    cy.get(".p-dialog-footer > Button").last().click();
-    cy.wait("@addTag").its("state").should("eq", "Complete");
-    cy.wait("@updateEvent").its("state").should("eq", "Complete");
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-    cy.get(".p-tag").should("be.visible");
-    cy.get(".p-tag > .tag").should("have.text", "TestTag");
-  });
-  it("Correctly edits event via edit event modal and reloads page", () => {
-    cy.intercept("PATCH", "/api/event/").as("updateEvent");
-    cy.intercept("GET", "/api/event/prevention_tool/?offset=0").as(
-      "eventPreventionTool",
-    );
-    cy.intercept("GET", "/api/event/remediation/?offset=0").as(
-      "eventRemediation",
-    );
-    cy.intercept("GET", "/api/event/risk_level/?offset=0").as("eventRiskLevel");
-    cy.intercept("GET", "/api/event/status/?offset=0").as("eventStatus");
-    cy.intercept("GET", "/api/event/type/?offset=0").as("eventType");
-    cy.intercept("GET", "/api/event/vector/?offset=0").as("eventVector");
-    cy.intercept("GET", "/api/node/threat_actor/?offset=0").as(
-      "nodeThreatActor",
-    );
-    cy.intercept("GET", "/api/node/threat/?offset=0").as("nodeThreat");
-    cy.intercept("GET", "/api/node/threat/type/?offset=0").as("nodeThreatType");
-    cy.intercept("GET", "/api/user/?offset=0").as("user");
-    cy.intercept("GET", "/api/event/*").as("event");
-
-    // Wait for all of the intercepted calls to complete
-    const intercepts = [
-      "@eventPreventionTool",
-      "@eventRemediation",
-      "@eventRiskLevel",
-      "@eventStatus",
-      "@eventType",
-      "@eventVector",
-      "@nodeThreatActor",
-      "@nodeThreat",
-      "@nodeThreatType",
-      "@user",
-    ];
-
-    // Click on the Actions dropdown
-    cy.get('[aria-haspopup="true"]').eq(0).click();
-    cy.get("span").contains("Edit Event").click();
-
-    cy.wait(intercepts).then((interceptions) => {
-      for (let i = 0; i < interceptions.length; i++) {
-        cy.wrap(interceptions[i]).its("state").should("eq", "Complete");
-      }
-    });
-    cy.get('[data-cy="event-name-field"] [data-cy="property-input-value"]')
-      .click()
-      .clear()
-      .type("New Name");
-    cy.get('[data-cy="save-edit-event-button"]').click();
-    cy.wait("@updateEvent").its("state").should("eq", "Complete");
-    cy.wait("@getEvent").its("state").should("eq", "Complete");
-    cy.get('[data-cy="event-title"]').should("have.text", "New Name");
+    // Reset the columns and check they're back to the default
+    cy.get('[data-cy="reset-table-button"]').click();
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(0)
+      .should("have.text", "Created");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(0)
+      .should("contain.text", nowString);
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(1)
+      .should("have.text", "Name");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(1)
+      .should("have.text", "Test Event");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(2)
+      .should("have.text", "Threats");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(2)
+      .should("contain.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(3)
+      .should("have.text", "Risk Level");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(3)
+      .should("have.text", "None");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(4)
+      .should("have.text", "Status");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(4)
+      .should("have.text", "OPEN");
+    cy.get(".p-column-header-content > .p-column-title")
+      .eq(5)
+      .should("have.text", "Owner");
+    cy.get(".p-datatable-tbody > tr >  > :nth-child(2)")
+      .eq(5)
+      .should("have.text", "None");
   });
 });

--- a/frontend/tests/mocks/events.ts
+++ b/frontend/tests/mocks/events.ts
@@ -170,6 +170,7 @@ export const eventSummaryFactory = ({
   uuid = mockEventUUID,
   vectors = [],
   queue = "None",
+  remediations = [],
 }: Partial<eventSummary> = {}): eventSummary => ({
   comments: comments,
   createdTime: createdTime,
@@ -185,4 +186,5 @@ export const eventSummaryFactory = ({
   uuid: uuid,
   vectors: vectors,
   queue: queue,
+  remediations: remediations,
 });

--- a/frontend/tests/unit/src/components/Events/EventSummary.spec.ts
+++ b/frontend/tests/unit/src/components/Events/EventSummary.spec.ts
@@ -1,0 +1,146 @@
+import EventSummary from "@/components/Events/EventSummary.vue";
+import { mount, VueWrapper } from "@vue/test-utils";
+import { TestingOptions } from "@pinia/testing";
+import { createCustomPinia } from "@unit/helpers";
+import { testConfiguration } from "@/etc/configuration/test/index";
+import { eventReadFactory } from "./../../../../mocks/events";
+import { expect } from "vitest";
+import { genericObjectReadFactory } from "../../../../mocks/genericObject";
+import { parseEventSummary } from "../../../../../src/stores/eventTable";
+
+const mockQueue = genericObjectReadFactory({ value: "external" });
+const mockEvent = eventReadFactory({
+  queue: mockQueue,
+});
+const mockEventSummary = parseEventSummary(mockEvent);
+
+const stubDate = new Date("2022-03-02T00:00:00.000-05:00");
+const mockEventManualTimes = eventReadFactory({
+  queue: mockQueue,
+  eventTime: stubDate,
+  autoEventTime: stubDate,
+  alertTime: stubDate,
+  autoAlertTime: stubDate,
+  ownershipTime: stubDate,
+  autoOwnershipTime: stubDate,
+  dispositionTime: stubDate,
+  autoDispositionTime: stubDate,
+  containTime: stubDate,
+  remediationTime: stubDate,
+});
+const mockEventAutoTimes = eventReadFactory({
+  queue: mockQueue,
+  eventTime: null,
+  autoEventTime: stubDate,
+  alertTime: null,
+  autoAlertTime: stubDate,
+  ownershipTime: null,
+  autoOwnershipTime: stubDate,
+  dispositionTime: null,
+  autoDispositionTime: stubDate,
+  containTime: null,
+  remediationTime: null,
+});
+
+function factory(options: TestingOptions = {}, openEvent = null) {
+  const wrapper: VueWrapper<any> = mount(EventSummary, {
+    global: {
+      plugins: [
+        createCustomPinia({
+          ...options,
+          initialState: {
+            eventStore: { open: openEvent, requestReload: false },
+          },
+        }),
+      ],
+      provide: { config: testConfiguration },
+    },
+  });
+
+  return { wrapper };
+}
+
+describe("EventSummary", () => {
+  it("renders", () => {
+    const { wrapper } = factory();
+    expect(wrapper.exists()).toBe(true);
+  });
+  it("sets up data onMounted if eventStore.open does not exist", () => {
+    const { wrapper } = factory();
+    expect(wrapper.vm.eventTableData).toEqual([]);
+    expect(wrapper.vm.eventTimes).toEqual([]);
+    expect(wrapper.vm.columns).toEqual([]);
+    expect(wrapper.vm.columnOptions).toEqual([]);
+    expect(wrapper.vm.selectedColumns).toEqual([]);
+  });
+  it("sets up data onMounted if eventStore.open exists", () => {
+    const { wrapper } = factory({}, mockEvent);
+    expect(wrapper.vm.eventTableData).toEqual([mockEventSummary]);
+    expect(wrapper.vm.eventTimes).toHaveLength(6);
+    expect(wrapper.vm.columns).toEqual(
+      testConfiguration.events.eventQueueColumnMappings["external"],
+    );
+    expect(wrapper.vm.columnOptions).toHaveLength(12);
+    expect(wrapper.vm.selectedColumns).toHaveLength(6);
+  });
+  it.each([
+    [
+      mockEventManualTimes,
+      stubDate,
+      stubDate,
+      stubDate,
+      stubDate,
+      stubDate,
+      stubDate,
+    ],
+    [mockEventAutoTimes, stubDate, stubDate, stubDate, stubDate, "TBD", "TBD"],
+  ])(
+    "sets up eventTimes in initData based on times in event",
+    (
+      event,
+      expectedEventTime,
+      expectedAlertTime,
+      expectedOwnershipTime,
+      expectedDispositionTime,
+      expectedContainTime,
+      expectedRemediationTime,
+    ) => {
+      const { wrapper } = factory({}, event);
+      expect(wrapper.vm.eventTimes).toHaveLength(6);
+      expect(wrapper.vm.eventTimes[0].label).toEqual("Event");
+      expect(wrapper.vm.eventTimes[0].datetime).toEqual(expectedEventTime);
+      expect(wrapper.vm.eventTimes[1].label).toEqual("Alert");
+      expect(wrapper.vm.eventTimes[1].datetime).toEqual(expectedAlertTime);
+      expect(wrapper.vm.eventTimes[2].label).toEqual("Ownership");
+      expect(wrapper.vm.eventTimes[2].datetime).toEqual(expectedOwnershipTime);
+      expect(wrapper.vm.eventTimes[3].label).toEqual("Disposition");
+      expect(wrapper.vm.eventTimes[3].datetime).toEqual(
+        expectedDispositionTime,
+      );
+      expect(wrapper.vm.eventTimes[4].label).toEqual("Contain");
+      expect(wrapper.vm.eventTimes[4].datetime).toEqual(expectedContainTime);
+      expect(wrapper.vm.eventTimes[5].label).toEqual("Remediation");
+      expect(wrapper.vm.eventTimes[5].datetime).toEqual(
+        expectedRemediationTime,
+      );
+    },
+  );
+  it("correctly computes timelineEvents", () => {
+    const { wrapper } = factory({}, mockEvent);
+    expect(wrapper.vm.timelineEvents).toEqual(wrapper.vm.eventTimes);
+  });
+  it("correctly returns a formatted time on formatDatetime", () => {
+    const { wrapper } = factory();
+    const res1 = wrapper.vm.formatDatetime("TBD");
+    expect(res1).toEqual("TBD");
+    const res2 = wrapper.vm.formatDatetime(stubDate);
+    expect(res2).toEqual("3/2/2022, 5:00:00 AM");
+  });
+  it("correctly resets selectedColumns in resetColumns", () => {
+    const { wrapper } = factory({}, mockEvent);
+    wrapper.vm.selectedColumns = [];
+    expect(wrapper.vm.selectedColumns).toEqual([]);
+    wrapper.vm.resetColumns();
+    expect(wrapper.vm.selectedColumns).toHaveLength(6);
+  });
+});

--- a/frontend/tests/unit/src/services/api/event.spec.ts
+++ b/frontend/tests/unit/src/services/api/event.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import { eventFilterParams } from "@/models/event";
 import { Event } from "@/services/api/event";
 import myNock from "@unit/services/api/nock";

--- a/frontend/tests/unit/src/store/event.spec.ts
+++ b/frontend/tests/unit/src/store/event.spec.ts
@@ -1,7 +1,3 @@
-/**
- * @jest-environment node
- */
-
 import myNock from "@unit/services/api/nock";
 import { useEventStore } from "@/stores/event";
 import { eventReadFactory } from "../../../mocks/events";


### PR DESCRIPTION
This PR includes updates for the 'event summary' section which includes simple but key details for an event. 

It is very similar to 1.0's event summary section, however the event timestamps have been moved to a timeline format (to be expanded upon on in the future) and the event details table has been improved to allow selection of more columns (default columns based on the event's queue).

Full Page:
![image](https://user-images.githubusercontent.com/31867815/157336202-406597e1-830f-4391-bb2a-40e6b9316f1f.png)

Half Page (overflow formatting):
![image](https://user-images.githubusercontent.com/31867815/157336069-b94b8ff1-645d-4b7a-bfb5-fb67d0929b56.png)
