### PR TITLE
Event details - Email Analysis - Headers & Body

### DIFF
--- a/backend/app/tests/alerts/smallWithHeadersBody.json
+++ b/backend/app/tests/alerts/smallWithHeadersBody.json
@@ -1,5 +1,5 @@
 {
-  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6a",
+  "alert_uuid": "6d3e764a-f565-430d-9208-308d3a69e219",
   "disposition_user": "alice",
   "name": "Small Alert",
   "owner": "bob",

--- a/backend/app/tests/alerts/smallWithHeadersBody.json
+++ b/backend/app/tests/alerts/smallWithHeadersBody.json
@@ -1,0 +1,209 @@
+{
+  "alert_uuid": "02f8299b-2a24-400f-9751-7dd9164daf6a",
+  "disposition_user": "alice",
+  "name": "Small Alert",
+  "owner": "bob",
+  "observables": [
+    {
+      "type": "file",
+      "value": "email.rfc822",
+      "analyses": [
+        {
+          "type": "Email Analysis",
+          "details": {
+            "from_address": "badguy@evil.com",
+            "to_address": "goodguy@company.com",
+            "cc_addresses": ["otherguy@company.com"],
+            "subject": "Hello",
+            "message_id": "<123abc@evil.com>",
+            "time": "2022-03-18T12:00:00.000Z",
+            "attachments": [],
+            "headers": "Return-Path: <badguy@evil.com> X-SpamCatcher-Score: 1 [X] Received: from [1.2.3.4] (HELO evil.com) by example.evil.com (CommuniGate Pro SMTP 4.1.8) with ESMTP-TLS id 12345678 for goodguy@company.com; Mon, 23 Aug 2021 11:40:10 -0400 Message-ID: <123abc@evil.com> Date: Mon, 23 Aug 2021 11:40:36 -0400 From: Bad Guy <badguy@evil.com> User-Agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.0.1) Gecko/20020823 Netscape/7.0 X-Accept-Language: en-us, en MIME-Version: 1.0 To: Good Guy <goodguy@company.com> Subject: Hello Content-Type: text/plain; charset=us-ascii; format=flowed Content-Transfer-Encoding: 7bit",
+            "body_text": "Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus",
+            "body_html": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo. Quisque sit amet est et sapien ullamcorper pharetra. Vestibulum erat wisi, condimentum sed, commodo vitae, ornare sit amet, wisi. Aenean fermentum, elit eget tincidunt condimentum, eros ipsum rutrum orci, sagittis tempus lacus enim ac dui. Donec non enim in turpis pulvinar facilisis. Ut felis. Praesent dapibus, neque id cursus faucibus, tortor neque egestas augue, eu vulputate magna eros eu erat. Aliquam erat volutpat. Nam dui mi, tincidunt quis, accumsan porttitor, facilisis luctus, metus</p>"
+          },
+          "observable_types": ["file"],
+          "required_directives": ["email"],
+          "required_tags": ["scan_me"],
+          "observables": [
+            {
+              "type": "email_address",
+              "value": "badguy@evil.com",
+              "node_metadata": {
+                "display": {
+                  "type": "sender"
+                }
+              },
+              "tags": ["from_address"],
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "link": "https://url.to.search/query=asdf",
+                    "hits": 5
+                  }
+                },
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [
+                    {
+                      "type": "fqdn",
+                      "value": "evil.com",
+                      "for_detection": true,
+                      "analyses": [
+                        {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "link": "https://url.to.search/query=asdf",
+                            "hits": 10
+                          }
+                        },
+                        {
+                          "type": "Test Analysis",
+                          "observables": [
+                            { "type": "test_type", "value": "test_value" }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "email_address",
+              "value": "goodguy@company.com",
+              "tags": ["recipient"],
+              "analyses": [
+                {
+                  "type": "Email Address Analysis",
+                  "observables": [{ "type": "fqdn", "value": "company.com" }]
+                }
+              ]
+            },
+            {
+              "type": "email_subject",
+              "value": "Hello",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "link": "https://url.to.search/query=asdf",
+                    "hits": 100
+                  }
+                }
+              ]
+            },
+            {
+              "type": "file",
+              "value": "email.rfc822.unknown_plain_text_000",
+              "node_metadata": {
+                "display": {
+                  "value": "email plaintext body"
+                }
+              },
+              "analyses": [
+                {
+                  "type": "URL Extraction Analysis",
+                  "observables": [
+                    {
+                      "type": "url",
+                      "value": "http://evil.com/malware.exe",
+                      "analyses": [
+                        {
+                          "type": "FA Queue Analysis",
+                          "details": {
+                            "link": "https://url.to.search/query=asdf",
+                            "hits": 5
+                          }
+                        },
+                        {
+                          "type": "URL Parse Analysis",
+                          "observables": [
+                            {
+                              "type": "fqdn",
+                              "value": "evil.com",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "link": "https://url.to.search/query=asdf",
+                                    "hits": 10
+                                  }
+                                },
+                                {
+                                  "type": "Test Analysis",
+                                  "observables": [
+                                    {
+                                      "type": "test_type",
+                                      "value": "test_value"
+                                    }
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "type": "uri_path",
+                              "value": "/malware.exe",
+                              "analyses": [
+                                {
+                                  "type": "FA Queue Analysis",
+                                  "details": {
+                                    "link": "https://url.to.search/query=asdf",
+                                    "hits": 20
+                                  }
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "File Analysis",
+          "observables": [
+            {
+              "type": "md5",
+              "value": "912ec803b2ce49e4a541068d495ab570",
+              "analyses": [
+                {
+                  "type": "FA Queue Analysis",
+                  "details": {
+                    "link": "https://url.to.search/query=asdf",
+                    "hits": 0
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ipv4",
+      "value": "127.0.0.1",
+      "tags": ["c2", "contacted_host"],
+      "node_metadata": {
+        "display": {
+          "type": "private ip address",
+          "value": "localhost"
+        }
+      },
+      "analyses": [
+        {
+          "type": "FA Queue Analysis",
+          "details": {
+            "link": "https://url.to.search/query=asdf",
+            "hits": 1000
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/frontend/src/components/Analysis/EmailAnalysis.vue
+++ b/frontend/src/components/Analysis/EmailAnalysis.vue
@@ -1,92 +1,20 @@
 <!-- EmailAnalysis.vue -->
 
 <template>
-  <DataTable
-    :value="emails"
-    responsive-layout="scroll"
-    data-cy="email-analysis-table"
-  >
-    <Column field="alertUuid" header="URL"
-      ><template #body="slotProps">
-        <span class="flex align-items-center justify-content-center"
-          ><router-link :to="`/alert/${slotProps.data.alertUuid}`" exact
-            >Alert</router-link
-          >
-        </span>
-      </template></Column
-    >
-    <Column field="time" header="Time" :sortable="true"
-      ><template #body="slotProps">
-        <span class="flex align-items-center justify-content-center">
-          {{ formatDateTime(slotProps.data.time) }}
-        </span>
-      </template></Column
-    >
-    <Column field="fromAddress" header="From" :sortable="true"></Column>
-    <Column field="toAddress" header="To" :sortable="true"></Column>
-    <Column field="subject" header="Subject"> :sortable="true"</Column>
-    <Column field="attachments" header="Attachments" :sortable="true"
-      ><template #body="slotProps">
-        <span class="flex align-items-center justify-content-center">
-          {{ formatList(slotProps.data.attachments) }}
-        </span>
-      </template></Column
-    >
-    <Column field="ccAddresses" header="CC" :sortable="true"
-      ><template #body="slotProps">
-        <span class="flex align-items-center justify-content-center">
-          {{ formatList(slotProps.data.ccAddresses) }}
-        </span>
-      </template></Column
-    >
-    <Column field="replyToAddress" header="Reply-To" :sortable="true"
-      ><template #body="slotProps">
-        <span
-          v-if="slotProps.data.replyToAddress"
-          class="flex align-items-center justify-content-center"
-        >
-          {{ slotProps.data.replyToAddress }}
-        </span>
-        <span>None</span>
-      </template></Column
-    >
-    <Column field="messageId" header="Message-ID" :sortable="true"></Column>
-  </DataTable>
+  <EmailAnalysisSummaryTable
+    :event-uuid="eventUuid"
+  ></EmailAnalysisSummaryTable>
+  <br />
+  <EmailAnalysisHeadersBody :event-uuid="eventUuid"></EmailAnalysisHeadersBody>
 </template>
 
 <script setup>
-  import DataTable from "primevue/datatable";
-  import Column from "primevue/column";
+  import EmailAnalysisSummaryTable from "@/components/Analysis/EmailAnalysisSummaryTable.vue";
+  import EmailAnalysisHeadersBody from "@/components/Analysis/EmailAnalysisHeadersBody.vue";
 
-  import { onMounted, ref, defineProps } from "vue";
-  import { Event } from "@/services/api/event";
+  import { defineProps } from "vue";
 
-  const props = defineProps({
+  defineProps({
     eventUuid: { type: String, required: true },
   });
-  const isLoading = ref(false);
-  const emails = ref([]);
-
-  onMounted(async () => {
-    isLoading.value = true;
-    emails.value = await Event.readEmailSummary(props.eventUuid);
-    isLoading.value = false;
-  });
-
-  const formatDateTime = (dateTime) => {
-    if (dateTime) {
-      const d = new Date(dateTime);
-      return d.toLocaleString("en-US", { timeZone: "UTC" });
-    }
-
-    return "None";
-  };
-
-  const formatList = (list) => {
-    if (list.length) {
-      return list.join(", ");
-    }
-
-    return "None";
-  };
 </script>

--- a/frontend/src/components/Analysis/EmailAnalysisHeadersBody.vue
+++ b/frontend/src/components/Analysis/EmailAnalysisHeadersBody.vue
@@ -1,0 +1,71 @@
+<!-- EmailAnalysis.vue -->
+
+<template>
+  <h5>Email Details</h5>
+  <div v-if="isLoading">Loading...</div>
+  <div v-else-if="emailHeadersBody">
+    <Panel header="Headers" :toggleable="true">
+      <div style="width: 100%">
+        <pre>{{ emailHeadersBody.headers }}</pre>
+      </div>
+    </Panel>
+    <br />
+    <Panel header="Body" :toggleable="true">
+      <div class="flex">
+        <div v-if="emailHeadersBody.bodyText" class="panel-content">
+          <h5>Body Text</h5>
+          <pre>{{ emailHeadersBody.bodyText }}</pre>
+        </div>
+        <Divider layout="vertical" />
+        <div v-if="emailHeadersBody.bodyHtml" class="panel-content">
+          <h5>Body HTML</h5>
+          <pre class="pre-panel">{{ emailHeadersBody.bodyHtml }}</pre>
+        </div>
+      </div>
+    </Panel>
+  </div>
+  <div v-else>
+    <div>Couldn't load email details: {{ error }}</div>
+  </div>
+</template>
+
+<script setup>
+  import { onMounted, ref, defineProps } from "vue";
+
+  import Panel from "primevue/panel";
+  import Divider from "primevue/divider";
+
+  import { Event } from "@/services/api/event";
+
+  const props = defineProps({
+    eventUuid: { type: String, required: true },
+  });
+  const isLoading = ref(false);
+  const error = ref(null);
+  const emailHeadersBody = ref(null);
+
+  onMounted(async () => {
+    isLoading.value = true;
+    try {
+      emailHeadersBody.value = await Event.readEmailHeadersAndBody(
+        props.eventUuid,
+      );
+    } catch (error) {
+      error.value = error.message;
+    }
+    isLoading.value = false;
+  });
+</script>
+
+<style scoped>
+  .panel-content {
+    width: 100%;
+    max-height: 800px;
+  }
+
+  pre {
+    white-space: pre-wrap;
+    overflow-y: auto;
+    max-height: 600px;
+  }
+</style>

--- a/frontend/src/components/Analysis/EmailAnalysisHeadersBody.vue
+++ b/frontend/src/components/Analysis/EmailAnalysisHeadersBody.vue
@@ -1,23 +1,38 @@
 <!-- EmailAnalysis.vue -->
 
 <template>
-  <h5>Email Details</h5>
   <div v-if="isLoading">Loading...</div>
   <div v-else-if="emailHeadersBody">
-    <Panel header="Headers" :toggleable="true">
+    <span>
+      <h5>
+        Email Details
+        <router-link :to="`/alert/${emailHeadersBody.alertUuid}`" exact
+          >(Alert)</router-link
+        >
+      </h5>
+    </span>
+    <Panel id="email-headers-panel" header="Headers" :toggleable="true">
       <div style="width: 100%">
         <pre>{{ emailHeadersBody.headers }}</pre>
       </div>
     </Panel>
     <br />
-    <Panel header="Body" :toggleable="true">
+    <Panel id="email-body-panel" header="Body" :toggleable="true">
       <div class="flex">
-        <div v-if="emailHeadersBody.bodyText" class="panel-content">
+        <div
+          v-if="emailHeadersBody.bodyText"
+          id="body-text"
+          class="panel-content"
+        >
           <h5>Body Text</h5>
           <pre>{{ emailHeadersBody.bodyText }}</pre>
         </div>
         <Divider layout="vertical" />
-        <div v-if="emailHeadersBody.bodyHtml" class="panel-content">
+        <div
+          v-if="emailHeadersBody.bodyHtml"
+          id="body-html"
+          class="panel-content"
+        >
           <h5>Body HTML</h5>
           <pre class="pre-panel">{{ emailHeadersBody.bodyHtml }}</pre>
         </div>

--- a/frontend/src/components/Analysis/EmailAnalysisSummaryTable.vue
+++ b/frontend/src/components/Analysis/EmailAnalysisSummaryTable.vue
@@ -1,0 +1,93 @@
+<!-- EmailAnalysisSummaryTable.vue -->
+
+<template>
+  <h5>Email Summary</h5>
+  <DataTable
+    :value="emails"
+    responsive-layout="scroll"
+    data-cy="email-analysis-table"
+  >
+    <Column field="alertUuid" header="URL"
+      ><template #body="slotProps">
+        <span class="flex align-items-center justify-content-center"
+          ><router-link :to="`/alert/${slotProps.data.alertUuid}`" exact
+            >Alert</router-link
+          >
+        </span>
+      </template></Column
+    >
+    <Column field="time" header="Time" :sortable="true"
+      ><template #body="slotProps">
+        <span class="flex align-items-center justify-content-center">
+          {{ formatDateTime(slotProps.data.time) }}
+        </span>
+      </template></Column
+    >
+    <Column field="fromAddress" header="From" :sortable="true"></Column>
+    <Column field="toAddress" header="To" :sortable="true"></Column>
+    <Column field="subject" header="Subject"> :sortable="true"</Column>
+    <Column field="attachments" header="Attachments" :sortable="true"
+      ><template #body="slotProps">
+        <span class="flex align-items-center justify-content-center">
+          {{ formatList(slotProps.data.attachments) }}
+        </span>
+      </template></Column
+    >
+    <Column field="ccAddresses" header="CC" :sortable="true"
+      ><template #body="slotProps">
+        <span class="flex align-items-center justify-content-center">
+          {{ formatList(slotProps.data.ccAddresses) }}
+        </span>
+      </template></Column
+    >
+    <Column field="replyToAddress" header="Reply-To" :sortable="true"
+      ><template #body="slotProps">
+        <span
+          v-if="slotProps.data.replyToAddress"
+          class="flex align-items-center justify-content-center"
+        >
+          {{ slotProps.data.replyToAddress }}
+        </span>
+        <span>None</span>
+      </template></Column
+    >
+    <Column field="messageId" header="Message-ID" :sortable="true"></Column>
+  </DataTable>
+</template>
+
+<script setup>
+  import DataTable from "primevue/datatable";
+  import Column from "primevue/column";
+
+  import { onMounted, ref, defineProps } from "vue";
+  import { Event } from "@/services/api/event";
+
+  const props = defineProps({
+    eventUuid: { type: String, required: true },
+  });
+  const isLoading = ref(false);
+  const emails = ref([]);
+
+  onMounted(async () => {
+    isLoading.value = true;
+    emails.value = await Event.readEmailSummary(props.eventUuid);
+    isLoading.value = false;
+  });
+
+  const formatDateTime = (dateTime) => {
+    if (dateTime) {
+      const d = new Date(dateTime);
+      return d.toLocaleString("en-US", { timeZone: "UTC" });
+    }
+
+    return "None";
+  };
+
+  const formatList = (list) => {
+    if (list.length) {
+      return list.join(", ");
+    }
+
+    return "None";
+  };
+</script>

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,7 +1,7 @@
 import { UUID } from "./base";
 import { observableRead } from "./observable";
 
-export interface EmailHeadersBody {
+export interface emailHeadersBody {
   alertUuid: UUID;
   bodyHtml: string | null;
   bodyText: string | null;

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -8,6 +8,7 @@ import {
 } from "@/models/event";
 import {
   emailSummary,
+  emailHeadersBody,
   observableSummary,
   userSummary,
   urlDomainSummary,
@@ -47,6 +48,9 @@ export const Event = {
 
   readEmailSummary: async (uuid: UUID): Promise<emailSummary[]> =>
     await api.read(`${endpoint}${uuid}/summary/email`),
+
+  readEmailHeadersAndBody: async (uuid: UUID): Promise<emailHeadersBody[]> =>
+    await api.read(`${endpoint}${uuid}/summary/email_headers_body`),
 
   readPage: (params?: eventFilterParams): Promise<eventReadPage> => {
     let formattedParams = {} as eventFilterParams;

--- a/frontend/tests/e2e/specs/ViewEvent.spec.js
+++ b/frontend/tests/e2e/specs/ViewEvent.spec.js
@@ -1358,7 +1358,7 @@ describe("Email Analysis Details", () => {
 
     // Check link to alert
     cy.get(".p-datatable-tbody > tr > :nth-child(1) > span").click();
-    cy.url().should("include", "/alert/02f8299b-2a24-400f-9751-7dd9164daf6a");
+    cy.url().should("include", "/alert/6d3e764a-f565-430d-9208-308d3a69e219");
   });
   it("renders Email Details section correctly", () => {
     // Check title
@@ -1396,6 +1396,6 @@ describe("Email Analysis Details", () => {
 
     // Check link to alert
     cy.get("h5 > a").click();
-    cy.url().should("include", "/alert/02f8299b-2a24-400f-9751-7dd9164daf6a");
+    cy.url().should("include", "/alert/6d3e764a-f565-430d-9208-308d3a69e219");
   });
 });

--- a/frontend/tests/unit/src/services/api/event.spec.ts
+++ b/frontend/tests/unit/src/services/api/event.spec.ts
@@ -64,6 +64,14 @@ describe("Event calls", () => {
     expect(res).toEqual("Read successful");
   });
 
+  it("will make a get request to the /event/{uuid}/summary/email_headers_body endpoint when 'readEmailHeadersAndBody' is called with a given UUID", async () => {
+    myNock
+      .get("/event/uuid/summary/email_headers_body")
+      .reply(200, "Read successful");
+    const res = await api.readEmailHeadersAndBody("uuid");
+    expect(res).toEqual("Read successful");
+  });
+
   it("will make a get request to the /event/ endpoint when 'readPage' is called with no params, if none given", async () => {
     myNock.get("/event/").reply(200, "Read successful");
     const res = await api.readPage();


### PR DESCRIPTION
This PR expands the existing "Email Analysis" section on the event details page to fetch the email headers & body data from the backend, and display the returne dheader and body data accordingly. 

Tried something new with the display of body text vs HTML, we'll have to get feedback on what people think.

Also, added a new test alert JSON for this so I could do testing with email analysis that included HTML, as well as longer bodies/headers w/o affecting backend tests using small.json.

Body Text only:
![image](https://user-images.githubusercontent.com/31867815/159338824-60eec1a3-7bf4-464f-8d75-c0a3a0dea885.png)

Body Text and HTML:
![image](https://user-images.githubusercontent.com/31867815/159339393-2715f46a-9423-4016-ad45-350f398a70aa.png)
