### PR TITLE
Event email summary API endpoint

### DIFF
--- a/backend/app/api/models/analysis.py
+++ b/backend/app/api/models/analysis.py
@@ -25,12 +25,6 @@ class AnalysisBase(NodeBase):
 
 
 class AnalysisCreate(NodeCreate, AnalysisBase):
-    # TODO - save for the end, still need to flesh out this functionality
-    # event_summary: Optional[AnalysisEventSummary] = Field(
-    #     description="""Optional summary information to display on an event page if this analysis is ever added to an
-    #     event"""
-    # )
-
     node_tree: NodeTreeCreateWithNode = Field(description="This defines where in a Node Tree this analysis fits")
 
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the analysis")
@@ -66,11 +60,5 @@ class AnalysisUpdate(NodeUpdate, AnalysisBase):
     details: Optional[Json] = Field(description="A JSON representation of the details produced by the analysis")
 
     error_message: Optional[type_str] = Field(description="An optional error message that occurred during analysis")
-
-    # TODO - save for the end, still need to flesh out this functionality
-    # event_summary: Optional[AnalysisEventSummary] = Field(
-    #     description="""Optional summary information to display on an event page if this analysis is ever added to an
-    #     event"""
-    # )
 
     stack_trace: Optional[type_str] = Field(description="An optional stack trace that occurred during analysis")

--- a/backend/app/api/models/analysis_details.py
+++ b/backend/app/api/models/analysis_details.py
@@ -24,10 +24,18 @@ class EmailAnalysisDetailsBase(BaseModel):
 
 
 class EmailAnalysisDetails(EmailAnalysisDetailsBase):
-    """Represents the fields in Email Analysis details that the frontend expects for event pages."""
+    """Represents the minimum fields in Email Analysis details that the frontend expects for event pages."""
 
     body_html: Optional[type_str] = Field(description="The HTML body of the email")
 
     body_text: Optional[type_str] = Field(description="The plaintext body of the email")
 
     headers: type_str = Field(description="The headers of the email")
+
+
+class FAQueueAnalysisDetails(BaseModel):
+    """Represents the minimum fields in FA Queue Analysis details that the frontend expects for event pages."""
+
+    hits: int = Field(description="The number of hits produced by the FA Queue search for the observable")
+
+    link: Optional[type_str] = Field(description="A link (such as to Splunk) where the FA Queue search can be viewed")

--- a/backend/app/api/models/analysis_details.py
+++ b/backend/app/api/models/analysis_details.py
@@ -14,9 +14,9 @@ class EmailAnalysisDetailsBase(BaseModel):
 
     message_id: type_str = Field(description="The email's message-id")
 
-    reply_to_address: Optional[str] = Field(description="The reply-to email address")
+    reply_to_address: Optional[type_str] = Field(description="The reply-to email address")
 
-    subject: Optional[str] = Field(description="The email's subject")
+    subject: Optional[type_str] = Field(description="The email's subject")
 
     time: datetime = Field(description="The time the email was received")
 
@@ -26,8 +26,8 @@ class EmailAnalysisDetailsBase(BaseModel):
 class EmailAnalysisDetails(EmailAnalysisDetailsBase):
     """Represents the fields in Email Analysis details that the frontend expects for event pages."""
 
-    body_html: Optional[str] = Field(description="The HTML body of the email")
+    body_html: Optional[type_str] = Field(description="The HTML body of the email")
 
-    body_text: Optional[str] = Field(description="The plaintext body of the email")
+    body_text: Optional[type_str] = Field(description="The plaintext body of the email")
 
     headers: type_str = Field(description="The headers of the email")

--- a/backend/app/api/models/analysis_details.py
+++ b/backend/app/api/models/analysis_details.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from pydantic import BaseModel, Field
+from typing import List, Optional
+
+from api.models import type_str
+
+
+class EmailAnalysisDetailsBase(BaseModel):
+    attachments: List[type_str] = Field(description="A list of the email attachment names")
+
+    cc_addresses: List[type_str] = Field(description="A list of CC recipient email addresses")
+
+    from_address: type_str = Field(description="The email sender's address")
+
+    message_id: type_str = Field(description="The email's message-id")
+
+    reply_to_address: Optional[str] = Field(description="The reply-to email address")
+
+    subject: Optional[str] = Field(description="The email's subject")
+
+    time: datetime = Field(description="The time the email was received")
+
+    to_address: type_str = Field(description="The recipient's email address")
+
+
+class EmailAnalysisDetails(EmailAnalysisDetailsBase):
+    """Represents the fields in Email Analysis details that the frontend expects for event pages."""
+
+    body_html: Optional[str] = Field(description="The HTML body of the email")
+
+    body_text: Optional[str] = Field(description="The plaintext body of the email")
+
+    headers: type_str = Field(description="The headers of the email")

--- a/backend/app/api/models/analysis_details.py
+++ b/backend/app/api/models/analysis_details.py
@@ -39,3 +39,21 @@ class FAQueueAnalysisDetails(BaseModel):
     hits: int = Field(description="The number of hits produced by the FA Queue search for the observable")
 
     link: Optional[type_str] = Field(description="A link (such as to Splunk) where the FA Queue search can be viewed")
+
+
+class UserAnalysisDetails(BaseModel):
+    """Represents the minimum fields in User Analysis details that the frontend expects for event pages."""
+
+    company: Optional[type_str] = Field(description="The company to which the user belongs")
+
+    department: Optional[type_str] = Field(description="The department to which the user belongs")
+
+    division: Optional[type_str] = Field(description="The division to which the user belongs")
+
+    email: type_str = Field(description="The user's email address")
+
+    manager_email: Optional[type_str] = Field(description="The email address of the user's manager")
+
+    title: Optional[type_str] = Field(description="The user's job title")
+
+    user_id: type_str = Field(description="The user's user ID")

--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -17,7 +17,7 @@ class ObservableSummary(ObservableRead):
 
     faqueue_hits: int = Field(description="The number of hits found by FA Queue Analysis for this observable")
 
-    faqueue_link: str = Field(description="An optional link to view the FA Queue search")
+    faqueue_link: Optional[type_str] = Field(description="An optional link to view the FA Queue search")
 
 
 class URLDomainSummaryIndividual(BaseModel):
@@ -41,16 +41,16 @@ class URLDomainSummary(BaseModel):
 class UserSummary(BaseModel):
     """Represents a user summary as used on the event pages."""
 
-    company: Optional[str] = Field(description="The company to which the user belongs")
+    company: Optional[type_str] = Field(description="The company to which the user belongs")
 
-    department: Optional[str] = Field(description="The department to which the user belongs")
+    department: Optional[type_str] = Field(description="The department to which the user belongs")
 
-    division: Optional[str] = Field(description="The division to which the user belongs")
+    division: Optional[type_str] = Field(description="The division to which the user belongs")
 
     email: type_str = Field(description="The user's email address")
 
-    manager_email: Optional[str] = Field(description="The email address of the user's manager")
+    manager_email: Optional[type_str] = Field(description="The email address of the user's manager")
 
-    title: Optional[str] = Field(description="The user's job title")
+    title: Optional[type_str] = Field(description="The user's job title")
 
     user_id: type_str = Field(description="The user's user ID")

--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -1,8 +1,15 @@
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, UUID4
 from typing import List, Optional
 
 from api.models import type_str
+from api.models.analysis_details import EmailAnalysisDetailsBase
 from api.models.observable import ObservableRead
+
+
+class EmailSummary(EmailAnalysisDetailsBase):
+    """Represents the fields in Email Analysis details that the frontend expects for event pages."""
+
+    alert_uuid: UUID4 = Field(description="The UUID of the alert to which this email belongs")
 
 
 class ObservableSummary(ObservableRead):

--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -2,7 +2,7 @@ from pydantic import BaseModel, Field, UUID4
 from typing import List, Optional
 
 from api.models import type_str
-from api.models.analysis_details import EmailAnalysisDetailsBase
+from api.models.analysis_details import EmailAnalysisDetailsBase, UserAnalysisDetails
 from api.models.observable import ObservableRead
 
 
@@ -38,19 +38,7 @@ class URLDomainSummary(BaseModel):
     )
 
 
-class UserSummary(BaseModel):
+class UserSummary(UserAnalysisDetails):
     """Represents a user summary as used on the event pages."""
 
-    company: Optional[type_str] = Field(description="The company to which the user belongs")
-
-    department: Optional[type_str] = Field(description="The department to which the user belongs")
-
-    division: Optional[type_str] = Field(description="The division to which the user belongs")
-
-    email: type_str = Field(description="The user's email address")
-
-    manager_email: Optional[type_str] = Field(description="The email address of the user's manager")
-
-    title: Optional[type_str] = Field(description="The user's job title")
-
-    user_id: type_str = Field(description="The user's user ID")
+    pass

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -50,8 +50,11 @@ def create_analysis(
         if analysis_module_type.value == "Email Analysis":
             try:
                 EmailAnalysisDetails(**analysis.details)
-            except:
-                raise HTTPException(status_code=400, detail=f"The Email Analysis details are invalid")
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"The Email Analysis details for alert {analysis.node_tree.root_node_uuid} are invalid: {e}",
+                )
 
     db.add(new_analysis)
     crud.commit(db)

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -43,6 +43,9 @@ def create_analysis(
             uuid=analysis.analysis_module_type, db_table=AnalysisModuleType, db=db
         )
 
+        # TODO: Do we want to verify certain types of analysis details here?
+        # For example, the analysis details the GUI depends upon to show the event pages.
+
     db.add(new_analysis)
     crud.commit(db)
 

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -45,8 +45,9 @@ def create_analysis(
         )
         new_analysis.analysis_module_type = analysis_module_type
 
-        # TODO: Do we want to verify certain types of analysis details here?
-        # For example, the analysis details the GUI depends upon to show the event pages.
+        # Validate certain types of analysis details. The GUI depends on specific analysis details
+        # when showing event pages. Because of this, we want to ensure that these details conform
+        # to what the GUI expects.
         if analysis_module_type.value == "Email Analysis":
             try:
                 EmailAnalysisDetails(**analysis.details)

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 
 from api.models.analysis import AnalysisCreate, AnalysisRead, AnalysisUpdate
-from api.models.analysis_details import EmailAnalysisDetails
+from api.models.analysis_details import EmailAnalysisDetails, FAQueueAnalysisDetails
 from api.routes import helpers
 from api.routes.node import create_node, update_node
 from db import crud
@@ -55,6 +55,15 @@ def create_analysis(
                 raise HTTPException(
                     status_code=400,
                     detail=f"The Email Analysis details for alert {analysis.node_tree.root_node_uuid} are invalid: {e}",
+                )
+
+        elif analysis_module_type.value.startswith("FA Queue"):
+            try:
+                FAQueueAnalysisDetails(**analysis.details)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"The FA Queue Analysis details for alert {analysis.node_tree.root_node_uuid} are invalid: {e}",
                 )
 
     db.add(new_analysis)

--- a/backend/app/api/routes/analysis.py
+++ b/backend/app/api/routes/analysis.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 from uuid import UUID
 
 from api.models.analysis import AnalysisCreate, AnalysisRead, AnalysisUpdate
-from api.models.analysis_details import EmailAnalysisDetails, FAQueueAnalysisDetails
+from api.models.analysis_details import EmailAnalysisDetails, FAQueueAnalysisDetails, UserAnalysisDetails
 from api.routes import helpers
 from api.routes.node import create_node, update_node
 from db import crud
@@ -64,6 +64,15 @@ def create_analysis(
                 raise HTTPException(
                     status_code=400,
                     detail=f"The FA Queue Analysis details for alert {analysis.node_tree.root_node_uuid} are invalid: {e}",
+                )
+
+        elif analysis_module_type.value == "User Analysis":
+            try:
+                UserAnalysisDetails(**analysis.details)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400,
+                    detail=f"The User Analysis details for alert {analysis.node_tree.root_node_uuid} are invalid: {e}",
                 )
 
     db.add(new_analysis)

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,10 +8,15 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
-from api.models.event_summaries import ObservableSummary, URLDomainSummary, UserSummary
+from api.models.event_summaries import EmailSummary, ObservableSummary, URLDomainSummary, UserSummary
 from api.models.history import EventHistoryRead
 from api.routes import helpers
-from api.routes.event_summaries import get_observable_summary, get_url_domain_summary, get_user_summary
+from api.routes.event_summaries import (
+    get_email_summary,
+    get_observable_summary,
+    get_url_domain_summary,
+    get_user_summary,
+)
 from api.routes.node import create_node, update_node
 from core.auth import validate_access_token
 from db import crud
@@ -656,6 +661,7 @@ helpers.api_route_update(router, update_events, path="/")
 # SUMMARIES
 #
 
+helpers.api_route_read(router, get_email_summary, List[EmailSummary], path="/{uuid}/summary/email")
 helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")
 helpers.api_route_read(router, get_user_summary, List[UserSummary], path="/{uuid}/summary/user")
 helpers.api_route_read(router, get_url_domain_summary, URLDomainSummary, path="/{uuid}/summary/url_domain")

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -41,6 +41,7 @@ def get_email_summary(uuid: UUID, db: Session = Depends(get_db)):
 
     alert_uuid_and_analysis: List[Tuple[UUID, Analysis]] = db.execute(query).unique().fetchall()
 
+    # Build a list of EmailSummary objects from the unique email analyses
     results: List[EmailSummary] = []
     unique_emails = []
     for alert_uuid, analysis in alert_uuid_and_analysis:

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -7,6 +7,7 @@ from typing import Dict, List, Tuple
 from urllib.parse import urlparse
 from uuid import UUID
 
+from api.models.analysis_details import FAQueueAnalysisDetails
 from api.models.event_summaries import EmailSummary, URLDomainSummaryIndividual
 from db import crud
 from db.database import get_db
@@ -93,15 +94,10 @@ def get_observable_summary(uuid: UUID, db: Session = Depends(get_db)):
     # Loop over the FA Queue analyses and inject their results into the observables.
     results = set()
     for parent_uuid, faqueue_analysis in node_tree_and_faqueue.items():
-        if "hits" in faqueue_analysis.details:
-            node_tree_and_observables[parent_uuid].faqueue_hits = faqueue_analysis.details["hits"]
-
-            if "link" in faqueue_analysis.details:
-                node_tree_and_observables[parent_uuid].faqueue_link = faqueue_analysis.details["link"]
-            else:
-                node_tree_and_observables[parent_uuid].faqueue_link = ""
-
-            results.add(node_tree_and_observables[parent_uuid])
+        analysis_details = FAQueueAnalysisDetails(**faqueue_analysis.details)
+        node_tree_and_observables[parent_uuid].faqueue_hits = analysis_details.hits
+        node_tree_and_observables[parent_uuid].faqueue_link = analysis_details.link
+        results.add(node_tree_and_observables[parent_uuid])
 
     # Return the observables sorted by their type then value
     return sorted(results, key=lambda x: (x.type.value, x.value))

--- a/backend/app/api/routes/event_summaries.py
+++ b/backend/app/api/routes/event_summaries.py
@@ -8,7 +8,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 from api.models.analysis_details import FAQueueAnalysisDetails
-from api.models.event_summaries import EmailSummary, URLDomainSummaryIndividual
+from api.models.event_summaries import EmailSummary, URLDomainSummaryIndividual, UserSummary
 from db import crud
 from db.database import get_db
 from db.schemas.analysis import Analysis
@@ -160,15 +160,12 @@ def get_user_summary(uuid: UUID, db: Session = Depends(get_db)):
     unique_emails = set()
     results = []
     for user_analysis in user_analyses:
-        # Skip this analysis if it does not have the required fields
-        if "user_id" not in user_analysis.details or "email" not in user_analysis.details:
-            continue
-
         if user_analysis.details["email"] in unique_emails:
             continue
+        else:
+            unique_emails.add(user_analysis.details["email"])
 
-        unique_emails.add(user_analysis.details["email"])
-        results.append(user_analysis.details)
+        results.append(UserSummary(**user_analysis.details))
 
     # Return the analysis details sorted by the email addresses
-    return sorted(results, key=lambda x: (x["email"]))
+    return sorted(results, key=lambda x: (x.email))

--- a/backend/app/tests/api/analysis/test_create.py
+++ b/backend/app/tests/api/analysis/test_create.py
@@ -132,6 +132,23 @@ def test_create_invalid_faqueue_analysis(client_valid_access_token, db):
     assert create.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_create_invalid_user_analysis(client_valid_access_token, db):
+    node_tree = helpers.create_alert(db=db)
+    analysis_module_type = helpers.create_analysis_module_type(value="User Analysis", db=db)
+
+    # Create the analysis - it is missing the required "user_id" key
+    create = client_valid_access_token.post(
+        "/api/analysis/",
+        json={
+            "analysis_module_type": str(analysis_module_type.uuid),
+            "node_tree": {"parent_tree_uuid": str(node_tree.uuid), "root_node_uuid": str(node_tree.root_node_uuid)},
+            "details": json.dumps({"username": "goodguy", "email": "goodguy@company.com"}),
+        },
+    )
+
+    assert create.status_code == status.HTTP_400_BAD_REQUEST
+
+
 #
 # VALID TESTS
 #

--- a/backend/app/tests/api/analysis/test_create.py
+++ b/backend/app/tests/api/analysis/test_create.py
@@ -2,6 +2,7 @@ import json
 import pytest
 import uuid
 
+from datetime import datetime
 from fastapi import status
 
 from tests import helpers
@@ -84,6 +85,34 @@ def test_create_nonexistent_analysis_module_type(client_valid_access_token, db):
         },
     )
     assert create.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_create_invalid_email_analysis(client_valid_access_token, db):
+    node_tree = helpers.create_alert(db=db)
+    analysis_module_type = helpers.create_analysis_module_type(value="Email Analysis", db=db)
+
+    # Create the analysis - it is missing the required "from_address" key
+    create = client_valid_access_token.post(
+        "/api/analysis/",
+        json={
+            "analysis_module_type": str(analysis_module_type.uuid),
+            "node_tree": {"parent_tree_uuid": str(node_tree.uuid), "root_node_uuid": str(node_tree.root_node_uuid)},
+            "details": json.dumps(
+                {
+                    "attachments": [],
+                    "cc_addresses": [],
+                    "headers": "blah",
+                    "message_id": "<abcd1234@evil.com>",
+                    "subject": "Hello",
+                    "time": datetime.now().isoformat(),
+                    "to_address": "goodguy@company.com",
+                    "extra_field": "extra_value",
+                }
+            ),
+        },
+    )
+
+    assert create.status_code == status.HTTP_400_BAD_REQUEST
 
 
 #

--- a/backend/app/tests/api/analysis/test_create.py
+++ b/backend/app/tests/api/analysis/test_create.py
@@ -115,6 +115,23 @@ def test_create_invalid_email_analysis(client_valid_access_token, db):
     assert create.status_code == status.HTTP_400_BAD_REQUEST
 
 
+def test_create_invalid_faqueue_analysis(client_valid_access_token, db):
+    node_tree = helpers.create_alert(db=db)
+    analysis_module_type = helpers.create_analysis_module_type(value="FA Queue Analysis", db=db)
+
+    # Create the analysis - it is missing the required "hits" key
+    create = client_valid_access_token.post(
+        "/api/analysis/",
+        json={
+            "analysis_module_type": str(analysis_module_type.uuid),
+            "node_tree": {"parent_tree_uuid": str(node_tree.uuid), "root_node_uuid": str(node_tree.root_node_uuid)},
+            "details": json.dumps({"faqueue_hits": 100, "link": "https://example.com"}),
+        },
+    )
+
+    assert create.status_code == status.HTTP_400_BAD_REQUEST
+
+
 #
 # VALID TESTS
 #

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -23,6 +23,88 @@ def test_get_nonexistent_uuid(client_valid_access_token):
     assert get.status_code == status.HTTP_404_NOT_FOUND
 
 
+def test_summary_observable_incorrect_details(client_valid_access_token, db):
+    # Create an event
+    event = helpers.create_event(name="test event", db=db)
+
+    # The observable summary should be empty
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
+    assert get.json() == []
+
+    # Add an alert with FA Queue analysis with the wrong details hits keys
+    alert_tree = helpers.create_alert(db=db, event=event)
+    alert_o1 = helpers.create_observable(type="fqdn", value="localhost.localdomain", parent_tree=alert_tree, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert_o1,
+        amt_value="FA Queue Type 1",
+        details={"link": "https://url.to.search/query=asdf", "faqueue_hits": 10},
+    )
+
+    # The observable summary should still be empty since the FA Queue analysis details has the wrong "hits" key
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
+    assert get.json() == []
+
+    # Add an alert with FA Queue analysis with the wrong details link keys
+    alert_tree = helpers.create_alert(db=db, event=event)
+    alert_o1 = helpers.create_observable(type="fqdn", value="localhost.localdomain", parent_tree=alert_tree, db=db)
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert_o1,
+        amt_value="FA Queue Type 1",
+        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
+    )
+
+    # The observable summary should have one entry, but its faqueue_link property should be an empty string
+    # since the FA Queue analysis details has the wrong "link" key
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
+    assert len(get.json()) == 1
+    assert get.json()[0]["faqueue_hits"] == 10
+    assert get.json()[0]["faqueue_link"] == ""
+
+
+def test_summary_user_incorrect_details(client_valid_access_token, db):
+    # Create an event
+    event = helpers.create_event(name="test event", db=db)
+
+    # The user summary should be empty
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
+    assert get.json() == []
+
+    # The required keys are "user_id" and "email". The others are optional.
+    # Add an alert with user analysis with the wrong user_id key.
+    alert_tree = helpers.create_alert(db=db, event=event)
+    alert_o1 = helpers.create_observable(
+        type="email_address", value="goodguy@company.com", parent_tree=alert_tree, db=db
+    )
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert_o1,
+        amt_value="User Analysis",
+        details={"username": "goodguy", "email": "goodguy@company.com"},
+    )
+
+    # The user summary should still be empty since the analysis details has the wrong "user_id" key
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
+    assert get.json() == []
+
+    # Add an alert with FA Queue analysis with the wrong details email keys
+    alert_tree = helpers.create_alert(db=db, event=event)
+    alert_o1 = helpers.create_observable(
+        type="email_address", value="goodguy@company.com", parent_tree=alert_tree, db=db
+    )
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert_o1,
+        amt_value="User Analysis",
+        details={"user_id": "goodguy", "email_address": "goodguy@company.com"},
+    )
+
+    # The user summary should still be empty since the analysis details has the wrong "user_id" key
+    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
+    assert get.json() == []
+
+
 #
 # VALID TESTS
 #
@@ -257,88 +339,6 @@ def test_summary_user(client_valid_access_token, db):
     assert len(get.json()) == 2
     assert get.json()[0]["email"] == "goodguy@company.com"
     assert get.json()[1]["email"] == "otherguy@company.com"
-
-
-def test_summary_observable_incorrect_details(client_valid_access_token, db):
-    # Create an event
-    event = helpers.create_event(name="test event", db=db)
-
-    # The observable summary should be empty
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
-    assert get.json() == []
-
-    # Add an alert with FA Queue analysis with the wrong details hits keys
-    alert_tree = helpers.create_alert(db=db, event=event)
-    alert_o1 = helpers.create_observable(type="fqdn", value="localhost.localdomain", parent_tree=alert_tree, db=db)
-    helpers.create_analysis(
-        db=db,
-        parent_tree=alert_o1,
-        amt_value="FA Queue Type 1",
-        details={"link": "https://url.to.search/query=asdf", "faqueue_hits": 10},
-    )
-
-    # The observable summary should still be empty since the FA Queue analysis details has the wrong "hits" key
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
-    assert get.json() == []
-
-    # Add an alert with FA Queue analysis with the wrong details link keys
-    alert_tree = helpers.create_alert(db=db, event=event)
-    alert_o1 = helpers.create_observable(type="fqdn", value="localhost.localdomain", parent_tree=alert_tree, db=db)
-    helpers.create_analysis(
-        db=db,
-        parent_tree=alert_o1,
-        amt_value="FA Queue Type 1",
-        details={"gui_link": "https://url.to.search/query=asdf", "hits": 10},
-    )
-
-    # The observable summary should have one entry, but its faqueue_link property should be an empty string
-    # since the FA Queue analysis details has the wrong "link" key
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/observable")
-    assert len(get.json()) == 1
-    assert get.json()[0]["faqueue_hits"] == 10
-    assert get.json()[0]["faqueue_link"] == ""
-
-
-def test_summary_user_incorrect_details(client_valid_access_token, db):
-    # Create an event
-    event = helpers.create_event(name="test event", db=db)
-
-    # The user summary should be empty
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
-    assert get.json() == []
-
-    # The required keys are "user_id" and "email". The others are optional.
-    # Add an alert with user analysis with the wrong user_id key.
-    alert_tree = helpers.create_alert(db=db, event=event)
-    alert_o1 = helpers.create_observable(
-        type="email_address", value="goodguy@company.com", parent_tree=alert_tree, db=db
-    )
-    helpers.create_analysis(
-        db=db,
-        parent_tree=alert_o1,
-        amt_value="User Analysis",
-        details={"username": "goodguy", "email": "goodguy@company.com"},
-    )
-
-    # The user summary should still be empty since the analysis details has the wrong "user_id" key
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
-    assert get.json() == []
-
-    # Add an alert with FA Queue analysis with the wrong details email keys
-    alert_tree = helpers.create_alert(db=db, event=event)
-    alert_o1 = helpers.create_observable(
-        type="email_address", value="goodguy@company.com", parent_tree=alert_tree, db=db
-    )
-    helpers.create_analysis(
-        db=db,
-        parent_tree=alert_o1,
-        amt_value="User Analysis",
-        details={"user_id": "goodguy", "email_address": "goodguy@company.com"},
-    )
-
-    # The user summary should still be empty since the analysis details has the wrong "user_id" key
-    get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/user")
-    assert get.json() == []
 
 
 def test_analysis_module_types(client_valid_access_token, db):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.7.5
 bcrypt==3.2.0
+deepdiff==5.7.0
 email-validator==1.1.3
 fastapi==0.73.0
 fastapi-pagination==0.9.1

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,5 +1,16 @@
 import { observableRead } from "./observable";
 
+export interface emailSummary {
+  attachments: string[];
+  ccAddresses: string[];
+  fromAddress: string;
+  messageId: string;
+  replyToAddress: string | null;
+  subject: string | null;
+  time: Date;
+  toAddress: string;
+}
+
 export interface observableSummary extends observableRead {
   faqueueHits: number;
   faqueueLink: string;

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,6 +1,8 @@
+import { UUID } from "./base";
 import { observableRead } from "./observable";
 
 export interface emailSummary {
+  alertUuid: UUID;
   attachments: string[];
   ccAddresses: string[];
   fromAddress: string;


### PR DESCRIPTION
The main purpose of this PR is that it adds the `/api/event/{uuid}/summary/email` API endpoint that will be used by the GUI to display the Email Summary section on event pages.

However, it also introduces Pydantic models for the specific types of analysis that the event pages depend upon. These models are used to validate the analysis details when the analysis is initially added to the database via the `/api/analysis` endpoint. If the details do not conform to their Pydantic model, the endpoint will issue a 400 response with a message saying what the Pydantic validation issue was.
