### PR TITLE
Add event observable summary tags column

### DIFF
--- a/frontend/src/components/Events/EventObservableSummary.vue
+++ b/frontend/src/components/Events/EventObservableSummary.vue
@@ -129,6 +129,16 @@
         />
       </template>
     </Column>
+    <Column field="tags" header="Tags">
+      <template #body="slotProps">
+        <NodeTagVue
+          v-for="tag of slotProps.data.tags"
+          :key="tag.value"
+          :tag="tag"
+          override-node-type="alerts"
+        />
+      </template>
+    </Column>
   </DataTable>
 </template>
 
@@ -140,6 +150,7 @@
   import DataTable from "primevue/datatable";
   import InputText from "primevue/inputtext";
   import MultiSelect from "primevue/multiselect";
+  import NodeTagVue from "@/components/Node/NodeTag.vue";
 
   import { Event } from "@/services/api/event";
   import { ObservableInstance } from "@/services/api/observable";

--- a/frontend/src/components/Node/NodeTag.vue
+++ b/frontend/src/components/Node/NodeTag.vue
@@ -15,18 +15,21 @@
   import { useRouter } from "vue-router";
   const router = useRouter();
   const nodeType = inject("nodeType");
+  const nodeRoutes = {
+    alerts: "/manage_alerts",
+    events: "/manage_events",
+  };
 
   const props = defineProps({
     tag: { type: Object, required: true },
+    overrideNodeType: { type: String, required: false, default: null },
   });
 
   function filterByTags() {
-    // Determine what page to route to, right now only option is alerts - Manage Alerts
-    const nodeRoutes = {
-      alerts: "/manage_alerts",
-      events: "/manage_events",
-    };
-    const route = nodeRoutes[nodeType];
+    const preferredNodeType = props.overrideNodeType
+      ? props.overrideNodeType
+      : nodeType;
+    const route = nodeRoutes[preferredNodeType];
     if (route) {
       // Route to given page with query for filtering by this tag's value
       router.replace({ path: route, query: { tags: props.tag.value } });

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -709,11 +709,12 @@ describe("Observable Summary Details - Don't Affect State", () => {
 
     // Check table
     cy.get('[data-cy="observables-table"]').should("be.visible");
-    cy.get(".p-column-title").should("have.length", 4);
+    cy.get(".p-column-title").should("have.length", 5);
     cy.get(".p-column-title").eq(0).should("have.text", "For Detection");
     cy.get(".p-column-title").eq(1).should("have.text", "FAQueue Hits");
     cy.get(".p-column-title").eq(2).should("have.text", "Type");
     cy.get(".p-column-title").eq(3).should("have.text", "Value");
+    cy.get(".p-column-title").eq(4).should("have.text", "Tags");
     cy.get(".p-paginator").should("be.visible");
 
     // Check all buttons / filters are visible
@@ -842,6 +843,36 @@ describe("Observable Summary Details - Don't Affect State", () => {
     cy.get(".p-datatable-tbody > > :nth-child(4)")
       .eq(6)
       .should("have.text", "http://evil.com/malware.exe");
+
+    // Check Tags column
+    cy.get(".p-datatable-tbody > > :nth-child(5)").should("have.length", 7);
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(0)
+      .should("have.text", "from_address");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(1)
+      .should("have.text", "");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(2)
+      .should("have.text", "");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(3)
+      .should("have.text", "c2contacted_host");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(4)
+      .should("have.text", "");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(5)
+      .should("have.text", "");
+    cy.get(".p-datatable-tbody > > :nth-child(5)")
+      .eq(6)
+      .should("have.text", "");
+    
+    // Check that the tags themselves are formatted as tags
+    cy.get('.p-tag').should('have.length', 3)
+    cy.get('.p-tag').eq(0).should('have.text', 'from_address')
+    cy.get('.p-tag').eq(1).should('have.text', 'c2')
+    cy.get('.p-tag').eq(2).should('have.text', 'contacted_host')
   });
   it("correctly selects observables with low hits when 'Select low hits' button clicked ", () => {
     cy.get("#select-low-hits-button").click();

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -867,12 +867,12 @@ describe("Observable Summary Details - Don't Affect State", () => {
     cy.get(".p-datatable-tbody > > :nth-child(5)")
       .eq(6)
       .should("have.text", "");
-    
+
     // Check that the tags themselves are formatted as tags
-    cy.get('.p-tag').should('have.length', 3)
-    cy.get('.p-tag').eq(0).should('have.text', 'from_address')
-    cy.get('.p-tag').eq(1).should('have.text', 'c2')
-    cy.get('.p-tag').eq(2).should('have.text', 'contacted_host')
+    cy.get(".p-tag").should("have.length", 3);
+    cy.get(".p-tag").eq(0).should("have.text", "from_address");
+    cy.get(".p-tag").eq(1).should("have.text", "c2");
+    cy.get(".p-tag").eq(2).should("have.text", "contacted_host");
   });
   it("correctly selects observables with low hits when 'Select low hits' button clicked ", () => {
     cy.get("#select-low-hits-button").click();


### PR DESCRIPTION
Apparently the 1.0 observable summary table also includes a 'Related' and 'Tags' column... oops! This PR adds the 'Tags' column to the table. If clicked, the tag will add a filter on *alerts* for the given tag (same behavior as 1.0).

The 'Related' column will require some backend API changes, and therefore will be included in a future PR.