### PR TITLE
Event detection point summary API endpoint

### DIFF
--- a/backend/app/api/models/event_summaries.py
+++ b/backend/app/api/models/event_summaries.py
@@ -3,7 +3,16 @@ from typing import List, Optional
 
 from api.models import type_str
 from api.models.analysis_details import EmailAnalysisDetailsBase, EmailAnalysisDetailsHeaderBody, UserAnalysisDetails
+from api.models.node_detection_point import NodeDetectionPointRead
 from api.models.observable import ObservableRead
+
+
+class DetectionSummary(NodeDetectionPointRead):
+    """Represents an individual detection point found in an event."""
+
+    alert_uuid: UUID4 = Field(description="An alert UUID in which this detection point was found")
+
+    count: int = Field(description="The number of times this detection point value was found in the event")
 
 
 class EmailHeadersBody(EmailAnalysisDetailsHeaderBody):

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -8,10 +8,18 @@ from typing import List, Optional
 from uuid import UUID
 
 from api.models.event import EventCreate, EventRead, EventUpdateMultiple
-from api.models.event_summaries import EmailHeadersBody, EmailSummary, ObservableSummary, URLDomainSummary, UserSummary
+from api.models.event_summaries import (
+    DetectionSummary,
+    EmailHeadersBody,
+    EmailSummary,
+    ObservableSummary,
+    URLDomainSummary,
+    UserSummary,
+)
 from api.models.history import EventHistoryRead
 from api.routes import helpers
 from api.routes.event_summaries import (
+    get_detection_point_summary,
     get_email_headers_body_summary,
     get_email_summary,
     get_observable_summary,
@@ -662,6 +670,9 @@ helpers.api_route_update(router, update_events, path="/")
 # SUMMARIES
 #
 
+helpers.api_route_read(
+    router, get_detection_point_summary, List[DetectionSummary], path="/{uuid}/summary/detection_point"
+)
 helpers.api_route_read(
     router, get_email_headers_body_summary, Optional[EmailHeadersBody], path="/{uuid}/summary/email_headers_body"
 )

--- a/frontend/src/models/eventSummaries.ts
+++ b/frontend/src/models/eventSummaries.ts
@@ -1,5 +1,11 @@
 import { UUID } from "./base";
+import { nodeDetectionPointRead } from "./nodeDetectionPoint";
 import { observableRead } from "./observable";
+
+export interface detectionPointSummary extends nodeDetectionPointRead {
+  alertUuid: UUID;
+  count: number;
+}
 
 export interface emailHeadersBody {
   alertUuid: UUID;


### PR DESCRIPTION
This PR adds the `/api/event/{uuid}/summary/detection_point` API endpoint. It returns a list of the various detection points found across the event. Each detection point in the returned list has a `count` field, which is the number of times that detection point value was found across the event, and an `alert_uuid` field, which is the UUID of one of the alerts that has the detection point in it.