### PR TITLE
Changes Save to Event modal's comment functionality

### DIFF
--- a/backend/app/tests/alerts/smallWithUrls.json
+++ b/backend/app/tests/alerts/smallWithUrls.json
@@ -1,8 +1,5 @@
 {
-  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6a",
-  "disposition_user": "alice",
-  "name": "Small Alert",
-  "owner": "bob",
+  "name": "Small Alert with URLs",
   "observables": [
     {
       "type": "file",

--- a/frontend/src/components/Modals/SaveToEventModal.vue
+++ b/frontend/src/components/Modals/SaveToEventModal.vue
@@ -44,7 +44,7 @@
                   rows="5"
                   cols="30"
                 />
-                <label for="newEventComment">Disposition Comment</label>
+                <label for="newEventComment">Event Comment</label>
               </span>
             </div>
           </div>
@@ -206,10 +206,13 @@
 
       // Add any comments if necessary
       if (commentData.value) {
-        const newCommentData = selectedAlertStore.selected.map((uuid) => ({
-          nodeUuid: uuid,
-          ...commentData.value,
-        }));
+        const newCommentData = [
+          {
+            nodeUuid: eventUuid,
+            ...commentData.value,
+          },
+        ];
+
         try {
           await NodeComment.create(newCommentData);
         } catch (err) {

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -1306,10 +1306,21 @@ describe("Manage Alerts - Save to Event", () => {
         "contain.text",
         "(Analyst) disposition comment",
       );
-      cy.get(".p-datatable-tbody > tr > :nth-child(4) .p-mr-2").should(
-        "contain.text",
-        "(Analyst) new event comment",
-      );
+
+      // Check the event comment (need to visit the Manage Events page)
+      cy.intercept(
+        "GET",
+        "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&queue=external",
+      ).as("getEvents");
+
+      visitUrl({
+        url: "/manage_events",
+        extraIntercepts: ["@getEvents"],
+      });
+
+      cy.get(
+        ".p-datatable-tbody > :nth-child(1) > :nth-child(5) .p-mr-2",
+      ).should("contain.text", "(Analyst) new event comment");
     });
   });
 });


### PR DESCRIPTION
The "Save to Event" modal previously had a comment box that would apply the given comment to each of the alerts being added to the event. This was done because it is how it works in ACE 1.0, but that is only because 1.0 does not have the ability to add comments directly to an event.

This PR changes that so that the comment is added to the event instead.