### PR TITLE
Tweak for Observable Summary API endpoint

### DIFF
--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -1,7 +1,5 @@
 from pydantic import Field
-from typing import Optional
 
-from api.models import type_str
 from api.models.observable import ObservableRead
 
 
@@ -10,4 +8,4 @@ class ObservableSummary(ObservableRead):
 
     faqueue_hits: int = Field(description="The number of hits found by FA Queue Analysis for this observable")
 
-    faqueue_link: Optional[type_str] = Field(description="An optional link to view the FA Queue search")
+    faqueue_link: str = Field(description="An optional link to view the FA Queue search")

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -55,9 +55,15 @@ def get_observable_summary(uuid: UUID, db: Session = Depends(get_db)):
     # Loop over the FA Queue analyses and inject their results into the observables.
     results = set()
     for parent_uuid, faqueue_analysis in node_tree_and_faqueue.items():
-        node_tree_and_observables[parent_uuid].faqueue_hits = faqueue_analysis.details["hits"]
-        node_tree_and_observables[parent_uuid].faqueue_link = faqueue_analysis.details["link"]
-        results.add(node_tree_and_observables[parent_uuid])
+        if "hits" in faqueue_analysis.details:
+            node_tree_and_observables[parent_uuid].faqueue_hits = faqueue_analysis.details["hits"]
+
+            if "link" in faqueue_analysis.details:
+                node_tree_and_observables[parent_uuid].faqueue_link = faqueue_analysis.details["link"]
+            else:
+                node_tree_and_observables[parent_uuid].faqueue_link = ""
+
+            results.add(node_tree_and_observables[parent_uuid])
 
     # Return the observables sorted by their type then value
     return sorted(results, key=lambda x: (x.type.value, x.value))

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -2,5 +2,5 @@ import { observableRead } from "./observable";
 
 export interface observableSummary extends observableRead {
   faqueueHits: number;
-  faqueueLink: string | null;
+  faqueueLink: string;
 }


### PR DESCRIPTION
This enhances the observable summary API endpoint so that it does not issue a 500 error if the FA Queue analysis details does not have the expected keys ("hits" and "link").