### PR TITLE
Adds API endpoint for fetching an event's email headers/body summary

### DIFF
--- a/backend/app/api/models/analysis_details.py
+++ b/backend/app/api/models/analysis_details.py
@@ -5,6 +5,14 @@ from typing import List, Optional
 from api.models import type_str
 
 
+class EmailAnalysisDetailsHeaderBody(BaseModel):
+    body_html: Optional[type_str] = Field(description="The HTML body of the email")
+
+    body_text: Optional[type_str] = Field(description="The plaintext body of the email")
+
+    headers: type_str = Field(description="The headers of the email")
+
+
 class EmailAnalysisDetailsBase(BaseModel):
     attachments: List[type_str] = Field(description="A list of the email attachment names")
 
@@ -23,14 +31,10 @@ class EmailAnalysisDetailsBase(BaseModel):
     to_address: type_str = Field(description="The recipient's email address")
 
 
-class EmailAnalysisDetails(EmailAnalysisDetailsBase):
+class EmailAnalysisDetails(EmailAnalysisDetailsBase, EmailAnalysisDetailsHeaderBody):
     """Represents the minimum fields in Email Analysis details that the frontend expects for event pages."""
 
-    body_html: Optional[type_str] = Field(description="The HTML body of the email")
-
-    body_text: Optional[type_str] = Field(description="The plaintext body of the email")
-
-    headers: type_str = Field(description="The headers of the email")
+    pass
 
 
 class FAQueueAnalysisDetails(BaseModel):

--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -2,8 +2,14 @@ from pydantic import BaseModel, Field, UUID4
 from typing import List, Optional
 
 from api.models import type_str
-from api.models.analysis_details import EmailAnalysisDetailsBase, UserAnalysisDetails
+from api.models.analysis_details import EmailAnalysisDetailsBase, EmailAnalysisDetailsHeaderBody, UserAnalysisDetails
 from api.models.observable import ObservableRead
+
+
+class EmailHeadersBody(EmailAnalysisDetailsHeaderBody):
+    """Represents the fields in Email Analysis details that the frontend expects for event pages."""
+
+    alert_uuid: UUID4 = Field(description="The UUID of the alert to which this email belongs")
 
 
 class EmailSummary(EmailAnalysisDetailsBase):

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,10 +8,11 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
-from api.models.event_summaries import EmailSummary, ObservableSummary, URLDomainSummary, UserSummary
+from api.models.event_summaries import EmailHeadersBody, EmailSummary, ObservableSummary, URLDomainSummary, UserSummary
 from api.models.history import EventHistoryRead
 from api.routes import helpers
 from api.routes.event_summaries import (
+    get_email_headers_body_summary,
     get_email_summary,
     get_observable_summary,
     get_url_domain_summary,
@@ -661,6 +662,9 @@ helpers.api_route_update(router, update_events, path="/")
 # SUMMARIES
 #
 
+helpers.api_route_read(
+    router, get_email_headers_body_summary, Optional[EmailHeadersBody], path="/{uuid}/summary/email_headers_body"
+)
 helpers.api_route_read(router, get_email_summary, List[EmailSummary], path="/{uuid}/summary/email")
 helpers.api_route_read(router, get_observable_summary, List[ObservableSummary], path="/{uuid}/summary/observable")
 helpers.api_route_read(router, get_user_summary, List[UserSummary], path="/{uuid}/summary/user")

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,6 +1,13 @@
 import { UUID } from "./base";
 import { observableRead } from "./observable";
 
+export interface EmailHeadersBody {
+  alertUuid: UUID;
+  bodyHtml: string | null;
+  bodyText: string | null;
+  headers: string;
+}
+
 export interface emailSummary {
   alertUuid: UUID;
   attachments: string[];


### PR DESCRIPTION
This PR adds the `/api/event/{uuid}/email_headers_body` API endpoint. If there are no emails in the event when this endpoint is called, the return JSON will be null. If there are emails, it returns the headers, HTML body, plaintext body, and alert UUID of the earliest email's received time.