### PR TITLE
Event Details - Detection Summary Section

### DIFF
--- a/frontend/src/components/Events/EventDetectionsSummary.vue
+++ b/frontend/src/components/Events/EventDetectionsSummary.vue
@@ -49,7 +49,7 @@
 
   onMounted(async () => {
     isLoading.value = true;
-    // detections.value = await Event.readUrlDomainSummary(props.eventUuid);
+    detections.value = await Event.readDetectionSummary(props.eventUuid);
     isLoading.value = false;
   });
 </script>

--- a/frontend/src/components/Events/EventDetectionsSummary.vue
+++ b/frontend/src/components/Events/EventDetectionsSummary.vue
@@ -13,12 +13,11 @@
         <template #body="slotProps">
           <div class="flex align-content-evenly">
             <span
-              class="flex align-items-center justify-content-center"
+              class="flex align-items-left justify-content-center"
               data-cy="detection-value"
-              style="width: 4em"
               >{{ slotProps.data.value }}</span
             >
-            <span class="flex align-items-center justify-content-center"
+            <span class="flex align-items-left justify-content-center" style="width: 10%"
               ><a
                 :href="`/alert/${slotProps.data.alertUuid}`"
                 style="text-decoration: none"

--- a/frontend/src/components/Events/EventDetectionsSummary.vue
+++ b/frontend/src/components/Events/EventDetectionsSummary.vue
@@ -1,0 +1,55 @@
+<!-- EventDetectionSummary.vue -->
+<!-- A simple table of all the detections in an event, their frequency, and a given alert to which they belong -->
+
+<template>
+  <div>
+    <DataTable
+      :value="detections"
+      :loading="isLoading"
+      responsive-layout="scroll"
+      data-cy="detection-summary-table"
+    >
+      <Column field="value" header="Detection">
+        <template #body="slotProps">
+          <div class="flex align-content-evenly">
+            <span
+              class="flex align-items-center justify-content-center"
+              data-cy="detection-value"
+              style="width: 4em"
+              >{{ slotProps.data.value }}</span
+            >
+          <span class="flex align-items-center justify-content-center"
+            ><a :href="`/alert/${slotProps.data.alertUuid}`" style="text-decoration: none"
+              ><Button
+                icon="pi pi-external-link"
+                class="p-button-rounded p-button-text"
+                data-cy="faqueue-external-link"
+            /></a>
+          </span>
+          </div> </template
+      ></Column>
+      <Column field="count" header="Count" :sortable="true" style="width: 20%"></Column>
+    </DataTable>
+  </div>
+</template>
+
+<script setup>
+  import Button from "primevue/button";
+  import DataTable from "primevue/datatable";
+  import Column from "primevue/column";
+  import { defineProps, ref, onMounted } from "vue";
+  import { Event } from "@/services/api/event";
+
+  const props = defineProps({
+    eventUuid: { type: String, required: true },
+  });
+
+  const isLoading = ref(false);
+  const detections = ref([{value: "example", count: 2, alertUuid: "madeUpUuid"}]);
+
+  onMounted(async () => {
+    isLoading.value = true;
+    // detections.value = await Event.readUrlDomainSummary(props.eventUuid);
+    isLoading.value = false;
+  });
+</script>

--- a/frontend/src/components/Events/EventDetectionsSummary.vue
+++ b/frontend/src/components/Events/EventDetectionsSummary.vue
@@ -17,7 +17,9 @@
               data-cy="detection-value"
               >{{ slotProps.data.value }}</span
             >
-            <span class="flex align-items-left justify-content-center" style="width: 10%"
+            <span
+              class="flex align-items-left justify-content-center"
+              style="width: 10%"
               ><a
                 :href="`/alert/${slotProps.data.alertUuid}`"
                 style="text-decoration: none"

--- a/frontend/src/components/Events/EventDetectionsSummary.vue
+++ b/frontend/src/components/Events/EventDetectionsSummary.vue
@@ -18,17 +18,25 @@
               style="width: 4em"
               >{{ slotProps.data.value }}</span
             >
-          <span class="flex align-items-center justify-content-center"
-            ><a :href="`/alert/${slotProps.data.alertUuid}`" style="text-decoration: none"
-              ><Button
-                icon="pi pi-external-link"
-                class="p-button-rounded p-button-text"
-                data-cy="faqueue-external-link"
-            /></a>
-          </span>
+            <span class="flex align-items-center justify-content-center"
+              ><a
+                :href="`/alert/${slotProps.data.alertUuid}`"
+                style="text-decoration: none"
+                ><Button
+                  icon="pi pi-external-link"
+                  class="p-button-rounded p-button-text"
+                  data-cy="detection-point-alert-link"
+              /></a>
+            </span>
           </div> </template
       ></Column>
-      <Column field="count" header="Count" :sortable="true" style="width: 20%"></Column>
+      <Column
+        field="count"
+        header="Count"
+        :sortable="true"
+        style="width: 20%"
+      ></Column>
+      <template #empty>No detection points found.</template>
     </DataTable>
   </div>
 </template>
@@ -45,7 +53,7 @@
   });
 
   const isLoading = ref(false);
-  const detections = ref([{value: "example", count: 2, alertUuid: "madeUpUuid"}]);
+  const detections = ref([]);
 
   onMounted(async () => {
     isLoading.value = true;

--- a/frontend/src/components/Events/TheEventDetailsMenuBar.vue
+++ b/frontend/src/components/Events/TheEventDetailsMenuBar.vue
@@ -176,7 +176,6 @@
                 command: () => {
                   emit("sectionClicked", "Detection Summary");
                 },
-                disabled: true,
               },
               {
                 label: "URL Summary",

--- a/frontend/src/etc/constants/events.ts
+++ b/frontend/src/etc/constants/events.ts
@@ -28,6 +28,7 @@ import EventAlertsTableVue from "@/components/Events/EventAlertsTable.vue";
 import EventURLSummaryVue from "@/components/Events/EventURLSummary.vue";
 import EventURLDomainSummaryVue from "@/components/Events/EventURLDomainSummary.vue";
 import EventObservableSummaryVue from "@/components/Events/EventObservableSummary.vue";
+import EventDetectionsSummaryVue from "@/components/Events/EventDetectionsSummary.vue";
 
 // ** Events ** //
 
@@ -266,6 +267,7 @@ export const validEventFilters: propertyOption[] = [
 export const defaultEventDetailsSections = {
   "Event Summary": EventSummaryVue,
   "Alert Summary": EventAlertsTableVue,
+  "Detection Summary": EventDetectionsSummaryVue,
   "URL Summary": EventURLSummaryVue,
   "URL Domain Summary": EventURLDomainSummaryVue,
   "Observable Summary": EventObservableSummaryVue,

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -9,6 +9,7 @@ import {
 import {
   emailSummary,
   emailHeadersBody,
+  detectionPointSummary,
   observableSummary,
   userSummary,
   urlDomainSummary,
@@ -51,6 +52,9 @@ export const Event = {
 
   readEmailHeadersAndBody: async (uuid: UUID): Promise<emailHeadersBody[]> =>
     await api.read(`${endpoint}${uuid}/summary/email_headers_body`),
+
+  readDetectionSummary: async (uuid: UUID): Promise<detectionPointSummary[]> =>
+  await api.read(`${endpoint}${uuid}/summary/detection_point`),
 
   readPage: (params?: eventFilterParams): Promise<eventReadPage> => {
     let formattedParams = {} as eventFilterParams;

--- a/frontend/src/services/api/event.ts
+++ b/frontend/src/services/api/event.ts
@@ -54,7 +54,7 @@ export const Event = {
     await api.read(`${endpoint}${uuid}/summary/email_headers_body`),
 
   readDetectionSummary: async (uuid: UUID): Promise<detectionPointSummary[]> =>
-  await api.read(`${endpoint}${uuid}/summary/detection_point`),
+    await api.read(`${endpoint}${uuid}/summary/detection_point`),
 
   readPage: (params?: eventFilterParams): Promise<eventReadPage> => {
     let formattedParams = {} as eventFilterParams;

--- a/frontend/tests/unit/src/services/api/event.spec.ts
+++ b/frontend/tests/unit/src/services/api/event.spec.ts
@@ -71,7 +71,7 @@ describe("Event calls", () => {
     const res = await api.readEmailHeadersAndBody("uuid");
     expect(res).toEqual("Read successful");
   });
-  
+
   it("will make a get request to the /event/{uuid}/summary/detection_point endpoint when 'readDetectionSummary' is called with a given UUID", async () => {
     myNock
       .get("/event/uuid/summary/detection_point")

--- a/frontend/tests/unit/src/services/api/event.spec.ts
+++ b/frontend/tests/unit/src/services/api/event.spec.ts
@@ -71,6 +71,14 @@ describe("Event calls", () => {
     const res = await api.readEmailHeadersAndBody("uuid");
     expect(res).toEqual("Read successful");
   });
+  
+  it("will make a get request to the /event/{uuid}/summary/detection_point endpoint when 'readDetectionSummary' is called with a given UUID", async () => {
+    myNock
+      .get("/event/uuid/summary/detection_point")
+      .reply(200, "Read successful");
+    const res = await api.readDetectionSummary("uuid");
+    expect(res).toEqual("Read successful");
+  });
 
   it("will make a get request to the /event/ endpoint when 'readPage' is called with no params, if none given", async () => {
     myNock.get("/event/").reply(200, "Read successful");


### PR DESCRIPTION
This PR adds the detection summary section to the event details page. The main differences from 1.0 include a slightly different table format, a link to an alert that includes the respective detection point, and ability to sort by detection point count.

![image](https://user-images.githubusercontent.com/31867815/159540138-eeb64714-d83f-4527-8aa5-4a88e80d81cc.png)
