### PR TITLE
Node detection points

### DIFF
--- a/backend/app/api/models/analysis.py
+++ b/backend/app/api/models/analysis.py
@@ -1,10 +1,11 @@
 from pydantic import Field, Json, UUID4
-from typing import Optional
+from typing import List, Optional
 from uuid import uuid4
 
 from api.models import type_str
 from api.models.analysis_module_type import AnalysisModuleTypeNodeTreeRead, AnalysisModuleTypeRead
 from api.models.node import NodeBase, NodeCreate, NodeRead, NodeTreeCreateWithNode, NodeTreeItemRead, NodeUpdate
+from api.models.node_detection_point import NodeDetectionPointRead
 
 
 class AnalysisBase(NodeBase):
@@ -49,6 +50,10 @@ class AnalysisRead(NodeRead, AnalysisBase):
     )
 
     details: Optional[dict] = Field(description="A JSON representation of the details produced by the analysis")
+
+    detection_points: List[NodeDetectionPointRead] = Field(
+        description="A list of detection points added to the analysis"
+    )
 
     uuid: UUID4 = Field(description="The UUID of the analysis")
 

--- a/backend/app/api/models/node_detection_point.py
+++ b/backend/app/api/models/node_detection_point.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+from pydantic import BaseModel, Field, UUID4
+from uuid import uuid4
+
+from api.models import type_str
+
+
+class NodeDetectionPointBase(BaseModel):
+    """Represents a detection point that can be added to a node."""
+
+    node_uuid: UUID4 = Field(description="The UUID of the node associated with this detection point")
+
+    value: type_str = Field(description="The value of the detection point")
+
+
+class NodeDetectionPointCreate(NodeDetectionPointBase):
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the detection point")
+
+
+class NodeDetectionPointRead(NodeDetectionPointBase):
+    insert_time: datetime = Field(description="The time the detection point was made")
+
+    uuid: UUID4 = Field(description="The UUID of the detection point")
+
+    class Config:
+        orm_mode = True
+
+
+class NodeDetectionPointUpdate(BaseModel):
+    # The only thing that makes sense to be able to update is the actual value of the detection point.
+    # Otherwise, you would delete the detection point and create a new one.
+    value: type_str = Field(description="The value of the detection point")

--- a/backend/app/api/models/observable.py
+++ b/backend/app/api/models/observable.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 from api.models import type_str, validators
 from api.models.node import NodeBase, NodeCreate, NodeRead, NodeTreeCreateWithNode, NodeTreeItemRead, NodeUpdate
 from api.models.node_comment import NodeCommentRead
+from api.models.node_detection_point import NodeDetectionPointRead
 from api.models.node_directive import NodeDirectiveRead
 from api.models.node_tag import NodeTagRead
 from api.models.node_threat import NodeThreatRead
@@ -68,6 +69,10 @@ class ObservableCreate(ObservableCreateBase):
 
 class ObservableRead(NodeRead, ObservableBase):
     comments: List[NodeCommentRead] = Field(description="A list of comments added to the observable")
+
+    detection_points: List[NodeDetectionPointRead] = Field(
+        description="A list of detection points added to the observable"
+    )
 
     directives: List[NodeDirectiveRead] = Field(description="A list of directives added to the observable")
 

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -18,6 +18,7 @@ from api.routes.event_type import router as event_type_router
 from api.routes.event_vector import router as event_vector_router
 from api.routes.node import router as node_router
 from api.routes.node_comment import router as node_comment_router
+from api.routes.node_detection_point import router as node_detection_point_router
 from api.routes.node_directive import router as node_directive_router
 from api.routes.node_tag import router as node_tag_router
 from api.routes.node_threat import router as node_threat_router
@@ -53,6 +54,7 @@ router.include_router(event_type_router)
 router.include_router(event_vector_router)
 router.include_router(node_router)
 router.include_router(node_comment_router)
+router.include_router(node_detection_point_router)
 router.include_router(node_directive_router)
 router.include_router(node_tag_router)
 router.include_router(node_threat_router)

--- a/backend/app/api/routes/node.py
+++ b/backend/app/api/routes/node.py
@@ -100,7 +100,7 @@ def update_node(
         db_node.threats = crud.read_by_values(values=update_data["threats"], db_table=NodeThreat, db=db)
 
     # Update the node version
-    db_node.version = uuid4()
+    crud.update_node_version(node=db_node, db=db)
 
     return db_node, diffs
 

--- a/backend/app/api/routes/node_comment.py
+++ b/backend/app/api/routes/node_comment.py
@@ -39,7 +39,7 @@ def create_node_comments(
         db_node: Node = crud.read(uuid=node_comment.node_uuid, db_table=Node, db=db)
 
         # This counts a modifying the node, so it should receive a new version.
-        db_node.version = uuid4()
+        crud.update_node_version(node=db_node, db=db)
 
         # Set the user on the comment
         new_comment.user = crud.read_user_by_username(username=claims["sub"], db=db)
@@ -99,10 +99,10 @@ def update_node_comment(
     diff = crud.Diff(field="comments", added_to_list=[node_comment.value], removed_from_list=[db_node_comment.value])
     db_node_comment.value = node_comment.value
 
-    # Modifying the comment counts as modifying the node, so it should receive a new version
-    db_node.version = uuid4()
-
     crud.commit(db)
+
+    # Modifying the comment counts as modifying the node, so it should receive a new version
+    crud.update_node_version(node=db_node, db=db)
 
     # Add an entry to the correct history table based on the node_type.
     crud.record_node_update_history(
@@ -122,12 +122,15 @@ helpers.api_route_update(router, update_node_comment)
 
 def delete_node_comment(uuid: UUID, db: Session = Depends(get_db), claims: dict = Depends(validate_access_token)):
     # Read the current node comment from the database to get its value
-    db_node_comment: NodeComment = crud.read(uuid=uuid, db_table=NodeComment, db=db)
+    db_node: NodeComment = crud.read(uuid=uuid, db_table=NodeComment, db=db)
+
+    # Update any root node versions
+    crud.update_node_version(node=db_node, db=db)
 
     # Add an entry to the correct history table based on the node_type.
-    diff = crud.Diff(field="comments", removed_from_list=[db_node_comment.value])
+    diff = crud.Diff(field="comments", removed_from_list=[db_node.value])
     crud.record_node_update_history(
-        record_node=db_node_comment.node,
+        record_node=db_node.node,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
         diff=diff,
         db=db,

--- a/backend/app/api/routes/node_comment.py
+++ b/backend/app/api/routes/node_comment.py
@@ -52,7 +52,7 @@ def create_node_comments(
         # Even though this is creating a comment, we treat it as though it is
         # modifying the node for history tracking purposes.
         diff = crud.Diff(field="comments", added_to_list=[node_comment.value])
-        crud.record_comment_history(record_node=db_node, action_by=new_comment.user, diff=diff, db=db)
+        crud.record_node_update_history(record_node=db_node, action_by=new_comment.user, diff=diff, db=db)
 
         response.headers["Content-Location"] = request.url_for("get_node_comment", uuid=new_comment.uuid)
 
@@ -105,7 +105,7 @@ def update_node_comment(
     crud.commit(db)
 
     # Add an entry to the correct history table based on the node_type.
-    crud.record_comment_history(
+    crud.record_node_update_history(
         record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
     )
 
@@ -126,7 +126,7 @@ def delete_node_comment(uuid: UUID, db: Session = Depends(get_db), claims: dict 
 
     # Add an entry to the correct history table based on the node_type.
     diff = crud.Diff(field="comments", removed_from_list=[db_node_comment.value])
-    crud.record_comment_history(
+    crud.record_node_update_history(
         record_node=db_node_comment.node,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
         diff=diff,

--- a/backend/app/api/routes/node_detection_point.py
+++ b/backend/app/api/routes/node_detection_point.py
@@ -1,0 +1,146 @@
+from datetime import datetime
+from fastapi import APIRouter, Depends, Request, Response
+from sqlalchemy.orm import Session
+from typing import List
+from uuid import UUID, uuid4
+
+from api.models.node_detection_point import NodeDetectionPointCreate, NodeDetectionPointRead, NodeDetectionPointUpdate
+from api.routes import helpers
+from core.auth import validate_access_token
+from db import crud
+from db.database import get_db
+from db.schemas.node import Node
+from db.schemas.node_detection_point import NodeDetectionPoint
+
+
+router = APIRouter(
+    prefix="/node/detection_point",
+    tags=["Node Detection Point"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_node_detection_points(
+    node_detection_points: List[NodeDetectionPointCreate],
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(validate_access_token),
+):
+    for node_detection_point in node_detection_points:
+        # Create the new node detection point
+        new_detection_point = NodeDetectionPoint(**node_detection_point.dict())
+
+        # Make sure the node actually exists
+        db_node: Node = crud.read(uuid=node_detection_point.node_uuid, db_table=Node, db=db)
+
+        # This counts a modifying the node, so it should receive a new version.
+        db_node.version = uuid4()
+
+        # Save the new detection point to the database
+        db.add(new_detection_point)
+        crud.commit(db)
+
+        # Add an entry to the correct history table based on the node_type.
+        # Even though this is creating a detection point, we treat it as though it is
+        # modifying the node for history tracking purposes.
+        diff = crud.Diff(field="detection_points", added_to_list=[node_detection_point.value])
+        crud.record_node_update_history(
+            record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
+        )
+
+        response.headers["Content-Location"] = request.url_for(
+            "get_node_detection_point", uuid=new_detection_point.uuid
+        )
+
+
+helpers.api_route_create(router, create_node_detection_points)
+
+
+#
+# READ
+#
+
+
+def get_node_detection_point(uuid: UUID, db: Session = Depends(get_db)):
+    return crud.read(uuid=uuid, db_table=NodeDetectionPoint, db=db)
+
+
+helpers.api_route_read(router, get_node_detection_point, NodeDetectionPointRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_node_detection_point(
+    uuid: UUID,
+    node_detection_point: NodeDetectionPointUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(validate_access_token),
+):
+    # Read the current node detection point from the database
+    db_node_detection_point: NodeDetectionPoint = crud.read(uuid=uuid, db_table=NodeDetectionPoint, db=db)
+
+    # Read the node from the database
+    db_node: Node = crud.read(uuid=db_node_detection_point.node_uuid, db_table=Node, db=db)
+
+    # Update the user and timestamp detection point
+    db_node_detection_point.insert_time = datetime.utcnow()
+
+    # Set the new detection point value
+    diff = crud.Diff(
+        field="detection_points",
+        added_to_list=[node_detection_point.value],
+        removed_from_list=[db_node_detection_point.value],
+    )
+    db_node_detection_point.value = node_detection_point.value
+
+    # Modifying the detection point counts as modifying the node, so it should receive a new version
+    db_node.version = uuid4()
+
+    crud.commit(db)
+
+    # Add an entry to the correct history table based on the node_type.
+    crud.record_node_update_history(
+        record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
+    )
+
+    response.headers["Content-Location"] = request.url_for("get_node_detection_point", uuid=uuid)
+
+
+helpers.api_route_update(router, update_node_detection_point)
+
+
+#
+# DELETE
+#
+
+
+def delete_node_detection_point(
+    uuid: UUID, db: Session = Depends(get_db), claims: dict = Depends(validate_access_token)
+):
+    # Read the current node detection point from the database to get its value
+    db_node_detection_point: NodeDetectionPoint = crud.read(uuid=uuid, db_table=NodeDetectionPoint, db=db)
+
+    # Add an entry to the correct history table based on the node_type.
+    diff = crud.Diff(field="detection_points", removed_from_list=[db_node_detection_point.value])
+    crud.record_node_update_history(
+        record_node=db_node_detection_point.node,
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
+        diff=diff,
+        db=db,
+    )
+
+    # Delete the detection point
+    crud.delete(uuid=uuid, db_table=NodeDetectionPoint, db=db)
+
+
+helpers.api_route_delete(router, delete_node_detection_point)

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -527,6 +527,24 @@ def update(uuid: UUID, obj: BaseModel, db_table: DeclarativeMeta, db: Session):
         )
 
 
+def update_node_version(node: Node, db: Session):
+    """Updates the given Node's version as well as the root Node's version if it is part of a tree."""
+
+    # Update the given Node's version
+    node.version = uuid4()
+
+    # Find any root Nodes for the given Node
+    root_node_uuids = select(NodeTree.root_node_uuid).where(NodeTree.node_uuid == node.uuid)
+    root_nodes = db.execute(select(Node).where(Node.uuid.in_(root_node_uuids))).scalars().unique().fetchall()
+
+    # Update each root Node's version
+    for root_node in root_nodes:
+        root_node.version = uuid4()
+
+    # Save the changes
+    commit(db)
+
+
 #
 # DELETE
 #

--- a/backend/app/db/crud/__init__.py
+++ b/backend/app/db/crud/__init__.py
@@ -100,7 +100,7 @@ def record_create_history(
     commit(db)
 
 
-def record_comment_history(record_node: Node, action_by: User, diff: Diff, db: Session):
+def record_node_update_history(record_node: Node, action_by: User, diff: Diff, db: Session):
     if record_node.node_type == "alert":
         record_update_histories(
             history_table=AlertHistory,

--- a/backend/app/db/schemas/__init__.py
+++ b/backend/app/db/schemas/__init__.py
@@ -28,6 +28,7 @@ from db.schemas.event_vector_queue_mapping import event_vector_queue_mapping
 from db.schemas.event_vector_mapping import event_vector_mapping
 from db.schemas.node import Node
 from db.schemas.node_comment import NodeComment
+from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_directive_mapping import node_directive_mapping
 from db.schemas.node_tag import NodeTag

--- a/backend/app/db/schemas/node.py
+++ b/backend/app/db/schemas/node.py
@@ -68,6 +68,8 @@ class Node(Base):
 
     comments = relationship("NodeComment", lazy="selectin")
 
+    detection_points = relationship("NodeDetectionPoint", lazy="selectin")
+
     directives = relationship("NodeDirective", secondary=node_directive_mapping, lazy="selectin")
 
     node_type = Column(String)

--- a/backend/app/db/schemas/node_detection_point.py
+++ b/backend/app/db/schemas/node_detection_point.py
@@ -1,0 +1,30 @@
+from sqlalchemy import func, Column, DateTime, ForeignKey, Index, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from db.database import Base
+from db.schemas.helpers import utcnow
+
+
+class NodeDetectionPoint(Base):
+    __tablename__ = "node_detection_point"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    insert_time = Column(DateTime, server_default=utcnow())
+
+    node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), index=True)
+
+    node = relationship("Node", foreign_keys=[node_uuid], lazy="selectin")
+
+    value = Column(String, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "value_trgm",
+            value,
+            postgresql_ops={"value": "gin_trgm_ops"},
+            postgresql_using="gin",
+        ),
+        UniqueConstraint("node_uuid", "value", name="node_detection_point_value_uc"),
+    )

--- a/backend/app/tests/api/node_detection_point/test_create.py
+++ b/backend/app/tests/api/node_detection_point/test_create.py
@@ -124,37 +124,48 @@ def test_create_verify_history_observables(client_valid_access_token, db):
 
 def test_create_multiple(client_valid_access_token, db):
     alert_tree1 = helpers.create_alert(db=db)
+    obs_tree1 = helpers.create_observable(type="test_type", value="test_value1", parent_tree=alert_tree1, db=db)
     initial_alert1_version = alert_tree1.node.version
+    initial_obs1_version = obs_tree1.node.version
 
     alert_tree2 = helpers.create_alert(db=db)
+    obs_tree2 = helpers.create_observable(type="test_type", value="test_value2", parent_tree=alert_tree2, db=db)
     initial_alert2_version = alert_tree2.node.version
+    initial_obs2_version = obs_tree2.node.version
 
     alert_tree3 = helpers.create_alert(db=db)
+    obs_tree3 = helpers.create_observable(type="test_type", value="test_value3", parent_tree=alert_tree3, db=db)
     initial_alert3_version = alert_tree3.node.version
+    initial_obs3_version = obs_tree3.node.version
 
-    assert alert_tree1.node.detection_points == []
-    assert alert_tree2.node.detection_points == []
-    assert alert_tree3.node.detection_points == []
+    assert obs_tree1.node.detection_points == []
+    assert obs_tree2.node.detection_points == []
+    assert obs_tree3.node.detection_points == []
 
-    # Add a detection point to each node at once
+    # Add a detection point to each observable at once
     create_json = [
-        {"node_uuid": str(alert_tree1.node_uuid), "value": "test1"},
-        {"node_uuid": str(alert_tree2.node_uuid), "value": "test2"},
-        {"node_uuid": str(alert_tree3.node_uuid), "value": "test3"},
+        {"node_uuid": str(obs_tree1.node_uuid), "value": "test1"},
+        {"node_uuid": str(obs_tree2.node_uuid), "value": "test2"},
+        {"node_uuid": str(obs_tree3.node_uuid), "value": "test3"},
     ]
     create = client_valid_access_token.post("/api/node/detection_point/", json=create_json)
     assert create.status_code == status.HTTP_201_CREATED
 
-    assert len(alert_tree1.node.detection_points) == 1
-    assert alert_tree1.node.detection_points[0].value == "test1"
+    # The observables should each have a detection point and a new version.
+    # The alerts (the root nodes) should also have a new version.
+    assert len(obs_tree1.node.detection_points) == 1
+    assert obs_tree1.node.detection_points[0].value == "test1"
+    assert obs_tree1.node.version != initial_obs1_version
     assert alert_tree1.node.version != initial_alert1_version
 
-    assert len(alert_tree2.node.detection_points) == 1
-    assert alert_tree2.node.detection_points[0].value == "test2"
+    assert len(obs_tree2.node.detection_points) == 1
+    assert obs_tree2.node.detection_points[0].value == "test2"
+    assert obs_tree2.node.version != initial_obs2_version
     assert alert_tree2.node.version != initial_alert2_version
 
-    assert len(alert_tree3.node.detection_points) == 1
-    assert alert_tree3.node.detection_points[0].value == "test3"
+    assert len(obs_tree3.node.detection_points) == 1
+    assert obs_tree3.node.detection_points[0].value == "test3"
+    assert obs_tree3.node.version != initial_obs3_version
     assert alert_tree3.node.version != initial_alert3_version
 
 

--- a/backend/app/tests/api/node_detection_point/test_create.py
+++ b/backend/app/tests/api/node_detection_point/test_create.py
@@ -1,0 +1,175 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("node_uuid", 123),
+        ("node_uuid", None),
+        ("node_uuid", ""),
+        ("node_uuid", "abc"),
+        ("uuid", 123),
+        ("uuid", None),
+        ("uuid", ""),
+        ("uuid", "abc"),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client_valid_access_token, key, value):
+    create = client_valid_access_token.post("/api/node/detection_point/", json=[{key: value}])
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_create_duplicate_node_uuid_value(client_valid_access_token, db):
+    alert_tree = helpers.create_alert(db=db)
+
+    # Create a detection point
+    create_json = {
+        "node_uuid": str(alert_tree.node_uuid),
+        "uuid": str(uuid.uuid4()),
+        "value": "test",
+    }
+    create = client_valid_access_token.post("/api/node/detection_point/", json=[create_json])
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Make sure you cannot add the same detection point value to a node
+    create_json = {
+        "node_uuid": str(alert_tree.node_uuid),
+        "uuid": str(uuid.uuid4()),
+        "value": "test",
+    }
+    create = client_valid_access_token.post("/api/node/detection_point/", json=[create_json])
+    assert create.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("uuid"),
+    ],
+)
+def test_create_duplicate_unique_fields(client_valid_access_token, db, key):
+    alert_tree = helpers.create_alert(db=db)
+
+    # Create a detection point
+    create1_json = {
+        "node_uuid": str(alert_tree.node_uuid),
+        "uuid": str(uuid.uuid4()),
+        "value": "test",
+    }
+    client_valid_access_token.post("/api/node/detection_point/", json=[create1_json])
+
+    # Ensure you cannot create another detection point with the same unique field value
+    create2_json = {
+        "node_uuid": str(alert_tree.node_uuid),
+        "uuid": str(uuid.uuid4()),
+        "value": "test2",
+    }
+    create2_json[key] = create1_json[key]
+    create2 = client_valid_access_token.post("/api/node/detection_point/", json=[create2_json])
+    assert create2.status_code == status.HTTP_409_CONFLICT
+
+
+def test_create_nonexistent_node_uuid(client_valid_access_token, db):
+    create_json = {
+        "node_uuid": str(uuid.uuid4()),
+        "uuid": str(uuid.uuid4()),
+        "value": "test",
+    }
+    create = client_valid_access_token.post("/api/node/detection_point/", json=[create_json])
+    assert create.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_create_verify_history_observables(client_valid_access_token, db):
+    alert_tree = helpers.create_alert(db=db)
+    observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
+
+    # Add a detection point to the node
+    create_json = [
+        {"node_uuid": str(observable_tree.node_uuid), "value": "test"},
+    ]
+    create = client_valid_access_token.post("/api/node/detection_point/", json=create_json)
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
+    assert history.json()["total"] == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "detection_points"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
+
+
+def test_create_multiple(client_valid_access_token, db):
+    alert_tree1 = helpers.create_alert(db=db)
+    initial_alert1_version = alert_tree1.node.version
+
+    alert_tree2 = helpers.create_alert(db=db)
+    initial_alert2_version = alert_tree2.node.version
+
+    alert_tree3 = helpers.create_alert(db=db)
+    initial_alert3_version = alert_tree3.node.version
+
+    assert alert_tree1.node.detection_points == []
+    assert alert_tree2.node.detection_points == []
+    assert alert_tree3.node.detection_points == []
+
+    # Add a detection point to each node at once
+    create_json = [
+        {"node_uuid": str(alert_tree1.node_uuid), "value": "test1"},
+        {"node_uuid": str(alert_tree2.node_uuid), "value": "test2"},
+        {"node_uuid": str(alert_tree3.node_uuid), "value": "test3"},
+    ]
+    create = client_valid_access_token.post("/api/node/detection_point/", json=create_json)
+    assert create.status_code == status.HTTP_201_CREATED
+
+    assert len(alert_tree1.node.detection_points) == 1
+    assert alert_tree1.node.detection_points[0].value == "test1"
+    assert alert_tree1.node.version != initial_alert1_version
+
+    assert len(alert_tree2.node.detection_points) == 1
+    assert alert_tree2.node.detection_points[0].value == "test2"
+    assert alert_tree2.node.version != initial_alert2_version
+
+    assert len(alert_tree3.node.detection_points) == 1
+    assert alert_tree3.node.detection_points[0].value == "test3"
+    assert alert_tree3.node.version != initial_alert3_version
+
+
+def test_create_valid_required_fields(client_valid_access_token, db):
+    alert_tree = helpers.create_alert(db=db)
+    initial_node_version = alert_tree.node.version
+
+    # Create a detection point
+    create_json = {
+        "node_uuid": str(alert_tree.node_uuid),
+        "uuid": str(uuid.uuid4()),
+        "value": "test",
+    }
+    create = client_valid_access_token.post("/api/node/detection_point/", json=[create_json])
+    assert create.status_code == status.HTTP_201_CREATED
+    assert len(alert_tree.node.detection_points) == 1
+    assert alert_tree.node.detection_points[0].value == "test"
+    assert alert_tree.node.version != initial_node_version

--- a/backend/app/tests/api/node_detection_point/test_delete.py
+++ b/backend/app/tests/api/node_detection_point/test_delete.py
@@ -1,0 +1,125 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+"""
+NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
+are in place in order to account for this.
+"""
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete("/api/node/comment/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete(f"/api/node/comment/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete_alerts(client_valid_access_token, db):
+    # Create a comment
+    alert_tree = helpers.create_alert(db=db)
+    comment = helpers.create_node_comment(node=alert_tree.node, username="johndoe", value="test", db=db)
+    assert alert_tree.node.comments[0].value == "test"
+
+    # Delete it
+    delete = client_valid_access_token.delete(f"/api/node/comment/{comment.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Make sure it is gone
+    get = client_valid_access_token.get(f"/api/node/comment/{comment.uuid}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+    # And make sure the node no longer shows the comment
+    assert len(alert_tree.node.comments) == 0
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
+
+
+def test_delete_events(client_valid_access_token, db):
+    # Create a comment
+    event = helpers.create_event(name="Test Event", db=db)
+    comment = helpers.create_node_comment(node=event, username="johndoe", value="test", db=db)
+    assert event.comments[0].value == "test"
+
+    # Delete it
+    delete = client_valid_access_token.delete(f"/api/node/comment/{comment.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Make sure it is gone
+    get = client_valid_access_token.get(f"/api/node/comment/{comment.uuid}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+    # And make sure the node no longer shows the comment
+    assert len(event.comments) == 0
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
+
+
+def test_delete_observables(client_valid_access_token, db):
+    # Create a comment
+    alert_tree = helpers.create_alert(db=db)
+    observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
+    comment = helpers.create_node_comment(node=observable_tree.node, username="johndoe", value="test", db=db)
+    assert observable_tree.node.comments[0].value == "test"
+
+    # Delete it
+    delete = client_valid_access_token.delete(f"/api/node/comment/{comment.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Make sure it is gone
+    get = client_valid_access_token.get(f"/api/node/comment/{comment.uuid}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+    # And make sure the node no longer shows the comment
+    assert len(alert_tree.node.comments) == 0
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
+    assert history.json()["total"] == 3
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/node_detection_point/test_read.py
+++ b/backend/app/tests/api/node_detection_point/test_read.py
@@ -1,0 +1,41 @@
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/comment/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.get(f"/api/node/comment/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+# There is currently no get_all endpoint for comments
+# def test_get_all(client_valid_access_token):
+#     # Create some objects
+#     client_valid_access_token.post("/api/analysis/", json={})
+#     client_valid_access_token.post("/api/analysis/", json={})
+
+#     # Read them back
+#     get = client_valid_access_token.get("/api/analysis/")
+#     assert get.status_code == status.HTTP_200_OK
+#     assert len(get.json()) == 2
+
+
+# def test_get_all_empty(client_valid_access_token):
+#     get = client_valid_access_token.get("/api/analysis/module_type/")
+#     assert get.status_code == status.HTTP_200_OK
+#     assert get.json() == []

--- a/backend/app/tests/api/node_detection_point/test_read.py
+++ b/backend/app/tests/api/node_detection_point/test_read.py
@@ -9,12 +9,12 @@ from fastapi import status
 
 
 def test_get_invalid_uuid(client_valid_access_token):
-    get = client_valid_access_token.get("/api/node/comment/1")
+    get = client_valid_access_token.get("/api/node/detection_point/1")
     assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_get_nonexistent_uuid(client_valid_access_token):
-    get = client_valid_access_token.get(f"/api/node/comment/{uuid.uuid4()}")
+    get = client_valid_access_token.get(f"/api/node/detection_point/{uuid.uuid4()}")
     assert get.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -23,7 +23,7 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-# There is currently no get_all endpoint for comments
+# There is currently no get_all endpoint for detection points
 # def test_get_all(client_valid_access_token):
 #     # Create some objects
 #     client_valid_access_token.post("/api/analysis/", json={})

--- a/backend/app/tests/api/node_detection_point/test_update.py
+++ b/backend/app/tests/api/node_detection_point/test_update.py
@@ -1,0 +1,174 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("value", None),
+        ("value", 123),
+        ("value", ""),
+    ],
+)
+def test_update_invalid_fields(client_valid_access_token, key, value):
+    update = client_valid_access_token.patch(f"/api/node/comment/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert key in update.text
+
+
+def test_update_invalid_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch("/api/node/comment/1", json={"value": "test"})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_nonexistent_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch(f"/api/node/comment/{uuid.uuid4()}", json={"value": "test"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_duplicate_node_uuid_value(client_valid_access_token, db):
+    # Create a node
+    node_tree = helpers.create_alert(db=db)
+
+    # Create some comments
+    comment1 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test", db=db)
+    comment2 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test2", db=db)
+
+    # Make sure you cannot update a comment on a node to one that already exists
+    update = client_valid_access_token.patch(f"/api/node/comment/{comment2.uuid}", json={"value": comment1.value})
+    assert update.status_code == status.HTTP_409_CONFLICT
+
+
+#
+# VALID TESTS
+#
+
+
+def test_update_alerts(client_valid_access_token, db):
+    # Create a comment
+    alert_tree = helpers.create_alert(db=db)
+    comment = helpers.create_node_comment(node=alert_tree.node, username="johndoe", value="test", db=db)
+    original_time = comment.insert_time
+    assert alert_tree.node.comments[0].value == "test"
+    assert comment.user.username == "johndoe"
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert alert_tree.node.comments[0].value == "updated"
+    assert alert_tree.node.comments[0].user.username == "analyst"
+    assert alert_tree.node.comments[0].insert_time != original_time
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(alert_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
+
+
+def test_update_events(client_valid_access_token, db):
+    # Create a comment
+    event = helpers.create_event(name="Test Event", db=db)
+    comment = helpers.create_node_comment(node=event, username="johndoe", value="test", db=db)
+    original_time = comment.insert_time
+    assert event.comments[0].value == "test"
+    assert comment.user.username == "johndoe"
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert event.comments[0].value == "updated"
+    assert event.comments[0].user.username == "analyst"
+    assert event.comments[0].insert_time != original_time
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(event.uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
+
+
+def test_update_observables(client_valid_access_token, db):
+    # Create a comment
+    alert_tree = helpers.create_alert(db=db)
+    observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
+    comment = helpers.create_node_comment(node=observable_tree.node, username="johndoe", value="test", db=db)
+    original_time = comment.insert_time
+    assert observable_tree.node.comments[0].value == "test"
+    assert comment.user.username == "johndoe"
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert observable_tree.node.comments[0].value == "updated"
+    assert observable_tree.node.comments[0].user.username == "analyst"
+    assert observable_tree.node.comments[0].insert_time != original_time
+
+    # Verify the history record
+    history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
+
+    assert history.json()["total"] == 3
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
+    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
+
+    assert history.json()["items"][2]["action"] == "UPDATE"
+    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][2]["record_uuid"] == str(observable_tree.node_uuid)
+    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["diff"]["old_value"] is None
+    assert history.json()["items"][2]["diff"]["new_value"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
+    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
+    assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/node_detection_point/test_update.py
+++ b/backend/app/tests/api/node_detection_point/test_update.py
@@ -20,31 +20,38 @@ from tests import helpers
     ],
 )
 def test_update_invalid_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(f"/api/node/comment/{uuid.uuid4()}", json={key: value})
+    update = client_valid_access_token.patch(f"/api/node/detection_point/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     assert key in update.text
 
 
 def test_update_invalid_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch("/api/node/comment/1", json={"value": "test"})
+    update = client_valid_access_token.patch("/api/node/detection_point/1", json={"value": "test"})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_update_nonexistent_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch(f"/api/node/comment/{uuid.uuid4()}", json={"value": "test"})
+    update = client_valid_access_token.patch(f"/api/node/detection_point/{uuid.uuid4()}", json={"value": "test"})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_update_duplicate_node_uuid_value(client_valid_access_token, db):
-    # Create a node
+    # Create an observable
     node_tree = helpers.create_alert(db=db)
+    observable = helpers.create_observable(type="test_type", value="test_value", parent_tree=node_tree, db=db)
 
-    # Create some comments
-    comment1 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test", db=db)
-    comment2 = helpers.create_node_comment(node=node_tree.node, username="johndoe", value="test2", db=db)
+    # Create some detection points
+    detection_point1 = helpers.create_node_detection_point(
+        node=observable.node, username="analyst", value="test", db=db
+    )
+    detection_point2 = helpers.create_node_detection_point(
+        node=observable.node, username="analyst", value="test2", db=db
+    )
 
-    # Make sure you cannot update a comment on a node to one that already exists
-    update = client_valid_access_token.patch(f"/api/node/comment/{comment2.uuid}", json={"value": comment1.value})
+    # Make sure you cannot update a detection point on a node to one that already exists
+    update = client_valid_access_token.patch(
+        f"/api/node/detection_point/{detection_point2.uuid}", json={"value": detection_point1.value}
+    )
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
@@ -53,110 +60,32 @@ def test_update_duplicate_node_uuid_value(client_valid_access_token, db):
 #
 
 
-def test_update_alerts(client_valid_access_token, db):
-    # Create a comment
-    alert_tree = helpers.create_alert(db=db)
-    comment = helpers.create_node_comment(node=alert_tree.node, username="johndoe", value="test", db=db)
-    original_time = comment.insert_time
-    assert alert_tree.node.comments[0].value == "test"
-    assert comment.user.username == "johndoe"
-
-    # Update it
-    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
-    assert update.status_code == status.HTTP_204_NO_CONTENT
-    assert alert_tree.node.comments[0].value == "updated"
-    assert alert_tree.node.comments[0].user.username == "analyst"
-    assert alert_tree.node.comments[0].insert_time != original_time
-
-    # Verify the history record
-    history = client_valid_access_token.get(f"/api/alert/{alert_tree.node_uuid}/history")
-
-    assert history.json()["total"] == 3
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
-    assert history.json()["items"][1]["record_uuid"] == str(alert_tree.node_uuid)
-    assert history.json()["items"][1]["field"] == "comments"
-    assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
-    assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
-
-    assert history.json()["items"][2]["action"] == "UPDATE"
-    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
-    assert history.json()["items"][2]["record_uuid"] == str(alert_tree.node_uuid)
-    assert history.json()["items"][2]["field"] == "comments"
-    assert history.json()["items"][2]["diff"]["old_value"] is None
-    assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
-    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
-
-
-def test_update_events(client_valid_access_token, db):
-    # Create a comment
-    event = helpers.create_event(name="Test Event", db=db)
-    comment = helpers.create_node_comment(node=event, username="johndoe", value="test", db=db)
-    original_time = comment.insert_time
-    assert event.comments[0].value == "test"
-    assert comment.user.username == "johndoe"
-
-    # Update it
-    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
-    assert update.status_code == status.HTTP_204_NO_CONTENT
-    assert event.comments[0].value == "updated"
-    assert event.comments[0].user.username == "analyst"
-    assert event.comments[0].insert_time != original_time
-
-    # Verify the history record
-    history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-
-    assert history.json()["total"] == 3
-    assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
-    assert history.json()["items"][1]["record_uuid"] == str(event.uuid)
-    assert history.json()["items"][1]["field"] == "comments"
-    assert history.json()["items"][1]["diff"]["old_value"] is None
-    assert history.json()["items"][1]["diff"]["new_value"] is None
-    assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
-    assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
-
-    assert history.json()["items"][2]["action"] == "UPDATE"
-    assert history.json()["items"][2]["action_by"]["username"] == "analyst"
-    assert history.json()["items"][2]["record_uuid"] == str(event.uuid)
-    assert history.json()["items"][2]["field"] == "comments"
-    assert history.json()["items"][2]["diff"]["old_value"] is None
-    assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]
-    assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
-    assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
-
-
 def test_update_observables(client_valid_access_token, db):
-    # Create a comment
+    # Create a detection point
     alert_tree = helpers.create_alert(db=db)
     observable_tree = helpers.create_observable(type="test_type", value="test_value", parent_tree=alert_tree, db=db)
-    comment = helpers.create_node_comment(node=observable_tree.node, username="johndoe", value="test", db=db)
-    original_time = comment.insert_time
-    assert observable_tree.node.comments[0].value == "test"
-    assert comment.user.username == "johndoe"
+    detection_point = helpers.create_node_detection_point(
+        node=observable_tree.node, username="analyst", value="test", db=db
+    )
+    original_time = detection_point.insert_time
+    assert observable_tree.node.detection_points[0].value == "test"
 
     # Update it
-    update = client_valid_access_token.patch(f"/api/node/comment/{comment.uuid}", json={"value": "updated"})
+    update = client_valid_access_token.patch(
+        f"/api/node/detection_point/{detection_point.uuid}", json={"value": "updated"}
+    )
     assert update.status_code == status.HTTP_204_NO_CONTENT
-    assert observable_tree.node.comments[0].value == "updated"
-    assert observable_tree.node.comments[0].user.username == "analyst"
-    assert observable_tree.node.comments[0].insert_time != original_time
+    assert observable_tree.node.detection_points[0].value == "updated"
+    assert observable_tree.node.detection_points[0].insert_time != original_time
 
     # Verify the history record
     history = client_valid_access_token.get(f"/api/observable/{observable_tree.node_uuid}/history")
 
     assert history.json()["total"] == 3
     assert history.json()["items"][1]["action"] == "UPDATE"
-    assert history.json()["items"][1]["action_by"]["username"] == "johndoe"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
     assert history.json()["items"][1]["record_uuid"] == str(observable_tree.node_uuid)
-    assert history.json()["items"][1]["field"] == "comments"
+    assert history.json()["items"][1]["field"] == "detection_points"
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
@@ -166,7 +95,7 @@ def test_update_observables(client_valid_access_token, db):
     assert history.json()["items"][2]["action"] == "UPDATE"
     assert history.json()["items"][2]["action_by"]["username"] == "analyst"
     assert history.json()["items"][2]["record_uuid"] == str(observable_tree.node_uuid)
-    assert history.json()["items"][2]["field"] == "comments"
+    assert history.json()["items"][2]["field"] == "detection_points"
     assert history.json()["items"][2]["diff"]["old_value"] is None
     assert history.json()["items"][2]["diff"]["new_value"] is None
     assert history.json()["items"][2]["diff"]["added_to_list"] == ["updated"]

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -469,7 +469,7 @@ def create_node_comment(
     db.add(obj)
     crud.commit(db)
 
-    crud.record_comment_history(
+    crud.record_node_update_history(
         record_node=node,
         action_by=create_user(username=username, display_name=username, db=db),
         diff=crud.Diff(field="comments", added_to_list=[obj.value]),

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -31,6 +31,7 @@ from db.schemas.event_type import EventType
 from db.schemas.event_vector import EventVector
 from db.schemas.node import Node
 from db.schemas.node_comment import NodeComment
+from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
@@ -473,6 +474,26 @@ def create_node_comment(
         record_node=node,
         action_by=create_user(username=username, display_name=username, db=db),
         diff=crud.Diff(field="comments", added_to_list=[obj.value]),
+        db=db,
+    )
+
+    return obj
+
+
+def create_node_detection_point(
+    node: Node, username: str, value: str, db: Session, insert_time: Optional[datetime] = None
+) -> NodeDetectionPoint:
+    if insert_time is None:
+        insert_time = datetime.utcnow()
+
+    obj = NodeDetectionPoint(insert_time=insert_time, node_uuid=node.uuid, uuid=uuid.uuid4(), value=value)
+    db.add(obj)
+    crud.commit(db)
+
+    crud.record_node_update_history(
+        record_node=node,
+        action_by=create_user(username=username, display_name=username, db=db),
+        diff=crud.Diff(field="detection_points", added_to_list=[obj.value]),
         db=db,
     )
 

--- a/frontend/src/models/nodeDetectionPoint.ts
+++ b/frontend/src/models/nodeDetectionPoint.ts
@@ -1,0 +1,21 @@
+import { UUID } from "./base";
+
+export interface nodeDetectionPointCreate {
+  nodeUuid: UUID;
+  uuid?: UUID;
+  value: string;
+  [key: string]: unknown;
+}
+
+export interface nodeDetectionPointRead {
+  insertTime: Date;
+  nodeUuid: UUID;
+  uuid: UUID;
+  value: string;
+}
+
+export interface nodeDetectionPointUpdate {
+  uuid: UUID;
+  value: string;
+  [key: string]: unknown;
+}

--- a/frontend/src/services/api/nodeDetectionPoint.ts
+++ b/frontend/src/services/api/nodeDetectionPoint.ts
@@ -1,0 +1,23 @@
+import {
+  nodeDetectionPointCreate,
+  nodeDetectionPointRead,
+  nodeDetectionPointUpdate,
+} from "@/models/nodeDetectionPoint";
+import { UUID } from "@/models/base";
+import { BaseApi } from "./base";
+
+const api = new BaseApi();
+const endpoint = "/node/detection_point/";
+
+export const NodeDetectionPoint = {
+  create: (
+    data: nodeDetectionPointCreate[],
+    getAfterCreate = false,
+  ): Promise<void> => api.create(endpoint, data, getAfterCreate),
+
+  read: (uuid: UUID): Promise<nodeDetectionPointRead> =>
+    api.read(`${endpoint}${uuid}`),
+
+  update: (uuid: UUID, data: nodeDetectionPointUpdate): Promise<void> =>
+    api.update(`${endpoint}${uuid}`, data),
+};


### PR DESCRIPTION
This PR adds the concept of "detection points" to node objects. ACE 1.0 has detection points, which are just strings that analysis modules can add when they detect something that they want to call attention to. Typically detection points are used to instantly turn the thing being analyzed into an alert.