### PR TITLE
Node relationships

### DIFF
--- a/backend/app/api/models/alert.py
+++ b/backend/app/api/models/alert.py
@@ -74,7 +74,7 @@ class AlertRead(NodeRead, AlertBase):
         description="A list of threats added to child Nodes in the alert's tree"
     )
 
-    comments: List[NodeCommentRead] = Field(description="A list of comments added to the alert")
+    comments: List[NodeCommentRead] = Field(description="A list of comments added to the alert", default_factory=list)
 
     disposition: Optional[AlertDispositionRead] = Field(description="The disposition assigned to this alert")
 

--- a/backend/app/api/models/event.py
+++ b/backend/app/api/models/event.py
@@ -105,7 +105,7 @@ class EventRead(NodeRead, EventBase):
         description="The automatically calculated earliest time an analyst took ownership of one of the alerts"
     )
 
-    comments: List[NodeCommentRead] = Field(description="A list of comments added to the event")
+    comments: List[NodeCommentRead] = Field(description="A list of comments added to the event", default_factory=list)
 
     creation_time: datetime = Field(description="The time the event was created")
 

--- a/backend/app/api/models/history.py
+++ b/backend/app/api/models/history.py
@@ -16,10 +16,12 @@ class Diff(BaseModel):
 
     new_value: Optional[Union[type_str, bool]] = Field(description="The string value of the field after to the action")
 
-    added_to_list: Optional[List[type_str]] = Field(description="A list of strings that were added to the field")
+    added_to_list: List[type_str] = Field(
+        description="A list of strings that were added to the field", default_factory=list
+    )
 
-    removed_from_list: Optional[List[type_str]] = Field(
-        description="A list of strings that were removed from the field"
+    removed_from_list: List[type_str] = Field(
+        description="A list of strings that were removed from the field", default_factory=list
     )
 
 

--- a/backend/app/api/models/node_relationship.py
+++ b/backend/app/api/models/node_relationship.py
@@ -1,32 +1,31 @@
 from pydantic import BaseModel, Field, UUID4
-from typing import Optional
 from uuid import uuid4
 
-from api.models import type_str, validators
+from api.models import type_str
+from api.models.node import NodeRead
+from api.models.node_relationship_type import NodeRelationshipTypeRead
 
 
 class NodeRelationshipBase(BaseModel):
     """Represents a node relationship that can be applied to a node (typically an observable)."""
 
-    description: Optional[type_str] = Field(
-        description="An optional human-readable description of the node relationship"
-    )
-
-    value: type_str = Field(description="The value of the node relationship")
+    node_uuid: UUID4 = Field(description="The UUID of the node")
 
 
 class NodeRelationshipCreate(NodeRelationshipBase):
+    related_node_uuid: UUID4 = Field(description="The UUID of the related node")
+
+    type: type_str = Field(description="The type of the node relationship")
+
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the node relationship")
 
 
 class NodeRelationshipRead(NodeRelationshipBase):
     uuid: UUID4 = Field(description="The UUID of the node relationship")
 
+    related_node: NodeRead = Field(description="The related node")
+
+    type: NodeRelationshipTypeRead = Field(description="The type of the node relationship")
+
     class Config:
         orm_mode = True
-
-
-class NodeRelationshipUpdate(NodeRelationshipBase):
-    value: Optional[type_str] = Field(description="The value of the node relationship")
-
-    _prevent_none: classmethod = validators.prevent_none("value")

--- a/backend/app/api/models/node_relationship.py
+++ b/backend/app/api/models/node_relationship.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api.models import type_str, validators
+
+
+class NodeRelationshipBase(BaseModel):
+    """Represents a node relationship that can be applied to a node (typically an observable)."""
+
+    description: Optional[type_str] = Field(
+        description="An optional human-readable description of the node relationship"
+    )
+
+    value: type_str = Field(description="The value of the node relationship")
+
+
+class NodeRelationshipCreate(NodeRelationshipBase):
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the node relationship")
+
+
+class NodeRelationshipRead(NodeRelationshipBase):
+    uuid: UUID4 = Field(description="The UUID of the node relationship")
+
+    class Config:
+        orm_mode = True
+
+
+class NodeRelationshipUpdate(NodeRelationshipBase):
+    value: Optional[type_str] = Field(description="The value of the node relationship")
+
+    _prevent_none: classmethod = validators.prevent_none("value")

--- a/backend/app/api/models/node_relationship_type.py
+++ b/backend/app/api/models/node_relationship_type.py
@@ -1,0 +1,32 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api.models import type_str, validators
+
+
+class NodeRelationshipTypeBase(BaseModel):
+    """Represents a node relationship type that can be used in a relationship applied to a node (typically an observable)."""
+
+    description: Optional[type_str] = Field(
+        description="An optional human-readable description of the node relationship type"
+    )
+
+    value: type_str = Field(description="The value of the node relationship type")
+
+
+class NodeRelationshipTypeCreate(NodeRelationshipTypeBase):
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the node relationship type")
+
+
+class NodeRelationshipTypeRead(NodeRelationshipTypeBase):
+    uuid: UUID4 = Field(description="The UUID of the node relationship type")
+
+    class Config:
+        orm_mode = True
+
+
+class NodeRelationshipTypeUpdate(NodeRelationshipTypeBase):
+    value: Optional[type_str] = Field(description="The value of the node relationship type")
+
+    _prevent_none: classmethod = validators.prevent_none("value")

--- a/backend/app/api/models/observable.py
+++ b/backend/app/api/models/observable.py
@@ -8,6 +8,7 @@ from api.models.node import NodeBase, NodeCreate, NodeRead, NodeTreeCreateWithNo
 from api.models.node_comment import NodeCommentRead
 from api.models.node_detection_point import NodeDetectionPointRead
 from api.models.node_directive import NodeDirectiveRead
+from api.models.node_relationship import NodeRelationshipRead
 from api.models.node_tag import NodeTagRead
 from api.models.node_threat import NodeThreatRead
 from api.models.node_threat_actor import NodeThreatActorRead
@@ -68,13 +69,19 @@ class ObservableCreate(ObservableCreateBase):
 
 
 class ObservableRead(NodeRead, ObservableBase):
-    comments: List[NodeCommentRead] = Field(description="A list of comments added to the observable")
+    comments: List[NodeCommentRead] = Field(
+        description="A list of comments added to the observable", default_factory=list
+    )
 
     detection_points: List[NodeDetectionPointRead] = Field(
-        description="A list of detection points added to the observable"
+        description="A list of detection points added to the observable", default_factory=list
     )
 
     directives: List[NodeDirectiveRead] = Field(description="A list of directives added to the observable")
+
+    observable_relationships: List["ObservableRelationshipRead"] = Field(
+        description="A list of observable relationships for this observable"
+    )
 
     tags: List[NodeTagRead] = Field(description="A list of tags added to the observable")
 
@@ -119,3 +126,12 @@ class ObservableUpdate(NodeUpdate, ObservableBase):
     _prevent_none: classmethod = validators.prevent_none(
         "directives", "for_detection", "tags", "threat_actors", "threats", "time", "type", "value"
     )
+
+
+class ObservableRelationshipRead(NodeRelationshipRead):
+    related_node: ObservableRead = Field(description="The related observable")
+
+
+# This is needed for the circular relationship between ObservableRead and ObservableRelationshipRead
+ObservableRead.update_forward_refs()
+ObservableNodeTreeRead.update_forward_refs()

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -20,6 +20,7 @@ from api.routes.node import router as node_router
 from api.routes.node_comment import router as node_comment_router
 from api.routes.node_detection_point import router as node_detection_point_router
 from api.routes.node_directive import router as node_directive_router
+from api.routes.node_relationship import router as node_relationship_router
 from api.routes.node_tag import router as node_tag_router
 from api.routes.node_threat import router as node_threat_router
 from api.routes.node_threat_actor import router as node_threat_actor_router
@@ -56,6 +57,7 @@ router.include_router(node_router)
 router.include_router(node_comment_router)
 router.include_router(node_detection_point_router)
 router.include_router(node_directive_router)
+router.include_router(node_relationship_router)
 router.include_router(node_tag_router)
 router.include_router(node_threat_router)
 router.include_router(node_threat_actor_router)

--- a/backend/app/api/routes/__init__.py
+++ b/backend/app/api/routes/__init__.py
@@ -21,6 +21,7 @@ from api.routes.node_comment import router as node_comment_router
 from api.routes.node_detection_point import router as node_detection_point_router
 from api.routes.node_directive import router as node_directive_router
 from api.routes.node_relationship import router as node_relationship_router
+from api.routes.node_relationship_type import router as node_relationship_type_router
 from api.routes.node_tag import router as node_tag_router
 from api.routes.node_threat import router as node_threat_router
 from api.routes.node_threat_actor import router as node_threat_actor_router
@@ -58,6 +59,7 @@ router.include_router(node_comment_router)
 router.include_router(node_detection_point_router)
 router.include_router(node_directive_router)
 router.include_router(node_relationship_router)
+router.include_router(node_relationship_type_router)
 router.include_router(node_tag_router)
 router.include_router(node_threat_router)
 router.include_router(node_threat_actor_router)

--- a/backend/app/api/routes/alert.py
+++ b/backend/app/api/routes/alert.py
@@ -84,12 +84,9 @@ def create_alert(
 
         crud.commit(db)
 
-        crud.record_create_history(
-            history_table=ObservableHistory,
+        crud.record_node_create_history(
+            record_node=db_observable,
             action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-            record_read_model=ObservableRead,
-            record_table=Observable,
-            record_uuid=db_observable.uuid,
             db=db,
         )
 
@@ -106,12 +103,9 @@ def create_alert(
     crud.commit(db)
 
     # Add an entry to the history table
-    crud.record_create_history(
-        history_table=AlertHistory,
+    crud.record_node_create_history(
+        record_node=new_alert,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        record_read_model=AlertRead,
-        record_table=Alert,
-        record_uuid=new_alert.uuid,
         db=db,
     )
 
@@ -485,12 +479,9 @@ def update_alerts(
         crud.commit(db)
 
         # Add the entries to the history table
-        crud.record_update_histories(
-            history_table=AlertHistory,
+        crud.record_node_update_history(
+            record_node=db_alert,
             action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-            record_read_model=AlertRead,
-            record_table=Alert,
-            record_uuid=alert.uuid,
             diffs=diffs,
             db=db,
         )

--- a/backend/app/api/routes/event.py
+++ b/backend/app/api/routes/event.py
@@ -112,12 +112,9 @@ def create_event(
     crud.commit(db)
 
     # Add an entry to the history table
-    crud.record_create_history(
-        history_table=EventHistory,
+    crud.record_node_create_history(
+        record_node=new_event,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        record_read_model=EventRead,
-        record_table=Event,
-        record_uuid=new_event.uuid,
         db=db,
     )
 
@@ -642,12 +639,9 @@ def update_events(
         crud.commit(db)
 
         # Add the entries to the history table
-        crud.record_update_histories(
-            history_table=EventHistory,
+        crud.record_node_update_history(
+            record_node=db_event,
             action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-            record_read_model=EventRead,
-            record_table=Event,
-            record_uuid=event.uuid,
             diffs=diffs,
             db=db,
         )

--- a/backend/app/api/routes/node.py
+++ b/backend/app/api/routes/node.py
@@ -21,6 +21,11 @@ router = APIRouter(
 )
 
 
+#
+# CREATE
+#
+
+
 def create_node(
     node_create: NodeCreate,
     db_node_type: DeclarativeMeta,
@@ -46,6 +51,11 @@ def create_node(
         db_node.threats = crud.read_by_values(values=node_create.threats, db_table=NodeThreat, db=db)
 
     return db_node
+
+
+#
+# UPDATE
+#
 
 
 def update_node(

--- a/backend/app/api/routes/node_comment.py
+++ b/backend/app/api/routes/node_comment.py
@@ -51,8 +51,12 @@ def create_node_comments(
         # Add an entry to the correct history table based on the node_type.
         # Even though this is creating a comment, we treat it as though it is
         # modifying the node for history tracking purposes.
-        diff = crud.Diff(field="comments", added_to_list=[node_comment.value])
-        crud.record_node_update_history(record_node=db_node, action_by=new_comment.user, diff=diff, db=db)
+        crud.record_node_update_history(
+            record_node=db_node,
+            action_by=new_comment.user,
+            diffs=[crud.Diff(field="comments", added_to_list=[node_comment.value], removed_from_list=[])],
+            db=db,
+        )
 
         response.headers["Content-Location"] = request.url_for("get_node_comment", uuid=new_comment.uuid)
 
@@ -106,7 +110,7 @@ def update_node_comment(
 
     # Add an entry to the correct history table based on the node_type.
     crud.record_node_update_history(
-        record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
+        record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diffs=[diff], db=db
     )
 
     response.headers["Content-Location"] = request.url_for("get_node_comment", uuid=uuid)
@@ -128,11 +132,10 @@ def delete_node_comment(uuid: UUID, db: Session = Depends(get_db), claims: dict 
     crud.update_node_version(node=db_node, db=db)
 
     # Add an entry to the correct history table based on the node_type.
-    diff = crud.Diff(field="comments", removed_from_list=[db_node.value])
     crud.record_node_update_history(
         record_node=db_node.node,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        diff=diff,
+        diffs=[crud.Diff(field="comments", added_to_list=[], removed_from_list=[db_node.value])],
         db=db,
     )
 

--- a/backend/app/api/routes/node_detection_point.py
+++ b/backend/app/api/routes/node_detection_point.py
@@ -48,9 +48,13 @@ def create_node_detection_points(
         # Add an entry to the correct history table based on the node_type.
         # Even though this is creating a detection point, we treat it as though it is
         # modifying the node for history tracking purposes.
-        diff = crud.Diff(field="detection_points", added_to_list=[node_detection_point.value])
         crud.record_node_update_history(
-            record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
+            record_node=db_node,
+            action_by=crud.read_user_by_username(username=claims["sub"], db=db),
+            diffs=[
+                crud.Diff(field="detection_points", added_to_list=[node_detection_point.value], removed_from_list=[])
+            ],
+            db=db,
         )
 
         response.headers["Content-Location"] = request.url_for(
@@ -110,7 +114,7 @@ def update_node_detection_point(
 
     # Add an entry to the correct history table based on the node_type.
     crud.record_node_update_history(
-        record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diff=diff, db=db
+        record_node=db_node, action_by=crud.read_user_by_username(username=claims["sub"], db=db), diffs=[diff], db=db
     )
 
     response.headers["Content-Location"] = request.url_for("get_node_detection_point", uuid=uuid)
@@ -134,11 +138,10 @@ def delete_node_detection_point(
     crud.update_node_version(node=db_node, db=db)
 
     # Add an entry to the correct history table based on the node_type.
-    diff = crud.Diff(field="detection_points", removed_from_list=[db_node.value])
     crud.record_node_update_history(
         record_node=db_node.node,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        diff=diff,
+        diffs=[crud.Diff(field="detection_points", added_to_list=[], removed_from_list=[db_node.value])],
         db=db,
     )
 

--- a/backend/app/api/routes/node_relationship.py
+++ b/backend/app/api/routes/node_relationship.py
@@ -76,8 +76,29 @@ helpers.api_route_read(router, get_node_relationship, NodeRelationshipRead)
 #
 
 
-def delete_node_relationship(uuid: UUID, db: Session = Depends(get_db)):
+def delete_node_relationship(
+    uuid: UUID,
+    db: Session = Depends(get_db),
+    claims: dict = Depends(validate_access_token),
+):
+    # Read the relationship to get the impacted node
+    relationship: NodeRelationship = crud.read(uuid=uuid, db_table=NodeRelationship, db=db)
+    node = relationship.node
+    related_node_uuid = relationship.related_node_uuid
+
+    # Removing the relationship counts as modifying the node, so update its version
+    crud.update_node_version(node=node, db=db)
+
+    # Delete the relationship
     crud.delete(uuid=uuid, db_table=NodeRelationship, db=db)
+
+    # Add the node history record
+    crud.record_node_update_history(
+        record_node=node,
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
+        diffs=[crud.Diff(field="relationships", added_to_list=[], removed_from_list=[str(related_node_uuid)])],
+        db=db,
+    )
 
 
 helpers.api_route_delete(router, delete_node_relationship)

--- a/backend/app/api/routes/node_relationship.py
+++ b/backend/app/api/routes/node_relationship.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import select
+from uuid import UUID
+
+from api.models.node_relationship import (
+    NodeRelationshipCreate,
+    NodeRelationshipRead,
+    NodeRelationshipUpdate,
+)
+from api.routes import helpers
+from db import crud
+from db.database import get_db
+from db.schemas.node_relationship import NodeRelationship
+
+
+router = APIRouter(
+    prefix="/node/relationship",
+    tags=["Node Relationship"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_node_relationship(
+    create: NodeRelationshipCreate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    obj: NodeRelationship = crud.create(obj=create, db_table=NodeRelationship, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_node_relationship", uuid=obj.uuid)
+
+
+helpers.api_route_create(router, create_node_relationship)
+
+
+#
+# READ
+#
+
+
+def get_all_node_relationships(db: Session = Depends(get_db)):
+    return paginate(db, select(NodeRelationship).order_by(NodeRelationship.value))
+
+
+def get_node_relationship(uuid: UUID, db: Session = Depends(get_db)):
+    return crud.read(uuid=uuid, db_table=NodeRelationship, db=db)
+
+
+helpers.api_route_read_all(router, get_all_node_relationships, NodeRelationshipRead)
+helpers.api_route_read(router, get_node_relationship, NodeRelationshipRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_node_relationship(
+    uuid: UUID,
+    node_relationship: NodeRelationshipUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    crud.update(uuid=uuid, obj=node_relationship, db_table=NodeRelationship, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_node_relationship", uuid=uuid)
+
+
+helpers.api_route_update(router, update_node_relationship)
+
+
+#
+# DELETE
+#
+
+
+def delete_node_relationship(uuid: UUID, db: Session = Depends(get_db)):
+    crud.delete(uuid=uuid, db_table=NodeRelationship, db=db)
+
+
+helpers.api_route_delete(router, delete_node_relationship)

--- a/backend/app/api/routes/node_relationship.py
+++ b/backend/app/api/routes/node_relationship.py
@@ -1,18 +1,15 @@
 from fastapi import APIRouter, Depends, Request, Response
-from fastapi_pagination.ext.sqlalchemy_future import paginate
 from sqlalchemy.orm import Session
-from sqlalchemy.sql.expression import select
 from uuid import UUID
 
-from api.models.node_relationship import (
-    NodeRelationshipCreate,
-    NodeRelationshipRead,
-    NodeRelationshipUpdate,
-)
+from api.models.node_relationship import NodeRelationshipCreate, NodeRelationshipRead
 from api.routes import helpers
+from core.auth import validate_access_token
 from db import crud
 from db.database import get_db
+from db.schemas.node import Node
 from db.schemas.node_relationship import NodeRelationship
+from db.schemas.node_relationship_type import NodeRelationshipType
 
 
 router = APIRouter(
@@ -31,8 +28,27 @@ def create_node_relationship(
     request: Request,
     response: Response,
     db: Session = Depends(get_db),
+    claims: dict = Depends(validate_access_token),
 ):
-    obj: NodeRelationship = crud.create(obj=create, db_table=NodeRelationship, db=db)
+    # Make sure the nodes actually exist
+    node: Node = crud.read(uuid=create.node_uuid, db_table=Node, db=db)
+    related_node: Node = crud.read(uuid=create.related_node_uuid, db_table=Node, db=db)
+
+    # Make sure the relationship type exists
+    type: NodeRelationshipType = crud.read_by_value(value=create.type, db_table=NodeRelationshipType, db=db)
+
+    # Create the relationship
+    obj = NodeRelationship(uuid=create.uuid, node_uuid=node.uuid, related_node=related_node, type=type)
+    db.add(obj)
+    crud.commit(db)
+
+    # Add the node history record
+    crud.record_node_update_history(
+        record_node=node,
+        action_by=crud.read_user_by_username(username=claims["sub"], db=db),
+        diffs=[crud.Diff(field="relationships", added_to_list=[str(related_node.uuid)], removed_from_list=[])],
+        db=db,
+    )
 
     response.headers["Content-Location"] = request.url_for("get_node_relationship", uuid=obj.uuid)
 
@@ -45,36 +61,11 @@ helpers.api_route_create(router, create_node_relationship)
 #
 
 
-def get_all_node_relationships(db: Session = Depends(get_db)):
-    return paginate(db, select(NodeRelationship).order_by(NodeRelationship.value))
-
-
 def get_node_relationship(uuid: UUID, db: Session = Depends(get_db)):
     return crud.read(uuid=uuid, db_table=NodeRelationship, db=db)
 
 
-helpers.api_route_read_all(router, get_all_node_relationships, NodeRelationshipRead)
 helpers.api_route_read(router, get_node_relationship, NodeRelationshipRead)
-
-
-#
-# UPDATE
-#
-
-
-def update_node_relationship(
-    uuid: UUID,
-    node_relationship: NodeRelationshipUpdate,
-    request: Request,
-    response: Response,
-    db: Session = Depends(get_db),
-):
-    crud.update(uuid=uuid, obj=node_relationship, db_table=NodeRelationship, db=db)
-
-    response.headers["Content-Location"] = request.url_for("get_node_relationship", uuid=uuid)
-
-
-helpers.api_route_update(router, update_node_relationship)
 
 
 #

--- a/backend/app/api/routes/node_relationship.py
+++ b/backend/app/api/routes/node_relationship.py
@@ -42,6 +42,9 @@ def create_node_relationship(
     db.add(obj)
     crud.commit(db)
 
+    # Adding the relationship counts as modifying the node, so update its version
+    crud.update_node_version(node=node, db=db)
+
     # Add the node history record
     crud.record_node_update_history(
         record_node=node,

--- a/backend/app/api/routes/node_relationship_type.py
+++ b/backend/app/api/routes/node_relationship_type.py
@@ -1,0 +1,89 @@
+from fastapi import APIRouter, Depends, Request, Response
+from fastapi_pagination.ext.sqlalchemy_future import paginate
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.expression import select
+from uuid import UUID
+
+from api.models.node_relationship_type import (
+    NodeRelationshipTypeCreate,
+    NodeRelationshipTypeRead,
+    NodeRelationshipTypeUpdate,
+)
+from api.routes import helpers
+from db import crud
+from db.database import get_db
+from db.schemas.node_relationship_type import NodeRelationshipType
+
+
+router = APIRouter(
+    prefix="/node/relationship/type",
+    tags=["Node Relationship Type"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_node_relationship_type(
+    create: NodeRelationshipTypeCreate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    obj: NodeRelationshipType = crud.create(obj=create, db_table=NodeRelationshipType, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_node_relationship_type", uuid=obj.uuid)
+
+
+helpers.api_route_create(router, create_node_relationship_type)
+
+
+#
+# READ
+#
+
+
+def get_all_node_relationship_types(db: Session = Depends(get_db)):
+    return paginate(db, select(NodeRelationshipType).order_by(NodeRelationshipType.value))
+
+
+def get_node_relationship_type(uuid: UUID, db: Session = Depends(get_db)):
+    return crud.read(uuid=uuid, db_table=NodeRelationshipType, db=db)
+
+
+helpers.api_route_read_all(router, get_all_node_relationship_types, NodeRelationshipTypeRead)
+helpers.api_route_read(router, get_node_relationship_type, NodeRelationshipTypeRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_node_relationship_type(
+    uuid: UUID,
+    node_relationship: NodeRelationshipTypeUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    crud.update(uuid=uuid, obj=node_relationship, db_table=NodeRelationshipType, db=db)
+
+    response.headers["Content-Location"] = request.url_for("get_node_relationship_type", uuid=uuid)
+
+
+helpers.api_route_update(router, update_node_relationship_type)
+
+
+#
+# DELETE
+#
+
+
+def delete_node_relationship_type(uuid: UUID, db: Session = Depends(get_db)):
+    crud.delete(uuid=uuid, db_table=NodeRelationshipType, db=db)
+
+
+helpers.api_route_delete(router, delete_node_relationship_type)

--- a/backend/app/api/routes/observable.py
+++ b/backend/app/api/routes/observable.py
@@ -79,12 +79,9 @@ def create_observables(
         crud.commit(db)
 
         # Add an entry to the history table
-        crud.record_create_history(
-            history_table=ObservableHistory,
+        crud.record_node_create_history(
+            record_node=new_observable,
             action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-            record_read_model=ObservableRead,
-            record_table=Observable,
-            record_uuid=new_observable.uuid,
             db=db,
         )
 
@@ -198,12 +195,12 @@ def update_observable(
     crud.commit(db)
 
     # Add the entries to the history table
-    crud.record_update_histories(
-        history_table=ObservableHistory,
+    crud.record_node_update_history(
+        record_node=db_observable,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        record_read_model=ObservableRead,
-        record_table=Observable,
-        record_uuid=db_observable.uuid,
+        # record_read_model=ObservableRead,
+        # record_table=Observable,
+        # record_uuid=db_observable.uuid,
         diffs=diffs,
         db=db,
     )

--- a/backend/app/api/routes/observable.py
+++ b/backend/app/api/routes/observable.py
@@ -198,9 +198,6 @@ def update_observable(
     crud.record_node_update_history(
         record_node=db_observable,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        # record_read_model=ObservableRead,
-        # record_table=Observable,
-        # record_uuid=db_observable.uuid,
         diffs=diffs,
         db=db,
     )

--- a/backend/app/api/routes/user.py
+++ b/backend/app/api/routes/user.py
@@ -59,9 +59,7 @@ def create_user(
     crud.record_create_history(
         history_table=UserHistory,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        record_read_model=UserRead,
-        record_table=User,
-        record_uuid=new_user.uuid,
+        record=new_user,
         db=db,
     )
 
@@ -176,12 +174,10 @@ def update_user(
     crud.commit(db)
 
     # Add the entries to the history table
-    crud.record_update_histories(
+    crud.record_update_history(
         history_table=UserHistory,
         action_by=crud.read_user_by_username(username=claims["sub"], db=db),
-        record_read_model=UserRead,
-        record_table=User,
-        record_uuid=db_user.uuid,
+        record=db_user,
         diffs=diffs,
         db=db,
     )

--- a/backend/app/db/migrations/versions/2d952cc05bfc_initial.py
+++ b/backend/app/db/migrations/versions/2d952cc05bfc_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: 739da2302b99
+Revision ID: 2d952cc05bfc
 Revises: 
-Create Date: 2022-03-22 14:30:53.455822
+Create Date: 2022-03-23 15:58:55.973087
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = '739da2302b99'
+revision = '2d952cc05bfc'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -122,13 +122,13 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_node_directive_value'), 'node_directive', ['value'], unique=True)
-    op.create_table('node_relationship',
+    op.create_table('node_relationship_type',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
     sa.Column('value', sa.String(), nullable=False),
     sa.PrimaryKeyConstraint('uuid')
     )
-    op.create_index(op.f('ix_node_relationship_value'), 'node_relationship', ['value'], unique=True)
+    op.create_index(op.f('ix_node_relationship_type_value'), 'node_relationship_type', ['value'], unique=True)
     op.create_table('node_tag',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -305,6 +305,18 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_node_directive_mapping_directive_uuid'), 'node_directive_mapping', ['directive_uuid'], unique=False)
     op.create_index(op.f('ix_node_directive_mapping_node_uuid'), 'node_directive_mapping', ['node_uuid'], unique=False)
+    op.create_table('node_relationship',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('node_uuid', postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column('related_node_uuid', postgresql.UUID(as_uuid=True), nullable=True),
+    sa.Column('type_uuid', postgresql.UUID(as_uuid=True), nullable=True),
+    sa.ForeignKeyConstraint(['node_uuid'], ['node.uuid'], ),
+    sa.ForeignKeyConstraint(['related_node_uuid'], ['node.uuid'], ),
+    sa.ForeignKeyConstraint(['type_uuid'], ['node_relationship_type.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid'),
+    sa.UniqueConstraint('node_uuid', 'related_node_uuid', 'type_uuid', name='node_related_type_uc')
+    )
+    op.create_index(op.f('ix_node_relationship_node_uuid'), 'node_relationship', ['node_uuid'], unique=False)
     op.create_table('node_tag_mapping',
     sa.Column('node_uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('tag_uuid', postgresql.UUID(as_uuid=True), nullable=False),
@@ -680,6 +692,8 @@ def downgrade() -> None:
     op.drop_index(op.f('ix_node_tag_mapping_tag_uuid'), table_name='node_tag_mapping')
     op.drop_index(op.f('ix_node_tag_mapping_node_uuid'), table_name='node_tag_mapping')
     op.drop_table('node_tag_mapping')
+    op.drop_index(op.f('ix_node_relationship_node_uuid'), table_name='node_relationship')
+    op.drop_table('node_relationship')
     op.drop_index(op.f('ix_node_directive_mapping_node_uuid'), table_name='node_directive_mapping')
     op.drop_index(op.f('ix_node_directive_mapping_directive_uuid'), table_name='node_directive_mapping')
     op.drop_table('node_directive_mapping')
@@ -733,8 +747,8 @@ def downgrade() -> None:
     op.drop_table('node_threat')
     op.drop_index(op.f('ix_node_tag_value'), table_name='node_tag')
     op.drop_table('node_tag')
-    op.drop_index(op.f('ix_node_relationship_value'), table_name='node_relationship')
-    op.drop_table('node_relationship')
+    op.drop_index(op.f('ix_node_relationship_type_value'), table_name='node_relationship_type')
+    op.drop_table('node_relationship_type')
     op.drop_index(op.f('ix_node_directive_value'), table_name='node_directive')
     op.drop_table('node_directive')
     op.drop_table('node')

--- a/backend/app/db/migrations/versions/739da2302b99_initial.py
+++ b/backend/app/db/migrations/versions/739da2302b99_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: ff77f773ba60
+Revision ID: 739da2302b99
 Revises: 
-Create Date: 2022-03-18 20:07:17.475184
+Create Date: 2022-03-22 14:30:53.455822
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = 'ff77f773ba60'
+revision = '739da2302b99'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -122,6 +122,13 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_node_directive_value'), 'node_directive', ['value'], unique=True)
+    op.create_table('node_relationship',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('description', sa.String(), nullable=True),
+    sa.Column('value', sa.String(), nullable=False),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_node_relationship_value'), 'node_relationship', ['value'], unique=True)
     op.create_table('node_tag',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -726,6 +733,8 @@ def downgrade() -> None:
     op.drop_table('node_threat')
     op.drop_index(op.f('ix_node_tag_value'), table_name='node_tag')
     op.drop_table('node_tag')
+    op.drop_index(op.f('ix_node_relationship_value'), table_name='node_relationship')
+    op.drop_table('node_relationship')
     op.drop_index(op.f('ix_node_directive_value'), table_name='node_directive')
     op.drop_table('node_directive')
     op.drop_table('node')

--- a/backend/app/db/schemas/__init__.py
+++ b/backend/app/db/schemas/__init__.py
@@ -31,6 +31,7 @@ from db.schemas.node_comment import NodeComment
 from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_directive_mapping import node_directive_mapping
+from db.schemas.node_relationship import NodeRelationship
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_tag_mapping import node_tag_mapping
 from db.schemas.node_threat import NodeThreat

--- a/backend/app/db/schemas/__init__.py
+++ b/backend/app/db/schemas/__init__.py
@@ -32,6 +32,7 @@ from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_directive_mapping import node_directive_mapping
 from db.schemas.node_relationship import NodeRelationship
+from db.schemas.node_relationship_type import NodeRelationshipType
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_tag_mapping import node_tag_mapping
 from db.schemas.node_threat import NodeThreat

--- a/backend/app/db/schemas/event.py
+++ b/backend/app/db/schemas/event.py
@@ -1,3 +1,5 @@
+import json
+
 from datetime import datetime
 from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
@@ -12,7 +14,7 @@ from db.schemas.event_prevention_tool_mapping import event_prevention_tool_mappi
 from db.schemas.event_remediation_mapping import event_remediation_mapping
 from db.schemas.event_vector_mapping import event_vector_mapping
 from db.schemas.helpers import utcnow
-from db.schemas.history import HistoryMixin
+from db.schemas.history import HasHistory, HistoryMixin
 from db.schemas.node import Node
 
 
@@ -22,7 +24,7 @@ class EventHistory(Base, HistoryMixin):
     record_uuid = Column(UUID(as_uuid=True), ForeignKey("event.uuid"), index=True, nullable=False)
 
 
-class Event(Node):
+class Event(Node, HasHistory):
     __tablename__ = "event"
 
     uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), primary_key=True)
@@ -90,6 +92,10 @@ class Event(Node):
 
     def serialize_for_node_tree(self) -> EventRead:
         return EventRead(**self.__dict__)
+
+    @property
+    def history_snapshot(self):
+        return json.loads(EventRead(**self.__dict__).json())
 
     @property
     def auto_alert_time(self) -> Optional[datetime]:

--- a/backend/app/db/schemas/history.py
+++ b/backend/app/db/schemas/history.py
@@ -33,3 +33,10 @@ class HistoryMixin:
     @declared_attr
     def action_by(cls):
         return relationship("User", primaryjoin="User.uuid == %s.action_by_user_uuid" % cls.__name__)
+
+
+class HasHistory:
+    @property
+    def history_snapshot(self):
+        """Returns the JSON view of the database object that will be saved as the snapshot in the history table"""
+        raise NotImplementedError()

--- a/backend/app/db/schemas/node.py
+++ b/backend/app/db/schemas/node.py
@@ -74,6 +74,13 @@ class Node(Base):
 
     node_type = Column(String)
 
+    relationships = relationship(
+        "NodeRelationship",
+        primaryjoin="NodeRelationship.node_uuid == Node.uuid",
+        viewonly=True,
+        lazy="selectin",
+    )
+
     tags = relationship("NodeTag", secondary=node_tag_mapping, lazy="selectin")
 
     threat_actors = relationship("NodeThreatActor", secondary=node_threat_actor_mapping, lazy="selectin")

--- a/backend/app/db/schemas/node_relationship.py
+++ b/backend/app/db/schemas/node_relationship.py
@@ -12,6 +12,9 @@ class NodeRelationship(Base):
 
     node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), index=True)
 
+    # The node relationship is not loaded automatically
+    node = relationship("Node", foreign_keys=[node_uuid])
+
     related_node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"))
 
     related_node = relationship("Node", foreign_keys=[related_node_uuid], lazy="selectin")

--- a/backend/app/db/schemas/node_relationship.py
+++ b/backend/app/db/schemas/node_relationship.py
@@ -1,0 +1,14 @@
+from sqlalchemy import func, Column, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from db.database import Base
+
+
+class NodeRelationship(Base):
+    __tablename__ = "node_relationship"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    description = Column(String)
+
+    value = Column(String, nullable=False, unique=True, index=True)

--- a/backend/app/db/schemas/node_relationship.py
+++ b/backend/app/db/schemas/node_relationship.py
@@ -1,5 +1,6 @@
-from sqlalchemy import func, Column, String
+from sqlalchemy import Column, ForeignKey, func, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
 
 from db.database import Base
 
@@ -9,6 +10,14 @@ class NodeRelationship(Base):
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
 
-    description = Column(String)
+    node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), index=True)
 
-    value = Column(String, nullable=False, unique=True, index=True)
+    related_node_uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"))
+
+    related_node = relationship("Node", foreign_keys=[related_node_uuid], lazy="selectin")
+
+    type_uuid = Column(UUID(as_uuid=True), ForeignKey("node_relationship_type.uuid"))
+
+    type = relationship("NodeRelationshipType", foreign_keys=[type_uuid], lazy="selectin")
+
+    __table_args__ = (UniqueConstraint("node_uuid", "related_node_uuid", "type_uuid", name="node_related_type_uc"),)

--- a/backend/app/db/schemas/node_relationship_type.py
+++ b/backend/app/db/schemas/node_relationship_type.py
@@ -1,0 +1,14 @@
+from sqlalchemy import func, Column, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from db.database import Base
+
+
+class NodeRelationshipType(Base):
+    __tablename__ = "node_relationship_type"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    description = Column(String)
+
+    value = Column(String, nullable=False, unique=True, index=True)

--- a/backend/app/db/schemas/user.py
+++ b/backend/app/db/schemas/user.py
@@ -1,9 +1,12 @@
+import json
+
 from sqlalchemy import Boolean, Column, ForeignKey, func, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
+from api.models.user import UserRead
 from db.database import Base
-from db.schemas.history import HistoryMixin
+from db.schemas.history import HasHistory, HistoryMixin
 from db.schemas.user_role_mapping import user_role_mapping
 
 
@@ -13,7 +16,7 @@ class UserHistory(Base, HistoryMixin):
     record_uuid = Column(UUID(as_uuid=True), ForeignKey("user.uuid"), index=True, nullable=False)
 
 
-class User(Base):
+class User(Base, HasHistory):
     __tablename__ = "user"
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
@@ -50,3 +53,7 @@ class User(Base):
     username = Column(String, unique=True, nullable=False)
 
     refresh_token = Column(String)
+
+    @property
+    def history_snapshot(self):
+        return json.loads(UserRead(**self.__dict__).json())

--- a/backend/app/etc/defaults.yml
+++ b/backend/app/etc/defaults.yml
@@ -155,6 +155,12 @@ node_threat_type:
     - rat
     - rootkit
     - some internal value
+node_relationship_type:
+  - DOWNLOADED_FROM
+  - EXECUTED_ON
+  - IS_HASH_OF
+  - LOGGED_INTO
+  - REDIRECTED_FROM
 observable_type:
   - file
   - ipv4

--- a/backend/app/seed.py
+++ b/backend/app/seed.py
@@ -19,6 +19,7 @@ from db.schemas.event_source import EventSource
 from db.schemas.event_status import EventStatus
 from db.schemas.event_type import EventType
 from db.schemas.event_vector import EventVector
+from db.schemas.node_relationship_type import NodeRelationshipType
 from db.schemas.node_threat_type import NodeThreatType
 from db.schemas.observable_type import ObservableType
 from db.schemas.queue import Queue
@@ -140,6 +141,11 @@ def seed(db: Session):
         add_queueable_values(
             db=db, db_table=EventVector, queues=queues, data=data, key="event_vector", print_value="event vector"
         )
+
+    if "node_relationship_type" in data:
+        for value in data["node_relationship_type"]:
+            db.add(NodeRelationshipType(value=value))
+            print(f"Adding node relationship type: {value}")
 
     if "node_threat_type" in data:
         add_queueable_values(

--- a/backend/app/tests/api/event/test_read.py
+++ b/backend/app/tests/api/event/test_read.py
@@ -299,7 +299,6 @@ def test_summary_email_headers_body(client_valid_access_token, db):
 
     # The email headers/body summary should now have the details of the second alert's email
     get = client_valid_access_token.get(f"/api/event/{event.uuid}/summary/email_headers_body")
-    print(get.json())
     assert get.json()["alert_uuid"] == str(alert_tree2.node_uuid)
     assert get.json()["headers"] == "headers2"
     assert get.json()["body_html"] == "<p>body2</p>"

--- a/backend/app/tests/api/event/test_update.py
+++ b/backend/app/tests/api/event/test_update.py
@@ -495,7 +495,6 @@ def test_update_vectors(client_valid_access_token, db):
 
     # Verify the history
     history = client_valid_access_token.get(f"/api/event/{event.uuid}/history")
-    print(history.json())
     assert history.json()["total"] == 3
     assert history.json()["items"][2]["action"] == "UPDATE"
     assert history.json()["items"][2]["action_by"]["username"] == "analyst"

--- a/backend/app/tests/api/node_comment/test_create.py
+++ b/backend/app/tests/api/node_comment/test_create.py
@@ -118,7 +118,7 @@ def test_create_verify_history_alerts(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
 
@@ -142,7 +142,7 @@ def test_create_verify_history_events(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
 
 
@@ -167,7 +167,7 @@ def test_create_verify_history_observables(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
 
 

--- a/backend/app/tests/api/node_comment/test_delete.py
+++ b/backend/app/tests/api/node_comment/test_delete.py
@@ -57,7 +57,7 @@ def test_delete_alerts(client_valid_access_token, db):
     assert history.json()["items"][2]["field"] == "comments"
     assert history.json()["items"][2]["diff"]["old_value"] is None
     assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
     assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
     assert history.json()["items"][2]["snapshot"]["name"] == "Test Alert"
 
@@ -88,7 +88,7 @@ def test_delete_events(client_valid_access_token, db):
     assert history.json()["items"][2]["field"] == "comments"
     assert history.json()["items"][2]["diff"]["old_value"] is None
     assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
     assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
     assert history.json()["items"][2]["snapshot"]["name"] == "Test Event"
 
@@ -120,6 +120,6 @@ def test_delete_observables(client_valid_access_token, db):
     assert history.json()["items"][2]["field"] == "comments"
     assert history.json()["items"][2]["diff"]["old_value"] is None
     assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
     assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
     assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/node_comment/test_update.py
+++ b/backend/app/tests/api/node_comment/test_update.py
@@ -79,7 +79,7 @@ def test_update_alerts(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["name"] == "Test Alert"
 
     assert history.json()["items"][2]["action"] == "UPDATE"
@@ -119,7 +119,7 @@ def test_update_events(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["name"] == "Test Event"
 
     assert history.json()["items"][2]["action"] == "UPDATE"
@@ -160,7 +160,7 @@ def test_update_observables(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
 
     assert history.json()["items"][2]["action"] == "UPDATE"

--- a/backend/app/tests/api/node_detection_point/test_create.py
+++ b/backend/app/tests/api/node_detection_point/test_create.py
@@ -118,7 +118,7 @@ def test_create_verify_history_observables(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
 
 

--- a/backend/app/tests/api/node_detection_point/test_delete.py
+++ b/backend/app/tests/api/node_detection_point/test_delete.py
@@ -58,6 +58,6 @@ def test_delete(client_valid_access_token, db):
     assert history.json()["items"][2]["field"] == "detection_points"
     assert history.json()["items"][2]["diff"]["old_value"] is None
     assert history.json()["items"][2]["diff"]["new_value"] is None
-    assert history.json()["items"][2]["diff"]["added_to_list"] is None
+    assert history.json()["items"][2]["diff"]["added_to_list"] == []
     assert history.json()["items"][2]["diff"]["removed_from_list"] == ["test"]
     assert history.json()["items"][2]["snapshot"]["value"] == "test_value"

--- a/backend/app/tests/api/node_detection_point/test_update.py
+++ b/backend/app/tests/api/node_detection_point/test_update.py
@@ -89,7 +89,7 @@ def test_update_observables(client_valid_access_token, db):
     assert history.json()["items"][1]["diff"]["old_value"] is None
     assert history.json()["items"][1]["diff"]["new_value"] is None
     assert history.json()["items"][1]["diff"]["added_to_list"] == ["test"]
-    assert history.json()["items"][1]["diff"]["removed_from_list"] is None
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == []
     assert history.json()["items"][1]["snapshot"]["value"] == "test_value"
 
     assert history.json()["items"][2]["action"] == "UPDATE"

--- a/backend/app/tests/api/node_relationship/test_create.py
+++ b/backend/app/tests/api/node_relationship/test_create.py
@@ -162,7 +162,7 @@ def test_create_valid_required_fields(client_valid_access_token, db):
     assert get.json()["type"]["value"] == "test_rel"
 
 
-def test_create_verify_observable_history(client_valid_access_token, db):
+def test_create_verify_observable(client_valid_access_token, db):
     # Create some nodes with relationships
     #
     # alert
@@ -175,6 +175,7 @@ def test_create_verify_observable_history(client_valid_access_token, db):
     observable_tree2 = helpers.create_observable(
         type="test_type", value="test_value2", parent_tree=analysis_tree, db=db
     )
+    initial_version = observable_tree2.node.version
     helpers.create_node_relationship_type(value="IS_HASH_OF", db=db)
 
     # Create the node relationship
@@ -186,6 +187,9 @@ def test_create_verify_observable_history(client_valid_access_token, db):
 
     create = client_valid_access_token.post("/api/node/relationship/", json=create_json)
     assert create.status_code == status.HTTP_201_CREATED
+
+    # Adding a relationship counts as modifying the node, so it should have a new version
+    assert observable_tree2.node.version != initial_version
 
     # Verify the observable history. The first record is for creating the observable, and
     # the second record is from adding the node relationship.

--- a/backend/app/tests/api/node_relationship/test_create.py
+++ b/backend/app/tests/api/node_relationship/test_create.py
@@ -1,0 +1,91 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client_valid_access_token, key, value):
+    create_json = {"value": "test"}
+    create_json[key] = value
+    create = client_valid_access_token.post("/api/node/relationship/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("uuid"),
+        ("value"),
+    ],
+)
+def test_create_duplicate_unique_fields(client_valid_access_token, key):
+    # Create an object
+    create1_json = {"uuid": str(uuid.uuid4()), "value": "test"}
+    client_valid_access_token.post("/api/node/relationship/", json=create1_json)
+
+    # Ensure you cannot create another object with the same unique field value
+    create2_json = {"value": "test2"}
+    create2_json[key] = create1_json[key]
+    create2 = client_valid_access_token.post("/api/node/relationship/", json=create2_json)
+    assert create2.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_create_missing_required_fields(client_valid_access_token, key):
+    create_json = {"value": "test"}
+    del create_json[key]
+    create = client_valid_access_token.post("/api/node/relationship/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("description", None), ("description", "test"), ("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client_valid_access_token, key, value):
+    # Create the object
+    create = client_valid_access_token.post("/api/node/relationship/", json={key: value, "value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client_valid_access_token):
+    # Create the object
+    create = client_valid_access_token.post("/api/node/relationship/", json={"value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()["value"] == "test"

--- a/backend/app/tests/api/node_relationship/test_delete.py
+++ b/backend/app/tests/api/node_relationship/test_delete.py
@@ -1,0 +1,48 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+"""
+NOTE: There are no tests for the foreign key constraints. The DELETE endpoint will need to be updated once the endpoints
+are in place in order to account for this.
+"""
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete("/api/node/relationship/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client_valid_access_token):
+    delete = client_valid_access_token.delete(f"/api/node/relationship/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete(client_valid_access_token, db):
+    # Create the object
+    obj = helpers.create_node_relationship(value="test", db=db)
+
+    # Read it back
+    get = client_valid_access_token.get(f"/api/node/relationship/{obj.uuid}")
+    assert get.status_code == status.HTTP_200_OK
+
+    # Delete it
+    delete = client_valid_access_token.delete(f"/api/node/relationship/{obj.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Make sure it is gone
+    get = client_valid_access_token.get(f"/api/node/relationship/{obj.uuid}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_relationship/test_delete.py
+++ b/backend/app/tests/api/node_relationship/test_delete.py
@@ -50,3 +50,43 @@ def test_delete(client_valid_access_token, db):
     # Make sure it is gone
     get = client_valid_access_token.get(f"/api/node/relationship/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_verify_observable(client_valid_access_token, db):
+    # Create some nodes with relationships
+    #
+    # alert
+    #   analysis
+    #     o1
+    #     o2 - IS_HASH_OF o1
+    alert_tree = helpers.create_alert(db=db)
+    analysis_tree = helpers.create_analysis(db=db, parent_tree=alert_tree)
+    observable_tree1 = helpers.create_observable(type="test_type", value="test_value", parent_tree=analysis_tree, db=db)
+    observable_tree2 = helpers.create_observable(
+        type="test_type", value="test_value2", parent_tree=analysis_tree, db=db
+    )
+    initial_version = observable_tree2.node.version
+    relationship = helpers.create_node_relationship(
+        node=observable_tree2.node, related_node=observable_tree1.node, type="IS_HASH_OF", db=db
+    )
+
+    # Delete the relationship
+    delete = client_valid_access_token.delete(f"/api/node/relationship/{relationship.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+
+    # Removing a relationship counts as modifying the node, so it should have a new version
+    assert observable_tree2.node.version != initial_version
+
+    # Verify the observable history. The first record is for creating the observable, and
+    # the second record is from removing the node relationship.
+    history = client_valid_access_token.get(f"/api/observable/{observable_tree2.node_uuid}/history")
+    assert len(history.json()["items"]) == 2
+    assert history.json()["items"][1]["action"] == "UPDATE"
+    assert history.json()["items"][1]["action_by"]["username"] == "analyst"
+    assert history.json()["items"][1]["record_uuid"] == str(observable_tree2.node_uuid)
+    assert history.json()["items"][1]["field"] == "relationships"
+    assert history.json()["items"][1]["diff"]["old_value"] is None
+    assert history.json()["items"][1]["diff"]["new_value"] is None
+    assert history.json()["items"][1]["diff"]["added_to_list"] == []
+    assert history.json()["items"][1]["diff"]["removed_from_list"] == [str(observable_tree1.node_uuid)]
+    assert history.json()["items"][1]["snapshot"]["observable_relationships"] == []

--- a/backend/app/tests/api/node_relationship/test_read.py
+++ b/backend/app/tests/api/node_relationship/test_read.py
@@ -2,8 +2,6 @@ import uuid
 
 from fastapi import status
 
-from tests import helpers
-
 
 #
 # INVALID TESTS
@@ -25,18 +23,4 @@ def test_get_nonexistent_uuid(client_valid_access_token):
 #
 
 
-def test_get_all(client_valid_access_token, db):
-    # Create some objects
-    helpers.create_node_relationship(value="test", db=db)
-    helpers.create_node_relationship(value="test2", db=db)
-
-    # Read them back
-    get = client_valid_access_token.get("/api/node/relationship/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 2
-
-
-def test_get_all_empty(client_valid_access_token):
-    get = client_valid_access_token.get("/api/node/relationship/")
-    assert get.status_code == status.HTTP_200_OK
-    assert get.json()["total"] == 0
+# There is no "get_all" endpoint for node relationships

--- a/backend/app/tests/api/node_relationship/test_read.py
+++ b/backend/app/tests/api/node_relationship/test_read.py
@@ -1,0 +1,42 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/relationship/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.get(f"/api/node/relationship/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_all(client_valid_access_token, db):
+    # Create some objects
+    helpers.create_node_relationship(value="test", db=db)
+    helpers.create_node_relationship(value="test2", db=db)
+
+    # Read them back
+    get = client_valid_access_token.get("/api/node/relationship/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 2
+
+
+def test_get_all_empty(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/relationship/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_relationship/test_update.py
+++ b/backend/app/tests/api/node_relationship/test_update.py
@@ -1,0 +1,79 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_update_invalid_fields(client_valid_access_token, key, value):
+    update = client_valid_access_token.patch(f"/api/node/relationship/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_invalid_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch("/api/node/relationship/1", json={"value": "test"})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
+    # Create some objects
+    obj1 = helpers.create_node_relationship(value="test", db=db)
+    obj2 = helpers.create_node_relationship(value="test2", db=db)
+
+    # Ensure you cannot update a unique field to a value that already exists
+    update = client_valid_access_token.patch(f"/api/node/relationship/{obj2.uuid}", json={key: getattr(obj1, key)})
+    assert update.status_code == status.HTTP_409_CONFLICT
+
+
+def test_update_nonexistent_uuid(client_valid_access_token):
+    update = client_valid_access_token.patch(f"/api/node/relationship/{uuid.uuid4()}", json={"value": "test"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,initial_value,updated_value",
+    [
+        ("description", None, "test"),
+        ("description", "test", "test"),
+        ("value", "test", "test2"),
+        ("value", "test", "test"),
+    ],
+)
+def test_update(client_valid_access_token, db, key, initial_value, updated_value):
+    # Create the object
+    obj = helpers.create_node_relationship(value="test", db=db)
+
+    # Set the initial value
+    setattr(obj, key, initial_value)
+
+    # Update it
+    update = client_valid_access_token.patch(f"/api/node/relationship/{obj.uuid}", json={key: updated_value})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/node_relationship_type/test_create.py
+++ b/backend/app/tests/api/node_relationship_type/test_create.py
@@ -1,0 +1,91 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client_valid_access_token, key, value):
+    create_json = {"value": "test"}
+    create_json[key] = value
+    create = client_valid_access_token.post("/api/node/relationship/type/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("uuid"),
+        ("value"),
+    ],
+)
+def test_create_duplicate_unique_fields(client_valid_access_token, key):
+    # Create an object
+    create1_json = {"uuid": str(uuid.uuid4()), "value": "test"}
+    client_valid_access_token.post("/api/node/relationship/type/", json=create1_json)
+
+    # Ensure you cannot create another object with the same unique field value
+    create2_json = {"value": "test2"}
+    create2_json[key] = create1_json[key]
+    create2 = client_valid_access_token.post("/api/node/relationship/type/", json=create2_json)
+    assert create2.status_code == status.HTTP_409_CONFLICT
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_create_missing_required_fields(client_valid_access_token, key):
+    create_json = {"value": "test"}
+    del create_json[key]
+    create = client_valid_access_token.post("/api/node/relationship/type/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("description", None), ("description", "test"), ("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client_valid_access_token, key, value):
+    # Create the object
+    create = client_valid_access_token.post("/api/node/relationship/type/", json={key: value, "value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client_valid_access_token):
+    # Create the object
+    create = client_valid_access_token.post("/api/node/relationship/type/", json={"value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client_valid_access_token.get(create.headers["Content-Location"])
+    assert get.json()["value"] == "test"

--- a/backend/app/tests/api/node_relationship_type/test_delete.py
+++ b/backend/app/tests/api/node_relationship_type/test_delete.py
@@ -17,12 +17,12 @@ are in place in order to account for this.
 
 
 def test_delete_invalid_uuid(client_valid_access_token):
-    delete = client_valid_access_token.delete("/api/node/relationship/1")
+    delete = client_valid_access_token.delete("/api/node/relationship/type/1")
     assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_delete_nonexistent_uuid(client_valid_access_token):
-    delete = client_valid_access_token.delete(f"/api/node/relationship/{uuid.uuid4()}")
+    delete = client_valid_access_token.delete(f"/api/node/relationship/type/{uuid.uuid4()}")
     assert delete.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -32,21 +32,17 @@ def test_delete_nonexistent_uuid(client_valid_access_token):
 
 
 def test_delete(client_valid_access_token, db):
-    # Create some nodes
-    alert_tree1 = helpers.create_alert(db=db)
-    alert_tree2 = helpers.create_alert(db=db)
-
     # Create the object
-    obj = helpers.create_node_relationship(node=alert_tree1.node, related_node=alert_tree2.node, type="test_rel", db=db)
+    obj = helpers.create_node_relationship_type(value="test", db=db)
 
     # Read it back
-    get = client_valid_access_token.get(f"/api/node/relationship/{obj.uuid}")
+    get = client_valid_access_token.get(f"/api/node/relationship/type/{obj.uuid}")
     assert get.status_code == status.HTTP_200_OK
 
     # Delete it
-    delete = client_valid_access_token.delete(f"/api/node/relationship/{obj.uuid}")
+    delete = client_valid_access_token.delete(f"/api/node/relationship/type/{obj.uuid}")
     assert delete.status_code == status.HTTP_204_NO_CONTENT
 
     # Make sure it is gone
-    get = client_valid_access_token.get(f"/api/node/relationship/{obj.uuid}")
+    get = client_valid_access_token.get(f"/api/node/relationship/type/{obj.uuid}")
     assert get.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/app/tests/api/node_relationship_type/test_read.py
+++ b/backend/app/tests/api/node_relationship_type/test_read.py
@@ -1,0 +1,42 @@
+import uuid
+
+from fastapi import status
+
+from tests import helpers
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/relationship/type/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client_valid_access_token):
+    get = client_valid_access_token.get(f"/api/node/relationship/type/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_all(client_valid_access_token, db):
+    # Create some objects
+    helpers.create_node_relationship_type(value="test", db=db)
+    helpers.create_node_relationship_type(value="test2", db=db)
+
+    # Read them back
+    get = client_valid_access_token.get("/api/node/relationship/type/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 2
+
+
+def test_get_all_empty(client_valid_access_token):
+    get = client_valid_access_token.get("/api/node/relationship/type/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 0

--- a/backend/app/tests/api/node_relationship_type/test_update.py
+++ b/backend/app/tests/api/node_relationship_type/test_update.py
@@ -22,12 +22,12 @@ from tests import helpers
     ],
 )
 def test_update_invalid_fields(client_valid_access_token, key, value):
-    update = client_valid_access_token.patch(f"/api/node/relationship/{uuid.uuid4()}", json={key: value})
+    update = client_valid_access_token.patch(f"/api/node/relationship/type/{uuid.uuid4()}", json={key: value})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
 def test_update_invalid_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch("/api/node/relationship/1", json={"value": "test"})
+    update = client_valid_access_token.patch("/api/node/relationship/type/1", json={"value": "test"})
     assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -39,16 +39,16 @@ def test_update_invalid_uuid(client_valid_access_token):
 )
 def test_update_duplicate_unique_fields(client_valid_access_token, db, key):
     # Create some objects
-    obj1 = helpers.create_node_relationship(value="test", db=db)
-    obj2 = helpers.create_node_relationship(value="test2", db=db)
+    obj1 = helpers.create_node_relationship_type(value="test", db=db)
+    obj2 = helpers.create_node_relationship_type(value="test2", db=db)
 
     # Ensure you cannot update a unique field to a value that already exists
-    update = client_valid_access_token.patch(f"/api/node/relationship/{obj2.uuid}", json={key: getattr(obj1, key)})
+    update = client_valid_access_token.patch(f"/api/node/relationship/type/{obj2.uuid}", json={key: getattr(obj1, key)})
     assert update.status_code == status.HTTP_409_CONFLICT
 
 
 def test_update_nonexistent_uuid(client_valid_access_token):
-    update = client_valid_access_token.patch(f"/api/node/relationship/{uuid.uuid4()}", json={"value": "test"})
+    update = client_valid_access_token.patch(f"/api/node/relationship/type/{uuid.uuid4()}", json={"value": "test"})
     assert update.status_code == status.HTTP_404_NOT_FOUND
 
 
@@ -68,12 +68,12 @@ def test_update_nonexistent_uuid(client_valid_access_token):
 )
 def test_update(client_valid_access_token, db, key, initial_value, updated_value):
     # Create the object
-    obj = helpers.create_node_relationship(value="test", db=db)
+    obj = helpers.create_node_relationship_type(value="test", db=db)
 
     # Set the initial value
     setattr(obj, key, initial_value)
 
     # Update it
-    update = client_valid_access_token.patch(f"/api/node/relationship/{obj.uuid}", json={key: updated_value})
+    update = client_valid_access_token.patch(f"/api/node/relationship/type/{obj.uuid}", json={key: updated_value})
     assert update.status_code == status.HTTP_204_NO_CONTENT
     assert getattr(obj, key) == updated_value

--- a/backend/app/tests/api/observable/test_read.py
+++ b/backend/app/tests/api/observable/test_read.py
@@ -53,3 +53,40 @@ def test_get_all_empty(client_valid_access_token):
     get = client_valid_access_token.get("/api/observable/")
     assert get.status_code == status.HTTP_200_OK
     assert get.json()["total"] == 0
+
+
+def test_observable_relationships(client_valid_access_token, db):
+    # Create some nodes with relationships
+    #
+    # alert
+    #   analysis
+    #     o1
+    #     o2
+    #     o3 - IS_HASH_OF o1, IS_EQUAL_TO o2, BLAH analysis
+    alert_tree = helpers.create_alert(db=db)
+    analysis_tree = helpers.create_analysis(db=db, parent_tree=alert_tree)
+    observable_tree1 = helpers.create_observable(type="test_type", value="test_value", parent_tree=analysis_tree, db=db)
+    observable_tree2 = helpers.create_observable(
+        type="test_type", value="test_value2", parent_tree=analysis_tree, db=db
+    )
+    observable_tree3 = helpers.create_observable(
+        type="test_type", value="test_value3", parent_tree=analysis_tree, db=db
+    )
+    helpers.create_node_relationship(
+        node=observable_tree3.node, related_node=observable_tree1.node, type="IS_HASH_OF", db=db
+    )
+    helpers.create_node_relationship(
+        node=observable_tree3.node, related_node=observable_tree2.node, type="IS_EQUAL_TO", db=db
+    )
+    helpers.create_node_relationship(node=observable_tree3.node, related_node=analysis_tree.node, type="BLAH", db=db)
+
+    # The o2 observable has three relationships but only two observable relationship. The observable relationships
+    # should be sorted by the related observable's type then value.
+    get = client_valid_access_token.get(f"/api/observable/{observable_tree3.node_uuid}")
+    assert get.status_code == status.HTTP_200_OK
+    assert len(observable_tree3.node.relationships) == 3
+    assert len(get.json()["observable_relationships"]) == 2
+    assert get.json()["observable_relationships"][0]["type"]["value"] == "IS_HASH_OF"
+    assert get.json()["observable_relationships"][0]["related_node"]["uuid"] == str(observable_tree1.node_uuid)
+    assert get.json()["observable_relationships"][1]["type"]["value"] == "IS_EQUAL_TO"
+    assert get.json()["observable_relationships"][1]["related_node"]["uuid"] == str(observable_tree2.node_uuid)

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -33,6 +33,7 @@ from db.schemas.node import Node
 from db.schemas.node_comment import NodeComment
 from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
+from db.schemas.node_relationship import NodeRelationship
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
 from db.schemas.node_threat_actor import NodeThreatActor
@@ -502,6 +503,10 @@ def create_node_detection_point(
 
 def create_node_directive(value: str, db: Session) -> NodeDirective:
     return _create_basic_object(db_table=NodeDirective, value=value, db=db)
+
+
+def create_node_relationship(value: str, db: Session) -> NodeRelationship:
+    return _create_basic_object(db_table=NodeRelationship, value=value, db=db)
 
 
 def create_node_tag(value: str, db: Session) -> NodeTag:

--- a/backend/app/tests/helpers.py
+++ b/backend/app/tests/helpers.py
@@ -8,20 +8,16 @@ from sqlalchemy.orm.decl_api import DeclarativeMeta
 from typing import Dict, List, Optional, Union
 from uuid import UUID
 
-from api.models.alert import AlertRead
-from api.models.event import EventRead
-from api.models.observable import ObservableRead
-from api.models.user import UserRead
 from core.auth import hash_password
 from db import crud
-from db.schemas.alert import Alert, AlertHistory
+from db.schemas.alert import Alert
 from db.schemas.alert_disposition import AlertDisposition
 from db.schemas.alert_tool import AlertTool
 from db.schemas.alert_tool_instance import AlertToolInstance
 from db.schemas.alert_type import AlertType
 from db.schemas.analysis import Analysis
 from db.schemas.analysis_module_type import AnalysisModuleType
-from db.schemas.event import Event, EventHistory
+from db.schemas.event import Event
 from db.schemas.event_prevention_tool import EventPreventionTool
 from db.schemas.event_remediation import EventRemediation
 from db.schemas.event_risk_level import EventRiskLevel
@@ -34,12 +30,13 @@ from db.schemas.node_comment import NodeComment
 from db.schemas.node_detection_point import NodeDetectionPoint
 from db.schemas.node_directive import NodeDirective
 from db.schemas.node_relationship import NodeRelationship
+from db.schemas.node_relationship_type import NodeRelationshipType
 from db.schemas.node_tag import NodeTag
 from db.schemas.node_threat import NodeThreat
 from db.schemas.node_threat_actor import NodeThreatActor
 from db.schemas.node_threat_type import NodeThreatType
 from db.schemas.node_tree import NodeTree
-from db.schemas.observable import Observable, ObservableHistory
+from db.schemas.observable import Observable
 from db.schemas.observable_type import ObservableType
 from db.schemas.queue import Queue
 from db.schemas.user import User, UserHistory
@@ -178,23 +175,17 @@ def create_alert(
     crud.commit(db)
 
     # Add an entry to the history table
-    crud.record_create_history(
-        history_table=AlertHistory,
+    crud.record_node_create_history(
+        record_node=alert,
         action_by=create_user(username="analyst", db=db),
-        record_read_model=AlertRead,
-        record_table=Alert,
-        record_uuid=alert.uuid,
         db=db,
     )
 
     if diffs and updated_by_user:
-        crud.record_update_histories(
-            history_table=AlertHistory,
+        crud.record_node_update_history(
+            record_node=alert,
             action_by=create_user(username=updated_by_user, db=db),
             action_time=update_time,
-            record_read_model=AlertRead,
-            record_table=Alert,
-            record_uuid=alert.uuid,
             diffs=diffs,
             db=db,
         )
@@ -377,12 +368,9 @@ def create_event(
     db.add(obj)
     crud.commit(db)
 
-    crud.record_create_history(
-        history_table=EventHistory,
+    crud.record_node_create_history(
+        record_node=obj,
         action_by=create_user(username="analyst", db=db),
-        record_read_model=EventRead,
-        record_table=Event,
-        record_uuid=obj.uuid,
         db=db,
     )
 
@@ -474,7 +462,8 @@ def create_node_comment(
     crud.record_node_update_history(
         record_node=node,
         action_by=create_user(username=username, display_name=username, db=db),
-        diff=crud.Diff(field="comments", added_to_list=[obj.value]),
+        action_time=insert_time,
+        diffs=[crud.Diff(field="comments", added_to_list=[obj.value], removed_from_list=[])],
         db=db,
     )
 
@@ -494,7 +483,8 @@ def create_node_detection_point(
     crud.record_node_update_history(
         record_node=node,
         action_by=create_user(username=username, display_name=username, db=db),
-        diff=crud.Diff(field="detection_points", added_to_list=[obj.value]),
+        action_time=insert_time,
+        diffs=[crud.Diff(field="detection_points", added_to_list=[obj.value], removed_from_list=[])],
         db=db,
     )
 
@@ -505,8 +495,17 @@ def create_node_directive(value: str, db: Session) -> NodeDirective:
     return _create_basic_object(db_table=NodeDirective, value=value, db=db)
 
 
-def create_node_relationship(value: str, db: Session) -> NodeRelationship:
-    return _create_basic_object(db_table=NodeRelationship, value=value, db=db)
+def create_node_relationship(node: Node, related_node: Node, type: str, db: Session) -> NodeRelationship:
+    obj = NodeRelationship(
+        node_uuid=node.uuid, related_node=related_node, type=create_node_relationship_type(value=type, db=db)
+    )
+    db.add(obj)
+    crud.commit(db)
+    return obj
+
+
+def create_node_relationship_type(value: str, db: Session) -> NodeRelationshipType:
+    return _create_basic_object(db_table=NodeRelationshipType, value=value, db=db)
 
 
 def create_node_tag(value: str, db: Session) -> NodeTag:
@@ -613,12 +612,9 @@ def create_observable(
 
     crud.commit(db)
 
-    crud.record_create_history(
-        history_table=ObservableHistory,
+    crud.record_node_create_history(
+        record_node=obj,
         action_by=create_user(username="analyst", db=db),
-        record_read_model=ObservableRead,
-        record_table=Observable,
-        record_uuid=obj.uuid,
         db=db,
     )
 
@@ -671,9 +667,7 @@ def create_user(
     crud.record_create_history(
         history_table=UserHistory,
         action_by=obj,
-        record_read_model=UserRead,
-        record_table=User,
-        record_uuid=obj.uuid,
+        record=obj,
         db=db,
     )
 

--- a/frontend/src/models/nodeRelationship.ts
+++ b/frontend/src/models/nodeRelationship.ts
@@ -1,0 +1,18 @@
+import { UUID } from "./base";
+import { nodeRead } from "./node";
+import { nodeRelationshipTypeRead } from "./nodeRelationshipType";
+
+export interface nodeRelationshipCreate {
+  nodeUuid: UUID;
+  relatedNodeUuid: UUID;
+  type: string;
+  uuid?: UUID;
+  [key: string]: unknown;
+}
+
+export interface nodeRelationshipRead {
+  nodeUuid: UUID;
+  relatedNode: nodeRead;
+  uuid: UUID;
+  type: nodeRelationshipTypeRead;
+}

--- a/frontend/src/models/nodeRelationshipType.ts
+++ b/frontend/src/models/nodeRelationshipType.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type nodeRelationshipTypeCreate = genericObjectCreate;
+
+export type nodeRelationshipTypeRead = genericObjectRead;
+
+export interface nodeRelationshipTypeReadPage extends genericObjectReadPage {
+  items: nodeRelationshipTypeRead[];
+}
+
+export type nodeRelationshipTypeUpdate = genericObjectUpdate;

--- a/frontend/src/models/observable.ts
+++ b/frontend/src/models/observable.ts
@@ -9,6 +9,7 @@ import {
 } from "./node";
 import { nodeCommentRead } from "./nodeComment";
 import { nodeDirectiveRead } from "./nodeDirective";
+import { nodeRelationshipRead } from "./nodeRelationship";
 import { nodeTagRead } from "./nodeTag";
 import { nodeThreatRead } from "./nodeThreat";
 import { nodeThreatActorRead } from "./nodeThreatActor";
@@ -36,6 +37,7 @@ export interface observableRead extends nodeRead {
   directives: nodeDirectiveRead[];
   expiresOn: Date | null;
   forDetection: boolean;
+  observableRelationships: observableRelationshipRead[];
   redirectionUuid: UUID | null;
   tags: nodeTagRead[];
   threatActors: nodeThreatActorRead[];
@@ -73,4 +75,8 @@ export interface observableUpdate extends nodeUpdate {
   type?: string;
   value?: string;
   [key: string]: unknown;
+}
+
+export interface observableRelationshipRead extends nodeRelationshipRead {
+  relatedNode: observableRead;
 }


### PR DESCRIPTION
This PR closes #11.

Node relationships are (at this point) only used for observables. You can add a relationship to say something like, "observable A has the IS_HASH_OF relationship to observable B". It's a way to add some extra contextual information between observables (and potentially other node objects in the future).

As part of this work, this PR also slightly simplifies some of the helper functions for adding the entries to the history tables.
