### PR TITLE
Fixes Manage Events page automatically fetching every displayed event

### DIFF
--- a/frontend/src/components/Events/EventTableCell.vue
+++ b/frontend/src/components/Events/EventTableCell.vue
@@ -44,7 +44,7 @@
       data-cy="edit-event-button"
       class="p-button-sm"
       icon="pi pi-pencil"
-      @click="open(`EditEventModal-${props.data.uuid}`)"
+      @click="open(editEventModalName)"
     />
     <EditEventModal
       :id="props.data.uuid"
@@ -58,7 +58,7 @@
 </template>
 
 <script setup>
-  import { defineProps } from "vue";
+  import { computed, defineProps } from "vue";
   import Button from "primevue/button";
 
   import NodeTagVue from "@/components/Node/NodeTag.vue";
@@ -75,6 +75,10 @@
     data: { type: Object, required: true },
     field: { type: String, required: true },
     showTags: { type: Boolean, required: false, default: true },
+  });
+
+  const editEventModalName = computed(() => {
+    return `EditEventModal-${props.data.uuid}`;
   });
 
   const formatDateTime = (dateTime) => {

--- a/frontend/src/components/Modals/EditEventModal.vue
+++ b/frontend/src/components/Modals/EditEventModal.vue
@@ -60,15 +60,7 @@
 </template>
 
 <script setup>
-  import {
-    computed,
-    defineEmits,
-    defineProps,
-    onMounted,
-    ref,
-    inject,
-    watch,
-  } from "vue";
+  import { computed, defineEmits, defineProps, ref, inject, watch } from "vue";
 
   import Button from "primevue/button";
   import Message from "primevue/message";
@@ -102,20 +94,6 @@
   const fieldOptionObjects = ref({});
   const formFields = ref({});
   const isLoading = ref(false);
-
-  onMounted(async () => {
-    await fetchEvent();
-
-    for (const option of availableEditFields[event.value.queue.value]) {
-      // Create a lookup by field/option name of all the fieldOptionObjects
-      fieldOptionObjects.value[option.name] = option;
-      // Set up all the form field objects (to be used in NodePropertyInput)
-      formFields.value[option.name] = {
-        propertyType: option.name,
-        propertyValue: null,
-      };
-    }
-  });
 
   // Load event data only when modal becomes active
   watch(modalStore, async () => {
@@ -151,6 +129,17 @@
     try {
       await fetchEvent();
       await populateEventStores();
+
+      for (const option of availableEditFields[event.value.queue.value]) {
+        // Create a lookup by field/option name of all the fieldOptionObjects
+        fieldOptionObjects.value[option.name] = option;
+        // Set up all the form field objects (to be used in NodePropertyInput)
+        formFields.value[option.name] = {
+          propertyType: option.name,
+          propertyValue: null,
+        };
+      }
+
       await resetForm();
     } catch (err) {
       error.value = err.message;


### PR DESCRIPTION
There was a logic bug with the Edit Event modal that caused it to automatically fetch every single event displayed in the Manage Events table. This makes it so that it will only fetch the event when the modal is opened.