### PR TITLE
Event Details URL Summary

### DIFF
--- a/backend/app/etc/defaults.yml
+++ b/backend/app/etc/defaults.yml
@@ -127,6 +127,7 @@ node_threat_type:
 observable_type:
   - file
   - ipv4
+  - url
 queue:
   - external
   - internal

--- a/backend/app/tests/alerts/smallWithUrls.json
+++ b/backend/app/tests/alerts/smallWithUrls.json
@@ -1,7 +1,7 @@
 {
-  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6b",
+  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6a",
   "disposition_user": "alice",
-  "name": "Small Alert w/ More URLs",
+  "name": "Small Alert",
   "owner": "bob",
   "observables": [
     {
@@ -34,12 +34,26 @@
               "tags": ["from_address"],
               "analyses": [
                 {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 5
+                  }
+                },
+                {
                   "type": "Email Address Analysis",
                   "observables": [
                     {
                       "type": "fqdn",
                       "value": "evil.com",
                       "analyses": [
+                        {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "gui_link": "https://url.to.search/query=asdf",
+                            "hits": 10
+                          }
+                        },
                         {
                           "type": "Test Analysis",
                           "observables": [
@@ -65,7 +79,16 @@
             },
             {
               "type": "email_subject",
-              "value": "Hello"
+              "value": "Hello",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 100
+                  }
+                }
+              ]
             },
             {
               "type": "file",
@@ -84,12 +107,26 @@
                       "value": "http://evil.com/malware.exe",
                       "analyses": [
                         {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "gui_link": "https://url.to.search/query=asdf",
+                            "hits": 5
+                          }
+                        },
+                        {
                           "type": "URL Parse Analysis",
                           "observables": [
                             {
                               "type": "fqdn",
                               "value": "evil.com",
                               "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 10
+                                  }
+                                },
                                 {
                                   "type": "Test Analysis",
                                   "observables": [
@@ -103,7 +140,16 @@
                             },
                             {
                               "type": "uri_path",
-                              "value": "/malware.exe"
+                              "value": "/malware.exe",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 20
+                                  }
+                                }
+                              ]
                             }
                           ]
                         }
@@ -120,7 +166,16 @@
           "observables": [
             {
               "type": "url",
-              "value": "http://amazon.com/"
+              "value": "http://amazon.com/",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 0
+                  }
+                }
+              ]
             }
           ]
         }
@@ -135,7 +190,16 @@
           "type": "private ip address",
           "value": "localhost"
         }
-      }
+      },
+      "analyses": [
+        {
+          "type": "FA Queue Analysis",
+          "details": {
+            "gui_link": "https://url.to.search/query=asdf",
+            "hits": 1000
+          }
+        }
+      ]
     }
   ]
 }

--- a/backend/app/tests/alerts/smallWithUrls.json
+++ b/backend/app/tests/alerts/smallWithUrls.json
@@ -1,0 +1,141 @@
+{
+  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6b",
+  "disposition_user": "alice",
+  "name": "Small Alert w/ More URLs",
+  "owner": "bob",
+  "observables": [
+    {
+      "type": "file",
+      "value": "email.rfc822",
+      "analyses": [
+        {
+          "type": "Email Analysis",
+          "details": {
+            "from": "badguy@evil.com",
+            "to": "goodguy@company.com",
+            "subject": "Hello",
+            "message_id": "<123abc@evil.com>",
+            "attachments": [],
+            "headers": "blah",
+            "body_text": "Here, download this malware."
+          },
+          "observable_types": ["file"],
+          "required_directives": ["email"],
+          "required_tags": ["scan_me"],
+          "observables": [
+            {
+              "type": "email_address",
+              "value": "badguy@evil.com",
+              "node_metadata": {
+                "display": {
+                  "type": "sender"
+                }
+              },
+              "tags": ["from_address"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [
+                    {
+                      "type": "fqdn",
+                      "value": "evil.com",
+                      "analyses": [
+                        {
+                          "type": "Test Analysis",
+                          "observables": [
+                            { "type": "test_type", "value": "test_value" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "email_address",
+              "value": "goodguy@company.com",
+              "tags": ["recipient"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [{ "type": "fqdn", "value": "company.com" }]
+                }
+              ]
+            },
+            {
+              "type": "email_subject",
+              "value": "Hello"
+            },
+            {
+              "type": "file",
+              "value": "email.rfc822.unknown_plain_text_000",
+              "node_metadata": {
+                "display": {
+                  "value": "email plaintext body"
+                }
+              },
+              "analyses": [
+                {
+                  "type": "URL Extraction Analysis",
+                  "observables": [
+                    {
+                      "type": "url",
+                      "value": "http://evil.com/malware.exe",
+                      "analyses": [
+                        {
+                          "type": "URL Parse Analysis",
+                          "observables": [
+                            {
+                              "type": "fqdn",
+                              "value": "evil.com",
+                              "analyses": [
+                                {
+                                  "type": "Test Analysis",
+                                  "observables": [
+                                    {
+                                      "type": "url",
+                                      "value": "http://notEvil.com/safe.exe"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "uri_path",
+                              "value": "/malware.exe"
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "File Analysis",
+          "observables": [
+            {
+              "type": "url",
+              "value": "http://amazon.com/"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ipv4",
+      "value": "127.0.0.1",
+      "tags": ["c2", "contacted_host"],
+      "node_metadata": {
+        "display": {
+          "type": "private ip address",
+          "value": "localhost"
+        }
+      }
+    }
+  ]
+}

--- a/frontend/src/components/Analysis/AnalysisDetailsBase.vue
+++ b/frontend/src/components/Analysis/AnalysisDetailsBase.vue
@@ -3,14 +3,4 @@
 
 <template>
   <span> Basic Analysis </span>
-  <br />
-  <span> {{ props.section }} </span>
 </template>
-
-<script setup>
-  import { defineProps } from "vue";
-
-  const props = defineProps({
-    section: { type: String, required: true },
-  });
-</script>

--- a/frontend/src/components/Events/EventURLSummary.vue
+++ b/frontend/src/components/Events/EventURLSummary.vue
@@ -1,0 +1,61 @@
+<!-- EventURLSummary.vue -->
+<!-- A simple list of all URLs contained in the given event uuid or open event (whichever is given) -->
+
+<template>
+  <Listbox
+    v-model="selectedURL"
+    :options="urlObservables"
+    option-value="value"
+    option-label="value"
+    data-key="uuid"
+    empty-message="This event doesn't have any URL observables."
+    @change="copyToClipboard(selectedURL)"
+  />
+</template>
+
+<script setup>
+  import { defineProps, ref, onBeforeMount } from "vue";
+  import Listbox from "primevue/listbox";
+  import { Alert } from "@/services/api/alert";
+  import { NodeTree } from "@/services/api/nodeTree";
+  import { copyToClipboard } from "@/etc/helpers";
+
+  const props = defineProps({
+    eventUuid: { type: String, required: true },
+  });
+
+  const selectedURL = ref(null);
+  const urlObservables = ref([]);
+
+  onBeforeMount(async () => {
+    const observables = await getAllObservables();
+    getURLObservables(observables);
+  });
+
+  const getAllObservables = async () => {
+    const allAlerts = await Alert.readAllPages({
+      eventUuid: props.eventUuid,
+      sort: "event_time|asc",
+    });
+
+    const allObservables = await NodeTree.readNodesOfNodeTree(
+      allAlerts.map((alert) => alert.uuid),
+      "observable",
+    );
+    return allObservables;
+  };
+
+  const getURLObservables = (allObservables) => {
+    urlObservables.value = allObservables.filter(
+      (observable) => observable.type.value == "url",
+    );
+
+    urlObservables.value = urlObservables.value.sort((a, b) => {
+      if (a.type.value === b.type.value) {
+        return a.value < b.value ? -1 : 1;
+      } else {
+        return a.type.value < b.type.value ? -1 : 1;
+      }
+    });
+  };
+</script>

--- a/frontend/src/components/Events/EventURLSummary.vue
+++ b/frontend/src/components/Events/EventURLSummary.vue
@@ -1,5 +1,5 @@
 <!-- EventURLSummary.vue -->
-<!-- A simple list of all URLs contained in the given event uuid or open event (whichever is given) -->
+<!-- A simple list of all URLs contained in the given alert UUIDs -->
 
 <template>
   <Listbox
@@ -17,12 +17,11 @@
 <script setup>
   import { defineProps, ref, onMounted } from "vue";
   import Listbox from "primevue/listbox";
-  import { Alert } from "@/services/api/alert";
   import { NodeTree } from "@/services/api/nodeTree";
   import { copyToClipboard } from "@/etc/helpers";
 
   const props = defineProps({
-    eventUuid: { type: String, required: true },
+    eventAlertUuids: { type: Array, required: true },
   });
 
   const selectedURL = ref(null);
@@ -34,13 +33,8 @@
   });
 
   const getAllObservables = async () => {
-    const allAlerts = await Alert.readAllPages({
-      eventUuid: props.eventUuid,
-      sort: "event_time|asc",
-    });
-
     const allObservables = await NodeTree.readNodesOfNodeTree(
-      allAlerts.map((alert) => alert.uuid),
+      props.eventAlertUuids,
       "observable",
     );
     return allObservables;

--- a/frontend/src/components/Events/EventURLSummary.vue
+++ b/frontend/src/components/Events/EventURLSummary.vue
@@ -4,7 +4,7 @@
 <template>
   <Listbox
     v-model="selectedURL"
-    :options="urlObservables"
+    :options="sortedUrlObservables"
     option-value="value"
     option-label="value"
     data-key="uuid"
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-  import { defineProps, ref, onBeforeMount } from "vue";
+  import { defineProps, ref, onMounted } from "vue";
   import Listbox from "primevue/listbox";
   import { Alert } from "@/services/api/alert";
   import { NodeTree } from "@/services/api/nodeTree";
@@ -25,11 +25,11 @@
   });
 
   const selectedURL = ref(null);
-  const urlObservables = ref([]);
+  const sortedUrlObservables = ref([]);
 
-  onBeforeMount(async () => {
+  onMounted(async () => {
     const observables = await getAllObservables();
-    getURLObservables(observables);
+    sortedUrlObservables.value = getURLObservables(observables);
   });
 
   const getAllObservables = async () => {
@@ -46,11 +46,11 @@
   };
 
   const getURLObservables = (allObservables) => {
-    urlObservables.value = allObservables.filter(
+    const urlObservables = allObservables.filter(
       (observable) => observable.type.value == "url",
     );
 
-    urlObservables.value = urlObservables.value.sort((a, b) => {
+    return urlObservables.sort((a, b) => {
       if (a.type.value === b.type.value) {
         return a.value < b.value ? -1 : 1;
       } else {

--- a/frontend/src/components/Events/EventURLSummary.vue
+++ b/frontend/src/components/Events/EventURLSummary.vue
@@ -9,6 +9,7 @@
     option-label="value"
     data-key="uuid"
     empty-message="This event doesn't have any URL observables."
+    data-cy="url-observable-listbox"
     @change="copyToClipboard(selectedURL)"
   />
 </template>

--- a/frontend/src/etc/constants/events.ts
+++ b/frontend/src/etc/constants/events.ts
@@ -25,6 +25,7 @@ import {
 } from "./base";
 import EventSummaryVue from "@/components/Events/EventSummary.vue";
 import EventAlertsTableVue from "@/components/Events/EventAlertsTable.vue";
+import EventURLSummaryVue from "@/components/Events/EventURLSummary.vue";
 
 // ** Events ** //
 
@@ -263,4 +264,5 @@ export const validEventFilters: propertyOption[] = [
 export const defaultEventDetailsSections = {
   "Event Summary": EventSummaryVue,
   "Alert Summary": EventAlertsTableVue,
+  "URL Summary": EventURLSummaryVue,
 };

--- a/frontend/src/pages/Events/ViewEvent.vue
+++ b/frontend/src/pages/Events/ViewEvent.vue
@@ -32,6 +32,7 @@
           <component
             :is="currentComponent"
             :event-uuid="route.params.eventID"
+            :event-alert-uuids="eventStore.open.alertUuids"
           ></component>
         </div>
       </template>

--- a/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
+++ b/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
@@ -72,7 +72,7 @@ describe("AnalyzeAlert.vue", () => {
     cy.get("div[name='observable-type']").click();
     cy.get("div[name='observable-input']")
       .get(".p-dropdown-item")
-      .should("have.length", 2)
+      .should("have.length", 3)
       .contains("ipv4")
       .click();
     // Check that input switched to text input

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -486,7 +486,6 @@ describe("URL Summary Details", () => {
       "GET",
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
     ).as("getEventsDefaultRows");
-    cy.intercept("GET", "/api/alert/?event_uuid=*").as("getEventAlerts");
     cy.intercept("POST", "/api/node/tree/observable").as("getObservables");
 
     // Add the test event to the database
@@ -512,7 +511,6 @@ describe("URL Summary Details", () => {
     // Select first available analysis type
     cy.get("span").contains("URL Summary").click();
 
-    cy.wait("@getEventAlerts").its("state").should("eq", "Complete");
     cy.wait("@getObservables").its("state").should("eq", "Complete");
   });
 

--- a/frontend/tests/mocks/observable.ts
+++ b/frontend/tests/mocks/observable.ts
@@ -1,0 +1,33 @@
+import { observableRead } from "@/models/observable";
+import { genericObjectReadFactory } from "./genericObject";
+
+export const observableReadFactory = ({
+  time = new Date("2020-01-01"),
+  uuid = "observableUuid1",
+  value = "TestObservable",
+  comments = [],
+  context = null,
+  directives = [],
+  forDetection = false,
+  redirectionUuid = null,
+  tags = [],
+  threatActors = [],
+  threats = [],
+  type = genericObjectReadFactory({ value: "testObservableType" }),
+  version = "observableVersion1",
+}: Partial<observableRead> = {}): observableRead => ({
+  time: time,
+  uuid: uuid,
+  value: value,
+  comments: comments,
+  context: context,
+  directives: directives,
+  forDetection: forDetection,
+  redirectionUuid: redirectionUuid,
+  tags: tags,
+  threatActors: threatActors,
+  threats: threats,
+  type: type,
+  nodeType: "observable",
+  version: version,
+});

--- a/frontend/tests/unit/src/components/Events/EventURLSummary.spec.ts
+++ b/frontend/tests/unit/src/components/Events/EventURLSummary.spec.ts
@@ -1,0 +1,115 @@
+import EventURLSummary from "@/components/Events/EventURLSummary.vue";
+import { shallowMount, VueWrapper, flushPromises } from "@vue/test-utils";
+import { TestingOptions } from "@pinia/testing";
+import { createCustomPinia } from "@unit/helpers";
+import { testConfiguration } from "@/etc/configuration/test/index";
+import { eventReadFactory } from "./../../../../mocks/events";
+import { expect } from "vitest";
+import { genericObjectReadFactory } from "../../../../mocks/genericObject";
+import { Alert } from "@/services/api/alert";
+import { NodeTree } from "@/services/api/nodeTree";
+import { observableReadFactory } from "../../../../mocks/observable.ts";
+import {
+  mockAlertReadA,
+  mockAlertReadB,
+  mockAlertReadC,
+} from "../../../../mocks/alert";
+
+const mockObservableTypeURL = genericObjectReadFactory({ value: "url" });
+const mockObservableTypeIPV4 = genericObjectReadFactory({ value: "ipv4" });
+const allObservables = [
+  observableReadFactory({
+    value: "http://notEvil.com",
+    type: mockObservableTypeURL,
+  }),
+  observableReadFactory({ value: "1.2.3.4", type: mockObservableTypeIPV4 }),
+  observableReadFactory({
+    value: "http://evil.com",
+    type: mockObservableTypeURL,
+  }),
+];
+const filteredAndSortedObservables = [
+  observableReadFactory({
+    value: "http://evil.com",
+    type: mockObservableTypeURL,
+  }),
+  observableReadFactory({
+    value: "http://notEvil.com",
+    type: mockObservableTypeURL,
+  }),
+];
+
+async function factory(options: TestingOptions = {}) {
+  const readAllPagesSpy = vi
+    .spyOn(Alert, "readAllPages")
+    .mockResolvedValueOnce([mockAlertReadA, mockAlertReadB, mockAlertReadC]);
+  const readNodesOfNodeTreeSpy = vi
+    .spyOn(NodeTree, "readNodesOfNodeTree")
+    .mockResolvedValueOnce(allObservables);
+
+  const wrapper: VueWrapper<any> = await shallowMount(EventURLSummary, {
+    global: {
+      plugins: [createCustomPinia(options)],
+    },
+    props: {
+      eventUuid: "uuid",
+    },
+  });
+
+  await flushPromises();
+
+  expect(readAllPagesSpy).toHaveBeenCalledWith({
+    eventUuid: "uuid",
+    sort: "event_time|asc",
+  });
+  expect(readNodesOfNodeTreeSpy.mock.calls[0]).toEqual([
+    [
+      "81d92d05-3b60-4ecf-931d-4525fc1113f3",
+      "b8a03b05-020d-4da7-b543-bb08137f862d",
+      "839e756b-39b7-407f-8e4a-513051ff4f53",
+    ],
+    "observable",
+  ]);
+
+  return { wrapper };
+}
+
+describe("EventURLSummary", () => {
+  it("renders", async () => {
+    const { wrapper } = await factory();
+    expect(wrapper.exists()).toBe(true);
+    expect(wrapper.vm.selectedURL).toBeNull();
+    expect(wrapper.vm.sortedUrlObservables).toEqual(
+      filteredAndSortedObservables,
+    );
+  });
+  it("correctly returns all observables for an event on getAllObservables", async () => {
+    const readAllPagesSpy = vi
+      .spyOn(Alert, "readAllPages")
+      .mockResolvedValueOnce([mockAlertReadA, mockAlertReadB, mockAlertReadC]);
+    const readNodesOfNodeTreeSpy = vi
+      .spyOn(NodeTree, "readNodesOfNodeTree")
+      .mockResolvedValueOnce(allObservables);
+    const { wrapper } = await factory();
+
+    wrapper.vm.getAllObservables();
+    await flushPromises();
+    expect(readAllPagesSpy).toHaveBeenCalledWith({
+      eventUuid: "uuid",
+      sort: "event_time|asc",
+    });
+    expect(readNodesOfNodeTreeSpy.mock.calls[0]).toEqual([
+      [
+        "81d92d05-3b60-4ecf-931d-4525fc1113f3",
+        "b8a03b05-020d-4da7-b543-bb08137f862d",
+        "839e756b-39b7-407f-8e4a-513051ff4f53",
+      ],
+      "observable",
+    ]);
+  });
+  it("correctly filters and sorts a list of observables on getURLObservables", async () => {
+    const { wrapper } = await factory();
+    const result = wrapper.vm.getURLObservables(allObservables);
+    expect(result).toEqual(filteredAndSortedObservables);
+  });
+});

--- a/frontend/tests/unit/src/components/Events/EventURLSummary.spec.ts
+++ b/frontend/tests/unit/src/components/Events/EventURLSummary.spec.ts
@@ -2,18 +2,10 @@ import EventURLSummary from "@/components/Events/EventURLSummary.vue";
 import { shallowMount, VueWrapper, flushPromises } from "@vue/test-utils";
 import { TestingOptions } from "@pinia/testing";
 import { createCustomPinia } from "@unit/helpers";
-import { testConfiguration } from "@/etc/configuration/test/index";
-import { eventReadFactory } from "./../../../../mocks/events";
 import { expect } from "vitest";
 import { genericObjectReadFactory } from "../../../../mocks/genericObject";
-import { Alert } from "@/services/api/alert";
 import { NodeTree } from "@/services/api/nodeTree";
 import { observableReadFactory } from "../../../../mocks/observable.ts";
-import {
-  mockAlertReadA,
-  mockAlertReadB,
-  mockAlertReadC,
-} from "../../../../mocks/alert";
 
 const mockObservableTypeURL = genericObjectReadFactory({ value: "url" });
 const mockObservableTypeIPV4 = genericObjectReadFactory({ value: "ipv4" });
@@ -40,9 +32,6 @@ const filteredAndSortedObservables = [
 ];
 
 async function factory(options: TestingOptions = {}) {
-  const readAllPagesSpy = vi
-    .spyOn(Alert, "readAllPages")
-    .mockResolvedValueOnce([mockAlertReadA, mockAlertReadB, mockAlertReadC]);
   const readNodesOfNodeTreeSpy = vi
     .spyOn(NodeTree, "readNodesOfNodeTree")
     .mockResolvedValueOnce(allObservables);
@@ -52,16 +41,16 @@ async function factory(options: TestingOptions = {}) {
       plugins: [createCustomPinia(options)],
     },
     props: {
-      eventUuid: "uuid",
+      eventAlertUuids: [
+        "81d92d05-3b60-4ecf-931d-4525fc1113f3",
+        "b8a03b05-020d-4da7-b543-bb08137f862d",
+        "839e756b-39b7-407f-8e4a-513051ff4f53",
+      ],
     },
   });
 
   await flushPromises();
 
-  expect(readAllPagesSpy).toHaveBeenCalledWith({
-    eventUuid: "uuid",
-    sort: "event_time|asc",
-  });
   expect(readNodesOfNodeTreeSpy.mock.calls[0]).toEqual([
     [
       "81d92d05-3b60-4ecf-931d-4525fc1113f3",
@@ -84,9 +73,6 @@ describe("EventURLSummary", () => {
     );
   });
   it("correctly returns all observables for an event on getAllObservables", async () => {
-    const readAllPagesSpy = vi
-      .spyOn(Alert, "readAllPages")
-      .mockResolvedValueOnce([mockAlertReadA, mockAlertReadB, mockAlertReadC]);
     const readNodesOfNodeTreeSpy = vi
       .spyOn(NodeTree, "readNodesOfNodeTree")
       .mockResolvedValueOnce(allObservables);
@@ -94,10 +80,6 @@ describe("EventURLSummary", () => {
 
     wrapper.vm.getAllObservables();
     await flushPromises();
-    expect(readAllPagesSpy).toHaveBeenCalledWith({
-      eventUuid: "uuid",
-      sort: "event_time|asc",
-    });
     expect(readNodesOfNodeTreeSpy.mock.calls[0]).toEqual([
       [
         "81d92d05-3b60-4ecf-931d-4525fc1113f3",


### PR DESCRIPTION
This PR introduces a new event details summary from 1.0, the URL summary. It is a basic list of all URL observables from all the alerts in the event. The URLs are both de-dup'd and sorted alphabetically.

Also, using Primevue's listbox component for formatting purposes presented an opportunity to 'select' one of the URLs. Now, if a user clicks/selects one of the URLs in the list, it will copied to the user's the clipboard. Yay!

![image](https://user-images.githubusercontent.com/31867815/157531192-097b6923-5267-4ed5-8325-e1992194a2d7.png)