### PR TITLE
API - event user summary

### DIFF
--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -1,11 +1,31 @@
-from pydantic import Field
+from pydantic import BaseModel, Field
+from typing import Optional
 
+from api.models import type_str
 from api.models.observable import ObservableRead
 
 
 class ObservableSummary(ObservableRead):
-    """Represents an event's observable summary."""
+    """Represents an observable summary as used on the event pages."""
 
     faqueue_hits: int = Field(description="The number of hits found by FA Queue Analysis for this observable")
 
     faqueue_link: str = Field(description="An optional link to view the FA Queue search")
+
+
+class UserSummary(BaseModel):
+    """Represents a user summary as used on the event pages."""
+
+    company: Optional[str] = Field(description="The company to which the user belongs")
+
+    department: Optional[str] = Field(description="The department to which the user belongs")
+
+    division: Optional[str] = Field(description="The division to which the user belongs")
+
+    email: type_str = Field(description="The user's email address")
+
+    manager_email: Optional[str] = Field(description="The email address of the user's manager")
+
+    title: Optional[str] = Field(description="The user's job title")
+
+    user_id: type_str = Field(description="The user's user ID")

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,10 +8,10 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
-from api.models.event_summaries import ObservableSummary
+from api.models.event_summaries import ObservableSummary, UserSummary
 from api.models.history import EventHistoryRead
 from api.routes import helpers
-from api.routes.event_summaries import get_observable_summary
+from api.routes.event_summaries import get_observable_summary, get_user_summary
 from api.routes.node import create_node, update_node
 from core.auth import validate_access_token
 from db import crud
@@ -657,3 +657,4 @@ helpers.api_route_update(router, update_events, path="/")
 #
 
 helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")
+helpers.api_route_read(router, get_user_summary, List[UserSummary], path="/{uuid}/summary/user")

--- a/backend/app/tests/alerts/smallWithUsers.json
+++ b/backend/app/tests/alerts/smallWithUsers.json
@@ -1,0 +1,178 @@
+{
+  "name": "Small Alert with User Analysis",
+  "observables": [
+    {
+      "type": "file",
+      "value": "email.rfc822",
+      "analyses": [
+        {
+          "type": "Email Analysis",
+          "details": {
+            "from": "badguy@evil.com",
+            "to": "goodguy@company.com",
+            "cc": "otherguy@company.com",
+            "subject": "Hello",
+            "message_id": "<123abc@evil.com>",
+            "attachments": [],
+            "headers": "blah",
+            "body_text": "Here, download this malware."
+          },
+          "observable_types": ["file"],
+          "required_directives": ["email"],
+          "required_tags": ["scan_me"],
+          "observables": [
+            {
+              "type": "email_address",
+              "value": "badguy@evil.com",
+              "node_metadata": {
+                "display": {
+                  "type": "sender"
+                }
+              },
+              "tags": ["from_address"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [
+                    {
+                      "type": "fqdn",
+                      "value": "evil.com",
+                      "analyses": [
+                        {
+                          "type": "Test Analysis",
+                          "observables": [
+                            { "type": "test_type", "value": "test_value" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "email_address",
+              "value": "goodguy@company.com",
+              "tags": ["recipient"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [{ "type": "fqdn", "value": "company.com" }]
+                },
+                {
+                  "type": "User Analysis",
+                  "details": {
+                    "user_id": "12345",
+                    "email": "goodguy@company.com",
+                    "company": "Company Inc.",
+                    "division": "R&D",
+                    "department": "Widgets",
+                    "title": "Director",
+                    "manager_email": "ceo@company.com"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "email_address",
+              "value": "otherguy@company.com",
+              "tags": ["recipient"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [{ "type": "fqdn", "value": "company.com" }]
+                },
+                {
+                  "type": "User Analysis",
+                  "details": {
+                    "user_id": "98765",
+                    "email": "otherguy@company.com",
+                    "company": "Company Inc.",
+                    "division": "R&D",
+                    "department": "Widgets",
+                    "title": "Engineer",
+                    "manager_email": "goodguy@company.com"
+                  }
+                }
+              ]
+            },
+            {
+              "type": "email_subject",
+              "value": "Hello",
+              "analyses": []
+            },
+            {
+              "type": "file",
+              "value": "email.rfc822.unknown_plain_text_000",
+              "node_metadata": {
+                "display": {
+                  "value": "email plaintext body"
+                }
+              },
+              "analyses": [
+                {
+                  "type": "URL Extraction Analysis",
+                  "observables": [
+                    {
+                      "type": "url",
+                      "value": "http://evil.com/malware.exe",
+                      "analyses": [
+                        {
+                          "type": "URL Parse Analysis",
+                          "observables": [
+                            {
+                              "type": "fqdn",
+                              "value": "evil.com",
+                              "analyses": [
+                                {
+                                  "type": "Test Analysis",
+                                  "observables": [
+                                    {
+                                      "type": "test_type",
+                                      "value": "test_value"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "uri_path",
+                              "value": "/malware.exe",
+                              "analyses": []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "File Analysis",
+          "observables": [
+            {
+              "type": "md5",
+              "value": "912ec803b2ce49e4a541068d495ab570",
+              "analyses": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ipv4",
+      "value": "127.0.0.1",
+      "tags": ["c2", "contacted_host"],
+      "node_metadata": {
+        "display": {
+          "type": "private ip address",
+          "value": "localhost"
+        }
+      },
+      "analyses": []
+    }
+  ]
+}

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -4,3 +4,13 @@ export interface observableSummary extends observableRead {
   faqueueHits: number;
   faqueueLink: string;
 }
+
+export interface userSummary {
+  company: string | null;
+  department: string | null;
+  division: string | null;
+  email: string;
+  managerEmail: string | null;
+  title: string | null;
+  userId: string;
+}


### PR DESCRIPTION
This PR adds the `/api/event/{uuid}/summary/user` API endpoint. This will retrieve all of the unique User Analysis that was performed in the event and return it in a summary format.

This will be used in the GUI on event pages to display the User Summary table.