### PR TITLE
API endpoint for event observable summary

### DIFF
--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -1,0 +1,13 @@
+from pydantic import Field
+from typing import Optional
+
+from api.models import type_str
+from api.models.observable import ObservableRead
+
+
+class ObservableSummary(ObservableRead):
+    """Represents an event's observable summary."""
+
+    faqueue_hits: int = Field(description="The number of hits found by FA Queue Analysis for this observable")
+
+    faqueue_link: Optional[type_str] = Field(description="An optional link to view the FA Queue search")

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,8 +8,10 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
+from api.models.event_summaries import ObservableSummary
 from api.models.history import EventHistoryRead
 from api.routes import helpers
+from api.routes.event_summaries import get_observable_summary
 from api.routes.node import create_node, update_node
 from core.auth import validate_access_token
 from db import crud
@@ -648,3 +650,10 @@ helpers.api_route_update(router, update_events, path="/")
 
 
 # We currently do not support deleting any Nodes.
+
+
+#
+# SUMMARIES
+#
+
+helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -1,0 +1,63 @@
+from fastapi import Depends
+from sqlalchemy import and_
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import join, select
+from typing import Dict
+from uuid import UUID
+
+from db import crud
+from db.database import get_db
+from db.schemas.analysis import Analysis
+from db.schemas.analysis_module_type import AnalysisModuleType
+from db.schemas.event import Event
+from db.schemas.node import Node
+from db.schemas.node_tree import NodeTree
+from db.schemas.observable import Observable
+
+
+#
+# OBSERVABLE
+#
+
+
+def get_observable_summary(uuid: UUID, db: Session = Depends(get_db)):
+    # Get the event from the database
+    event: Event = crud.read(uuid=uuid, db_table=Event, db=db)
+
+    # Get all the FA Queue analyses (and their parent NodeTree UUIDs) performed in the event.
+    # The query results are turned into a dictionary with the parent NodeTree UUID as the key.
+    query = (
+        select([NodeTree.parent_tree_uuid, Analysis])
+        .select_from(join(NodeTree, Node, NodeTree.node_uuid == Node.uuid))
+        .join(
+            Analysis,
+            onclause=and_(
+                Node.node_type == "analysis",
+                Analysis.uuid == NodeTree.node_uuid,
+                Analysis.analysis_module_type.has(AnalysisModuleType.value.startswith("FA Queue")),
+            ),
+        )
+        .where(NodeTree.root_node_uuid.in_(event.alert_uuids))
+    )
+
+    node_tree_and_faqueue: Dict[UUID, Analysis] = dict(db.execute(query).unique().fetchall())
+
+    # Get all the observables (and their NodeTree UUIDs) that go with the FA Queue analyses.
+    # The query results are turned into a dictionary with the NodeTree UUID as the key.
+    query = (
+        select([NodeTree.uuid, Observable])
+        .select_from(join(NodeTree, Node, NodeTree.node_uuid == Node.uuid))
+        .where(Node.node_type == "observable", NodeTree.uuid.in_(node_tree_and_faqueue.keys()))
+    )
+
+    node_tree_and_observables: Dict[UUID, Observable] = dict(db.execute(query).unique().fetchall())
+
+    # Loop over the FA Queue analyses and inject their results into the observables.
+    results = set()
+    for parent_uuid, faqueue_analysis in node_tree_and_faqueue.items():
+        node_tree_and_observables[parent_uuid].faqueue_hits = faqueue_analysis.details["hits"]
+        node_tree_and_observables[parent_uuid].faqueue_link = faqueue_analysis.details["link"]
+        results.add(node_tree_and_observables[parent_uuid])
+
+    # Return the observables sorted by their type then value
+    return sorted(results, key=lambda x: (x.type.value, x.value))

--- a/backend/app/db/migrations/versions/9dac6f40a0d3_initial.py
+++ b/backend/app/db/migrations/versions/9dac6f40a0d3_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: 0e67677dd8f7
+Revision ID: 9dac6f40a0d3
 Revises: 
-Create Date: 2022-02-23 21:13:46.127108
+Create Date: 2022-03-09 20:33:25.335488
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = '0e67677dd8f7'
+revision = '9dac6f40a0d3'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -57,6 +57,7 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid'),
     sa.UniqueConstraint('value', 'version', name='value_version_uc')
     )
+    op.create_index('amt_value_trgm', 'analysis_module_type', ['value'], unique=False, postgresql_ops={'value': 'gin_trgm_ops'}, postgresql_using='gin')
     op.create_index(op.f('ix_analysis_module_type_value'), 'analysis_module_type', ['value'], unique=False)
     op.create_index(op.f('ix_analysis_module_type_version'), 'analysis_module_type', ['version'], unique=False)
     op.create_table('event_prevention_tool',
@@ -722,6 +723,7 @@ def downgrade() -> None:
     op.drop_table('event_prevention_tool')
     op.drop_index(op.f('ix_analysis_module_type_version'), table_name='analysis_module_type')
     op.drop_index(op.f('ix_analysis_module_type_value'), table_name='analysis_module_type')
+    op.drop_index('amt_value_trgm', table_name='analysis_module_type', postgresql_ops={'value': 'gin_trgm_ops'}, postgresql_using='gin')
     op.drop_table('analysis_module_type')
     op.drop_index(op.f('ix_alert_type_value'), table_name='alert_type')
     op.drop_table('alert_type')

--- a/backend/app/db/schemas/analysis_module_type.py
+++ b/backend/app/db/schemas/analysis_module_type.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func, Boolean, Column, String, UniqueConstraint
+from sqlalchemy import func, Boolean, Column, Index, String, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
@@ -41,4 +41,12 @@ class AnalysisModuleType(Base):
 
     version = Column(String, nullable=False, index=True)
 
-    __table_args__ = (UniqueConstraint("value", "version", name="value_version_uc"),)
+    __table_args__ = (
+        Index(
+            "amt_value_trgm",
+            value,
+            postgresql_ops={"value": "gin_trgm_ops"},
+            postgresql_using="gin",
+        ),
+        UniqueConstraint("value", "version", name="value_version_uc"),
+    )

--- a/backend/app/tests/alerts/small.json
+++ b/backend/app/tests/alerts/small.json
@@ -34,12 +34,26 @@
               "tags": ["from_address"],
               "analyses": [
                 {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 5
+                  }
+                },
+                {
                   "type": "Email Address Analysis",
                   "observables": [
                     {
                       "type": "fqdn",
                       "value": "evil.com",
                       "analyses": [
+                        {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "gui_link": "https://url.to.search/query=asdf",
+                            "hits": 10
+                          }
+                        },
                         {
                           "type": "Test Analysis",
                           "observables": [
@@ -65,7 +79,16 @@
             },
             {
               "type": "email_subject",
-              "value": "Hello"
+              "value": "Hello",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 100
+                  }
+                }
+              ]
             },
             {
               "type": "file",
@@ -84,12 +107,26 @@
                       "value": "http://evil.com/malware.exe",
                       "analyses": [
                         {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "gui_link": "https://url.to.search/query=asdf",
+                            "hits": 5
+                          }
+                        },
+                        {
                           "type": "URL Parse Analysis",
                           "observables": [
                             {
                               "type": "fqdn",
                               "value": "evil.com",
                               "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 10
+                                  }
+                                },
                                 {
                                   "type": "Test Analysis",
                                   "observables": [
@@ -103,7 +140,16 @@
                             },
                             {
                               "type": "uri_path",
-                              "value": "/malware.exe"
+                              "value": "/malware.exe",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 20
+                                  }
+                                }
+                              ]
                             }
                           ]
                         }
@@ -120,7 +166,16 @@
           "observables": [
             {
               "type": "md5",
-              "value": "912ec803b2ce49e4a541068d495ab570"
+              "value": "912ec803b2ce49e4a541068d495ab570",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 0
+                  }
+                }
+              ]
             }
           ]
         }
@@ -135,7 +190,16 @@
           "type": "private ip address",
           "value": "localhost"
         }
-      }
+      },
+      "analyses": [
+        {
+          "type": "FA Queue Analysis",
+          "details": {
+            "gui_link": "https://url.to.search/query=asdf",
+            "hits": 1000
+          }
+        }
+      ]
     }
   ]
 }

--- a/backend/app/tests/alerts/small_template.json
+++ b/backend/app/tests/alerts/small_template.json
@@ -24,6 +24,13 @@
               "tags": ["<TAG>"],
               "analyses": [
                 {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 5
+                  }
+                },
+                {
                   "type": "<A_TYPE> Analysis",
                   "observables": [{ "type": "<O_TYPE>", "value": "<O_VALUE>" }]
                 }
@@ -35,6 +42,13 @@
               "tags": ["<TAG>"],
               "analyses": [
                 {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 10
+                  }
+                },
+                {
                   "type": "<A_TYPE> Analysis",
                   "observables": [{ "type": "<O_TYPE>", "value": "<O_VALUE>" }]
                 }
@@ -42,12 +56,28 @@
             },
             {
               "type": "<O_TYPE>",
-              "value": "<O_VALUE>"
+              "value": "<O_VALUE>",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 15
+                  }
+                }
+              ]
             },
             {
               "type": "<O_TYPE>",
               "value": "<O_VALUE>",
               "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "gui_link": "https://url.to.search/query=asdf",
+                    "hits": 100
+                  }
+                },
                 {
                   "type": "<A_TYPE> Analysis",
                   "observables": [
@@ -56,15 +86,40 @@
                       "value": "<O_VALUE>",
                       "analyses": [
                         {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "gui_link": "https://url.to.search/query=asdf",
+                            "hits": 10
+                          }
+                        },
+                        {
                           "type": "<A_TYPE> Analysis",
                           "observables": [
                             {
                               "type": "<O_TYPE>",
-                              "value": "<O_VALUE>"
+                              "value": "<O_VALUE>",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 0
+                                  }
+                                }
+                              ]
                             },
                             {
                               "type": "<O_TYPE>",
-                              "value": "<O_VALUE>"
+                              "value": "<O_VALUE>",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "gui_link": "https://url.to.search/query=asdf",
+                                    "hits": 1000
+                                  }
+                                }
+                              ]
                             }
                           ]
                         }

--- a/backend/app/tests/api/alert/test_read.py
+++ b/backend/app/tests/api/alert/test_read.py
@@ -750,8 +750,8 @@ def test_get_alert_tree(client_valid_access_token, db):
         db=db, json_path="/app/tests/alerts/small.json", alert_name="Test Alert"
     )
 
-    # The small.json alert has 14 observables and 8 analyses. However, it only has two root observables.
+    # The small.json alert has 14 observables and 16 analyses. However, it only has two root observables.
     get = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}")
     assert str(get.json()["children"]).count("'observable'") == 14
-    assert str(get.json()["children"]).count("'analysis'") == 8
+    assert str(get.json()["children"]).count("'analysis'") == 16
     assert len(get.json()["children"]) == 2

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -28,6 +28,73 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
+def test_summary_observable(client_valid_access_token, db):
+    # Create an event
+    event = helpers.create_event(name="test event", db=db)
+
+    # The observable summary should be empty
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
+    assert get.json() == []
+
+    # Add some alerts with analyses to the event
+    #
+    # alert1
+    #   o1
+    #     a1
+    #       o2 - 127.0.0.1
+    #         a2 - FA Q
+    #   o3 - 127.0.0.1
+    #     a3 - FA Q
+    #
+    # alert2
+    #  o1 - 127.0.0.1
+    #    a1 - FA Q
+    #  o2 - 192.168.1.1
+    #    a2 - FA Q
+    alert_tree1 = helpers.create_alert(db=db, event=event)
+    alert1_o1 = helpers.create_observable(type="fqdn", value="localhost.localdomain", parent_tree=alert_tree1, db=db)
+    alert1_a1 = helpers.create_analysis(db=db, parent_tree=alert1_o1, amt_value="FQDN Analysis")
+    alert1_o2 = helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert1_a1, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert1_o2,
+        amt_value="FA Queue Analysis",
+        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+    )
+    alert1_o3 = helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree1, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert1_o3,
+        amt_value="FA Queue Analysis",
+        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+    )
+
+    alert_tree2 = helpers.create_alert(db=db, event=event)
+    alert2_o1 = helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree2, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert2_o1,
+        amt_value="FA Queue Analysis",
+        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+    )
+    alert2_o2 = helpers.create_observable(type="ipv4", value="192.168.1.1", parent_tree=alert_tree2, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert2_o2,
+        amt_value="FA Queue Analysis",
+        details={"gui_link": "https://url.to.search/query=asdf", "hits": 100},
+    )
+
+    # The observable summary should now have two entries in it. Even though the 127.0.0.1 observable was repeated three
+    # times across the two alerts, its FA Queue Analysis is going to be the same for each, so it appears once in the summary.
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
+    assert len(get.json()) == 2
+    assert get.json()[0]["value"] == "127.0.0.1"
+    assert get.json()[0]["hits"] == 10
+    assert get.json()[1]["value"] == "192.168.1.1"
+    assert get.json()[1]["hits"] == 100
+
+
 def test_analysis_module_types(client_valid_access_token, db):
     # Create an event
     event = helpers.create_event(name="test event", db=db)

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -58,15 +58,15 @@ def test_summary_observable(client_valid_access_token, db):
     helpers.create_analysis(
         db=db,
         parent_tree=alert1_o2,
-        amt_value="FA Queue Analysis",
-        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+        amt_value="FA Queue Type 1",
+        details={"link": "https://url.to.search/query=asdf", "hits": 10},
     )
     alert1_o3 = helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree1, db=db)
     helpers.create_analysis(
         db=db,
         parent_tree=alert1_o3,
-        amt_value="FA Queue Analysis",
-        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+        amt_value="FA Queue Type 1",
+        details={"link": "https://url.to.search/query=asdf", "hits": 10},
     )
 
     alert_tree2 = helpers.create_alert(db=db, event=event)
@@ -74,25 +74,36 @@ def test_summary_observable(client_valid_access_token, db):
     helpers.create_analysis(
         db=db,
         parent_tree=alert2_o1,
-        amt_value="FA Queue Analysis",
-        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+        amt_value="FA Queue Type 1",
+        details={"link": "https://url.to.search/query=asdf", "hits": 10},
     )
     alert2_o2 = helpers.create_observable(type="ipv4", value="192.168.1.1", parent_tree=alert_tree2, db=db)
     helpers.create_analysis(
         db=db,
         parent_tree=alert2_o2,
-        amt_value="FA Queue Analysis",
-        details={"gui_link": "https://url.to.search/query=asdf", "hits": 100},
+        amt_value="FA Queue Type 2",
+        details={"link": "https://url.to.search/query=asdf", "hits": 100},
+    )
+
+    # Add a third alert that is not part of the event
+    alert_tree3 = helpers.create_alert(db=db)
+    alert3_o1 = helpers.create_observable(type="ipv4", value="172.16.1.1", parent_tree=alert_tree3, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert3_o1,
+        amt_value="FA Queue Type 1",
+        details={"link": "https://url.to.search/query=asdf", "hits": 0},
     )
 
     # The observable summary should now have two entries in it. Even though the 127.0.0.1 observable was repeated three
     # times across the two alerts, its FA Queue Analysis is going to be the same for each, so it appears once in the summary.
+    # Additionally, the results should be sorted by their type then value.
     get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
     assert len(get.json()) == 2
     assert get.json()[0]["value"] == "127.0.0.1"
-    assert get.json()[0]["hits"] == 10
+    assert get.json()[0]["faqueue_hits"] == 10
     assert get.json()[1]["value"] == "192.168.1.1"
-    assert get.json()[1]["hits"] == 100
+    assert get.json()[1]["faqueue_hits"] == 100
 
 
 def test_analysis_module_types(client_valid_access_token, db):

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,0 +1,6 @@
+import { observableRead } from "./observable";
+
+export interface observableSummary extends observableRead {
+  faqueueHits: number;
+  faqueueLink: string | null;
+}

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -32,13 +32,13 @@ describe("ViewAlert.vue", () => {
 
   it("Renders the expected number of nodes", () => {
     // Total number of nodes
-    cy.get(".p-treenode-content").should("have.length", 20);
+    cy.get(".p-treenode-content").should("have.length", 27);
 
     // Number of expandable nodes
-    cy.get(".p-tree-toggler-icon").should("have.length", 14);
+    cy.get(".p-tree-toggler-icon").should("have.length", 18);
 
     // Number of expanded nodes
-    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 13);
+    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 17);
     // Number of collapsed nodes
     cy.get(".p-treenode-content .pi-chevron-right").should("have.length", 1);
   });
@@ -95,7 +95,7 @@ describe("ViewAlert.vue", () => {
 
     // Only that icon should have changed
     // Number of expanded nodes
-    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 15);
+    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 19);
     // Number of collapsed nodes
     cy.get(".p-treenode-content .pi-chevron-right").should("not.exist");
 
@@ -128,7 +128,7 @@ describe("ViewAlert.vue", () => {
 
     // Node counts back to original
     // Number of expanded nodes
-    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 13);
+    cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 17);
     // Number of collapsed nodes
     cy.get(".p-treenode-content .pi-chevron-right").should("have.length", 1);
   });
@@ -286,8 +286,8 @@ describe("ViewAlert.vue", () => {
     // Should have been rerouted
     cy.url().should("contain", "/manage_alerts");
 
-    // Check which alerts are visible (should be none (1 checkbox visible for the header row))
-    cy.get(".p-checkbox-box").should("have.length", 1);
+    // Check which alerts are visible (should be 1 (1 checkbox visible for the header row))
+    cy.get(".p-checkbox-box").should("have.length", 2);
 
     // Verify in the filter modal that the correct filter is set
     cy.get(".p-splitbutton-menubutton").click();
@@ -303,7 +303,7 @@ describe("ViewAlert.vue", () => {
     cy.get(".p-dialog-header-icon").click();
   });
 
-  it("will reroute to the Manage Alerts page with observable filter applied when observable clicked", () => {
+  it.only("will reroute to the Manage Alerts page with observable filter applied when observable clicked", () => {
     // Find the email subject observable and click
     cy.get(
       '[data-cy="email_subject: Hello"] > .p-treenode-content > .treenode-text',
@@ -312,8 +312,8 @@ describe("ViewAlert.vue", () => {
     // Should have been rerouted
     cy.url().should("contain", "/manage_alerts");
 
-    // Check which alerts are visible (should be none (1 checkbox visible for the header row))
-    cy.get(".p-checkbox-box").should("have.length", 1);
+    // Check which alerts are visible (should be 1 (1 checkbox visible for the header row))
+    cy.get(".p-checkbox-box").should("have.length", 2);
 
     // Verify in the filter modal that the correct filter is set
     cy.get(".p-splitbutton-menubutton").click();

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -276,6 +276,12 @@ describe("ViewAlert.vue", () => {
   });
 
   it("will reroute to the Manage Alerts page with tag filter applied when tag clicked", () => {
+    // Intercept the API call that loads the alerts
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&tags=recipient",
+    ).as("getAlerts");
+
     // Find the recipient tag and click
     cy.get(
       '[data-cy="email_address: goodguy@company.com"] > :nth-child(1) > :nth-child(3) > :nth-child(1) > .p-tag',
@@ -285,6 +291,9 @@ describe("ViewAlert.vue", () => {
 
     // Should have been rerouted
     cy.url().should("contain", "/manage_alerts");
+
+    // Wait for the API call to fetch the alerts to finish
+    cy.wait("@getAlerts").its("state").should("eq", "Complete");
 
     // Check which alerts are visible (should be 1 (1 checkbox visible for the header row))
     cy.get(".p-checkbox-box").should("have.length", 2);
@@ -303,7 +312,13 @@ describe("ViewAlert.vue", () => {
     cy.get(".p-dialog-header-icon").click();
   });
 
-  it.only("will reroute to the Manage Alerts page with observable filter applied when observable clicked", () => {
+  it("will reroute to the Manage Alerts page with observable filter applied when observable clicked", () => {
+    // Intercept the API call that loads the alerts
+    cy.intercept(
+      "GET",
+      "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&observable=email_subject%7CHello",
+    ).as("getAlerts");
+
     // Find the email subject observable and click
     cy.get(
       '[data-cy="email_subject: Hello"] > .p-treenode-content > .treenode-text',
@@ -311,6 +326,9 @@ describe("ViewAlert.vue", () => {
 
     // Should have been rerouted
     cy.url().should("contain", "/manage_alerts");
+
+    // Wait for the API call to fetch the alerts to finish
+    cy.wait("@getAlerts").its("state").should("eq", "Complete");
 
     // Check which alerts are visible (should be 1 (1 checkbox visible for the header row))
     cy.get(".p-checkbox-box").should("have.length", 2);


### PR DESCRIPTION
This PR adds the `/api/event/{uuid}/summary/observable` API endpoint that will be used by the GUI to display the observable summary section. The endpoint fetches all the FA Queue analysis results from the event and injects the results into their matching observables that get returned as the result.