### PR TITLE
Event URL Domain summary API endpoint

### DIFF
--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import List, Optional
 
 from api.models import type_str
 from api.models.observable import ObservableRead
@@ -13,12 +13,18 @@ class ObservableSummary(ObservableRead):
     faqueue_link: str = Field(description="An optional link to view the FA Queue search")
 
 
-class URLDomainSummary(BaseModel):
-    """Represents a URL domain summary as used on the event pages."""
+class URLDomainSummaryIndividual(BaseModel):
+    """Represents an individual URL domain summary."""
 
     domain: type_str = Field(description="The domain from the URL observables")
 
     count: int = Field(description="The number of times the domain occurred in unique URL observables")
+
+
+class URLDomainSummary(BaseModel):
+    """Represents a URL domain summary as used on the event pages."""
+
+    domains: List[URLDomainSummaryIndividual] = Field(description="The domain from the URL observables")
 
     total: int = Field(
         description="The cumulative total of all the counts. count/total gives the ratio of this domain's occurrences."

--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -13,6 +13,18 @@ class ObservableSummary(ObservableRead):
     faqueue_link: str = Field(description="An optional link to view the FA Queue search")
 
 
+class URLDomainSummary(BaseModel):
+    """Represents a URL domain summary as used on the event pages."""
+
+    domain: type_str = Field(description="The domain from the URL observables")
+
+    count: int = Field(description="The number of times the domain occurred in unique URL observables")
+
+    total: int = Field(
+        description="The cumulative total of all the counts. count/total gives the ratio of this domain's occurrences."
+    )
+
+
 class UserSummary(BaseModel):
     """Represents a user summary as used on the event pages."""
 

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,10 +8,10 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
-from api.models.event_summaries import ObservableSummary, UserSummary
+from api.models.event_summaries import ObservableSummary, URLDomainSummary, UserSummary
 from api.models.history import EventHistoryRead
 from api.routes import helpers
-from api.routes.event_summaries import get_observable_summary, get_user_summary
+from api.routes.event_summaries import get_observable_summary, get_url_domain_summary, get_user_summary
 from api.routes.node import create_node, update_node
 from core.auth import validate_access_token
 from db import crud
@@ -658,3 +658,4 @@ helpers.api_route_update(router, update_events, path="/")
 
 helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")
 helpers.api_route_read(router, get_user_summary, List[UserSummary], path="/{uuid}/summary/user")
+helpers.api_route_read(router, get_url_domain_summary, List[URLDomainSummary], path="/{uuid}/summary/url_domain")

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -658,4 +658,4 @@ helpers.api_route_update(router, update_events, path="/")
 
 helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")
 helpers.api_route_read(router, get_user_summary, List[UserSummary], path="/{uuid}/summary/user")
-helpers.api_route_read(router, get_url_domain_summary, List[URLDomainSummary], path="/{uuid}/summary/url_domain")
+helpers.api_route_read(router, get_url_domain_summary, URLDomainSummary, path="/{uuid}/summary/url_domain")

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -89,6 +89,10 @@ def get_user_summary(uuid: UUID, db: Session = Depends(get_db)):
     unique_emails = set()
     results = []
     for user_analysis in user_analyses:
+        # Skip this analysis if it does not have the required fields
+        if "user_id" not in user_analysis.details or "email" not in user_analysis.details:
+            continue
+
         if user_analysis.details["email"] in unique_emails:
             continue
 

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -112,7 +112,7 @@ def test_summary_url_domains(client_valid_access_token, db):
 
     # The URL domains summary should be empty
     get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/url_domain")
-    assert get.json() == []
+    assert get.json() == {"domains": [], "total": 0}
 
     # Add some alerts with analyses to the event
     #
@@ -145,16 +145,14 @@ def test_summary_url_domains(client_valid_access_token, db):
     #
     # Results: example.com (2), example2.com (1), example3.com (1)
     get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/url_domain")
-    assert len(get.json()) == 3
-    assert get.json()[0]["domain"] == "example.com"
-    assert get.json()[0]["count"] == 2
-    assert get.json()[0]["total"] == 4
-    assert get.json()[1]["domain"] == "example2.com"
-    assert get.json()[1]["count"] == 1
-    assert get.json()[1]["total"] == 4
-    assert get.json()[2]["domain"] == "example3.com"
-    assert get.json()[2]["count"] == 1
-    assert get.json()[2]["total"] == 4
+    assert get.json()["total"] == 4
+    assert len(get.json()["domains"]) == 3
+    assert get.json()["domains"][0]["domain"] == "example.com"
+    assert get.json()["domains"][0]["count"] == 2
+    assert get.json()["domains"][1]["domain"] == "example2.com"
+    assert get.json()["domains"][1]["count"] == 1
+    assert get.json()["domains"][2]["domain"] == "example3.com"
+    assert get.json()["domains"][2]["count"] == 1
 
 
 def test_summary_user(client_valid_access_token, db):

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -106,6 +106,57 @@ def test_summary_observable(client_valid_access_token, db):
     assert get.json()[1]["faqueue_hits"] == 100
 
 
+def test_summary_url_domains(client_valid_access_token, db):
+    # Create an event
+    event = helpers.create_event(name="test event", db=db)
+
+    # The URL domains summary should be empty
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/url_domain")
+    assert get.json() == []
+
+    # Add some alerts with analyses to the event
+    #
+    # alert1
+    #   o1 - https://example.com
+    #     a1
+    #       o2 - https://example2.com
+    #       o3 - https://example.com
+    #
+    # alert2
+    #  o1 - https://example.com/index.html
+    #  o2 - https://example3.com
+    alert_tree1 = helpers.create_alert(db=db, event=event)
+    alert1_o1 = helpers.create_observable(type="url", value="https://example.com", parent_tree=alert_tree1, db=db)
+    alert1_a1 = helpers.create_analysis(db=db, parent_tree=alert1_o1, amt_value="URL Analysis")
+    helpers.create_observable(type="url", value="https://example2.com", parent_tree=alert1_a1, db=db)
+    helpers.create_observable(type="url", value="https://example.com", parent_tree=alert1_a1, db=db)
+
+    alert_tree2 = helpers.create_alert(db=db, event=event)
+    helpers.create_observable(type="url", value="https://example.com/index.html", parent_tree=alert_tree2, db=db)
+    helpers.create_observable(type="url", value="https://example3.com", parent_tree=alert_tree2, db=db)
+
+    # Add a third alert that is not part of the event
+    alert_tree3 = helpers.create_alert(db=db)
+    helpers.create_observable(type="url", value="https://example4.com", parent_tree=alert_tree3, db=db)
+
+    # The URL domain summary should now have three entries in it. The https://example.com URL is repeated, so it
+    # only counts once for the purposes of the summary.
+    # Additionally, the results should be sorted by the number of times the domains appeared then by the domain.
+    #
+    # Results: example.com (2), example2.com (1), example3.com (1)
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/url_domain")
+    assert len(get.json()) == 3
+    assert get.json()[0]["domain"] == "example.com"
+    assert get.json()[0]["count"] == 2
+    assert get.json()[0]["total"] == 4
+    assert get.json()[1]["domain"] == "example2.com"
+    assert get.json()[1]["count"] == 1
+    assert get.json()[1]["total"] == 4
+    assert get.json()[2]["domain"] == "example3.com"
+    assert get.json()[2]["count"] == 1
+    assert get.json()[2]["total"] == 4
+
+
 def test_summary_user(client_valid_access_token, db):
     # Create an event
     event = helpers.create_event(name="test event", db=db)

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -5,6 +5,12 @@ export interface observableSummary extends observableRead {
   faqueueLink: string;
 }
 
+export interface urlDomainSummary {
+  domain: string;
+  count: number;
+  total: number;
+}
+
 export interface userSummary {
   company: string | null;
   department: string | null;

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -5,9 +5,13 @@ export interface observableSummary extends observableRead {
   faqueueLink: string;
 }
 
-export interface urlDomainSummary {
+interface urlDomainSummaryIndividual {
   domain: string;
   count: number;
+}
+
+export interface urlDomainSummary {
+  domains: urlDomainSummaryIndividual[];
   total: number;
 }
 


### PR DESCRIPTION
This PR adds the `/api/event/{uuid}/summary/url_domain` API endpoint. The overall logic for this endpoint is that it gets all of the **UNIQUE** URL observables in the event and then counts the number of times the domains in the URLs appear.

The data is returned in a format like:

```
{
  "domains": [ {"domain": "blah.com", "count": 5}, {"domain": "other.com", "count": 1} ],
  "total": 6
}
```

The data is first sorted by the domain counts (descending) and then by the domain (ascending). You can get the ratio of the domains by `count` / `total`.