### PR TITLE
Disables vitest globals and uses Jest expect API

### DIFF
--- a/frontend/tests/unit/src/App.spec.ts.old
+++ b/frontend/tests/unit/src/App.spec.ts.old
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import App from "@/App.vue";
 import { mount } from "@vue/test-utils";
 import { TestingOptions } from "@pinia/testing";

--- a/frontend/tests/unit/src/etc/helpers.spec.ts
+++ b/frontend/tests/unit/src/etc/helpers.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { alertFilters } from "@/etc/configuration/alerts";
 import {
   formatNodeFiltersForAPI,
@@ -63,7 +64,7 @@ describe("parseFilters", () => {
       alertFilters.external,
     );
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       observableTypes: [
         { value: "ipv4", description: null, uuid: "1" },
         { value: "file", description: null, uuid: "2" },
@@ -74,7 +75,7 @@ describe("parseFilters", () => {
   it("will correctly parse and add any chips filters", async () => {
     const results = parseFilters({ tags: "tagA,tagB" }, alertFilters.external);
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       tags: ["tagA", "tagB"],
     });
   });
@@ -111,7 +112,7 @@ describe("parseFilters", () => {
 
     const results = parseFilters({ owner: "analystB" }, alertFilters.external);
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       owner: mockUserB,
     });
   });
@@ -125,7 +126,7 @@ describe("parseFilters", () => {
       alertFilters.external,
     );
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       eventTimeBefore: new Date("2022-01-08T16:31:51.000Z"),
     });
   });
@@ -136,13 +137,13 @@ describe("parseFilters", () => {
       alertFilters.external,
     );
 
-    expect(results).to.eql({});
+    expect(results).toEqual({});
   });
 
   it("will correctly parse and add any input text filters", async () => {
     const results = parseFilters({ name: "test name" }, alertFilters.external);
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       name: "test name",
     });
   });
@@ -158,7 +159,7 @@ describe("parseFilters", () => {
       alertFilters.external,
     );
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       observable: {
         category: { value: "ipv4", description: null, uuid: "1" },
         value: "1.2.3.4",
@@ -215,7 +216,7 @@ describe("parseFilters", () => {
       alertFilters.external,
     );
 
-    expect(results).to.eql({
+    expect(results).toEqual({
       tags: ["tagA", "tagB"],
       owner: mockUserB,
       observableTypes: [
@@ -262,7 +263,7 @@ describe("formatNodeFiltersForAPI", () => {
       alertFilters.external,
       MOCK_PARAMS,
     );
-    expect(formattedFilters).to.eql({
+    expect(formattedFilters).toEqual({
       limit: 10,
       offset: 10,
       disposition: "FALSE_POSITIVE",
@@ -276,12 +277,12 @@ describe("formatNodeFiltersForAPI", () => {
 
   it("getAlertLink correctly generates an alert link given an alert object", () => {
     const result = getAlertLink(mockAlertTreeRead);
-    expect(result).to.eql("/alert/testAlertUuid");
+    expect(result).toEqual("/alert/testAlertUuid");
   });
 
   it("getAllAlertTags formats a given alert's tags into a sorted and dedup'd list of tags", () => {
     const result = getAllAlertTags(mockAlertTreeRead);
-    expect(result).to.eql([
+    expect(result).toEqual([
       {
         description: null,
         value: "c2",
@@ -340,6 +341,6 @@ describe("groupItemsByQueue", () => {
     };
 
     const result = groupItemsByQueue(testData);
-    expect(result).to.eql(expected);
+    expect(result).toEqual(expected);
   });
 });

--- a/frontend/tests/unit/src/services/api/alert.spec.ts
+++ b/frontend/tests/unit/src/services/api/alert.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { alertCreate, alertFilterParams, alertUpdate } from "@/models/alert";
 import { Alert } from "@/services/api/alert";
 import myNock from "@unit/services/api/nock";
@@ -47,19 +48,19 @@ describe("Alert calls", () => {
       .get("/newItem")
       .reply(200, "Read successful");
     const res = await api.createAndRead(MOCK_ALERT_CREATE);
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /alert/{uuid} endpoint when 'read' is called with a given UUID", async () => {
     myNock.get("/alert/uuid").reply(200, "Read successful");
     const res = await api.read("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /alert/ endpoint when 'readPage' is called with no params, if none given", async () => {
     myNock.get("/alert/").reply(200, "Read successful");
     const res = await api.readPage();
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /alert/ endpoint when 'readPage' is called with properly formatted params", async () => {
@@ -69,12 +70,12 @@ describe("Alert calls", () => {
       )
       .reply(200, "Read successful");
     const res = await api.readPage(MOCK_PARAMS);
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a patch request to the /alert/ endpoint when 'update' is called with an array of update data", async () => {
     myNock.patch("/alert/").reply(200, "Update successful");
     const res = await api.update([MOCK_ALERT_UPDATE]);
-    expect(res).to.eql("Update successful");
+    expect(res).toEqual("Update successful");
   });
 });

--- a/frontend/tests/unit/src/services/api/analysis.spec.ts
+++ b/frontend/tests/unit/src/services/api/analysis.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { Analysis } from "@/services/api/analysis";
 import myNock from "@unit/services/api/nock";
 import { analysisReadFactory } from "@mocks/analysis";
@@ -7,7 +8,7 @@ describe("Analysis API calls", () => {
     myNock.get("/analysis/uuid2").reply(200, analysisReadFactory());
 
     const res = await Analysis.read("uuid2");
-    expect(res).to.eql(analysisReadFactory());
+    expect(res).toEqual(analysisReadFactory());
   });
 
   it("will throw an error if a request fails", async () => {
@@ -16,7 +17,9 @@ describe("Analysis API calls", () => {
       await Analysis.read("uuid2");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 404");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 404",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/services/api/auth.spec.ts
+++ b/frontend/tests/unit/src/services/api/auth.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import auth from "@/services/api/auth";
 import myNock from "@unit/services/api/nock";
 import { createCustomPinia } from "@unit/helpers";
@@ -13,25 +14,25 @@ describe("/auth API calls", () => {
   it("will make a post request to /auth when authenticate is called", async () => {
     myNock.post("/auth").reply(200);
     const res = await auth.authenticate(mockLoginData);
-    expect(res).to.equal(undefined);
+    expect(res).toStrictEqual(undefined);
   });
 
   it("will make a get request to /auth/refresh when refresh is called", async () => {
     myNock.get("/auth/refresh").reply(200);
     const res = await auth.refresh();
-    expect(res).to.equal(undefined);
+    expect(res).toStrictEqual(undefined);
   });
 
   it("will make a get request to /auth/validate when validate is called", async () => {
     myNock.get("/auth/validate").reply(200);
     const res = await auth.validate();
-    expect(res).to.equal(undefined);
+    expect(res).toStrictEqual(undefined);
   });
 
   it("will make a get request to /auth/logout when logout is called", async () => {
     myNock.get("/auth/logout").reply(200);
     const res = await auth.logout();
-    expect(res).to.equal(undefined);
+    expect(res).toStrictEqual(undefined);
   });
 
   it("will throw an error if refreshing without being authenticated", async () => {
@@ -40,7 +41,9 @@ describe("/auth API calls", () => {
       await auth.refresh();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 401");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 401",
+      );
     }
   });
 
@@ -50,7 +53,9 @@ describe("/auth API calls", () => {
       await auth.authenticate(mockLoginData);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 401");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 401",
+      );
     }
   });
 
@@ -60,7 +65,9 @@ describe("/auth API calls", () => {
       await auth.validate();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 401");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 401",
+      );
     }
   });
 
@@ -70,7 +77,9 @@ describe("/auth API calls", () => {
       await auth.logout();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 405");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 405",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/services/api/axios.spec.ts
+++ b/frontend/tests/unit/src/services/api/axios.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import auth from "@/services/api/auth";
 import { User } from "@/services/api/user";
 import myNock from "@unit/services/api/nock";
@@ -12,7 +13,9 @@ describe("Axios interceptor functionality", () => {
       await User.readAll();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 405");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 405",
+      );
     }
   });
 
@@ -22,7 +25,9 @@ describe("Axios interceptor functionality", () => {
       await auth.logout();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 405");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 405",
+      );
     }
   });
 
@@ -34,7 +39,7 @@ describe("Axios interceptor functionality", () => {
       .reply(200, { items: [{ username: "analyst" }] });
 
     const res = await User.readAll();
-    expect(res).to.eql([{ username: "analyst" }]);
+    expect(res).toEqual([{ username: "analyst" }]);
   });
 
   it("will reject a bad request after successfully refreshing tokens", async () => {
@@ -45,7 +50,9 @@ describe("Axios interceptor functionality", () => {
       await User.readAll();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 405");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 405",
+      );
     }
   });
 
@@ -56,7 +63,9 @@ describe("Axios interceptor functionality", () => {
       await User.readAll();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 401");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 401",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/services/api/base.spec.ts
+++ b/frontend/tests/unit/src/services/api/base.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { describe, it, expect } from "vitest";
 import { BaseApi } from "@/services/api/base";
 import myNock from "@unit/services/api/nock";
 
@@ -17,13 +18,13 @@ describe("BaseAPI calls", () => {
       .get("/newItem")
       .reply(200, "Read successful");
     const res = await api.create("/create", {}, true);
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make only a post request when getAfterCreate is true and there is NOT a 'content-location' header", async () => {
     myNock.post("/create").reply(200, "Create successful");
     const res = await api.create("/create", {}, true);
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("will make only a post request when getAfterCreate is false and there is a 'content-location' header", async () => {
@@ -31,25 +32,25 @@ describe("BaseAPI calls", () => {
       "content-location": "/newItem",
     });
     const res = await api.create("/create", {}, false);
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("will make only a post request when getAfterCreate is false and there is NOT a 'content-location' header", async () => {
     myNock.post("/create").reply(200, "Create successful");
     const res = await api.create("/create", {}, false);
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("make a get request when readRequest called", async () => {
     myNock.get("/read").reply(200, "Read successful");
     const res = await api.read("/read");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("make a patch request when updateRequest called", async () => {
     myNock.patch("/update").reply(200, "Update successful");
     const res = await api.update("/update");
-    expect(res).to.eql("Update successful");
+    expect(res).toEqual("Update successful");
   });
 
   it("will format outgoing data into snake_case keys", async () => {
@@ -64,7 +65,7 @@ describe("BaseAPI calls", () => {
       },
       false,
     );
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("will not change format of outgoing data if its an array of strings", async () => {
@@ -75,13 +76,13 @@ describe("BaseAPI calls", () => {
       { data: ["A", "B"] },
       false,
     );
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("will format incoming data into camelCase keys", async () => {
     myNock.post("/create").reply(200, { first_key: "A", second_key: 2 });
     const res = await api.create("/create", {}, false);
-    expect(res).to.eql({
+    expect(res).toEqual({
       firstKey: "A",
       secondKey: 2,
     });
@@ -93,7 +94,7 @@ describe("BaseAPI calls", () => {
       { third_key: "B", fourth_key: 3 },
     ]);
     const res = await api.create("/create", {}, false);
-    expect(res).to.eql([
+    expect(res).toEqual([
       {
         firstKey: "A",
         secondKey: 2,
@@ -108,7 +109,7 @@ describe("BaseAPI calls", () => {
   it("will correctly format URL parameters when given", async () => {
     myNock.get("/read?limit=5&offset=0").reply(200, "Read successful");
     const res = await api.read("/read", { limit: 5, offset: 0 });
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will throw an error if a request completes, but without a successful response code", async () => {
@@ -117,7 +118,9 @@ describe("BaseAPI calls", () => {
       await api.update("/update");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 404");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 404",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/services/api/event.spec.ts
+++ b/frontend/tests/unit/src/services/api/event.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, expect } from "vitest";
 import { eventFilterParams } from "@/models/event";
 import { Event } from "@/services/api/event";
 import myNock from "@unit/services/api/nock";
@@ -11,7 +12,7 @@ describe("Event calls", () => {
       "content-location": "/newItem",
     });
     const res = await api.create(eventCreateFactory());
-    expect(res).to.eql("Create successful");
+    expect(res).toEqual("Create successful");
   });
 
   it("will make a get request to fetch new event when 'create' is called with getAfterEvent set to true", async () => {
@@ -23,42 +24,42 @@ describe("Event calls", () => {
       .get("/newItem")
       .reply(200, "Read successful");
     const res = await api.create(eventCreateFactory(), true);
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid} endpoint when 'read' is called with a given UUID", async () => {
     myNock.get("/event/uuid").reply(200, "Read successful");
     const res = await api.read("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
   it("will make a get request to the /event/{uuid}/history endpoint when 'readHistory' is called with a given UUID", async () => {
     myNock.get("/event/uuid/history").reply(200, "Read successful");
     const res = await api.readHistory("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/observable endpoint when 'readObservableSummary' is called with a given UUID", async () => {
     myNock.get("/event/uuid/summary/observable").reply(200, "Read successful");
     const res = await api.readObservableSummary("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/user endpoint when 'readUserSummary' is called with a given UUID", async () => {
     myNock.get("/event/uuid/summary/user").reply(200, "Read successful");
     const res = await api.readUserSummary("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/url_domain endpoint when 'readUrlDomainSummary' is called with a given UUID", async () => {
     myNock.get("/event/uuid/summary/url_domain").reply(200, "Read successful");
     const res = await api.readUrlDomainSummary("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/email endpoint when 'readEmailSummary' is called with a given UUID", async () => {
     myNock.get("/event/uuid/summary/email").reply(200, "Read successful");
     const res = await api.readEmailSummary("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/email_headers_body endpoint when 'readEmailHeadersAndBody' is called with a given UUID", async () => {
@@ -66,7 +67,7 @@ describe("Event calls", () => {
       .get("/event/uuid/summary/email_headers_body")
       .reply(200, "Read successful");
     const res = await api.readEmailHeadersAndBody("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/{uuid}/summary/detection_point endpoint when 'readDetectionSummary' is called with a given UUID", async () => {
@@ -74,13 +75,13 @@ describe("Event calls", () => {
       .get("/event/uuid/summary/detection_point")
       .reply(200, "Read successful");
     const res = await api.readDetectionSummary("uuid");
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/ endpoint when 'readPage' is called with no params, if none given", async () => {
     myNock.get("/event/").reply(200, "Read successful");
     const res = await api.readPage();
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a get request to the /event/?offset={offset} endpoint as many times as needed to get all pages when 'readAllPages' is called with no params, if none given", async () => {
@@ -88,7 +89,7 @@ describe("Event calls", () => {
       .get("/event/?offset=0")
       .reply(200, { limit: 1, total: 1, items: ["eventA"] });
     const res = await api.readAllPages();
-    expect(res).to.eql(["eventA"]);
+    expect(res).toEqual(["eventA"]);
   });
 
   it("will make a get request to the /event/?offset={offset} endpoint as many times as needed to get all pages when 'readAllPages' is called with formatted params, if given", async () => {
@@ -100,7 +101,7 @@ describe("Event calls", () => {
       .get("/event/?offset=0&limit=10&name=Test+Name")
       .reply(200, { limit: 10, total: 1, items: ["eventA"] });
     const res = await api.readAllPages(eventParams);
-    expect(res).to.eql(["eventA"]);
+    expect(res).toEqual(["eventA"]);
   });
 
   it("will make a get request to the /event/ endpoint when 'readPage' is called with properly formatted params", async () => {
@@ -113,12 +114,12 @@ describe("Event calls", () => {
       .get("/event/?limit=10&offset=10&name=Test+Name")
       .reply(200, "Read successful");
     const res = await api.readPage(eventParams);
-    expect(res).to.eql("Read successful");
+    expect(res).toEqual("Read successful");
   });
 
   it("will make a patch request to the /event/ endpoint when 'update' is called with an array of update data", async () => {
     myNock.patch("/event/").reply(200, "Update successful");
     const res = await api.update([eventUpdateFactory()]);
-    expect(res).to.eql("Update successful");
+    expect(res).toEqual("Update successful");
   });
 });

--- a/frontend/tests/unit/src/services/api/nodeComment.spec.ts
+++ b/frontend/tests/unit/src/services/api/nodeComment.spec.ts
@@ -2,6 +2,7 @@
  * @vitest-environment node
  */
 
+import { describe, it, expect } from "vitest";
 import snakecaseKeys from "snakecase-keys";
 import { NodeComment } from "@/services/api/nodeComment";
 import myNock from "@unit/services/api/nock";
@@ -34,7 +35,7 @@ describe("NodeComment API calls", () => {
       .reply(200, successMessage);
 
     const res = await NodeComment.create(mockObjectCreate, false);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make only a post request when create is called and return create results if getAfterCreate is false and there is a content-location header", async () => {
@@ -45,7 +46,7 @@ describe("NodeComment API calls", () => {
       });
 
     const res = await NodeComment.create(mockObjectCreate, false);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make only a post request when create is called and return create results if getAfterCreate is true and there is NOT a content-location header", async () => {
@@ -54,7 +55,7 @@ describe("NodeComment API calls", () => {
       .reply(200, successMessage);
 
     const res = await NodeComment.create(mockObjectCreate);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make a post and get request when create is called and return GET results if getAfterCreate is true and there is a content-location header", async () => {
@@ -67,14 +68,14 @@ describe("NodeComment API calls", () => {
       .reply(200, secondSuccessMessage);
 
     const res = await NodeComment.create(mockObjectCreate, true);
-    expect(res).to.eql(secondSuccessMessage);
+    expect(res).toEqual(secondSuccessMessage);
   });
 
   it("will make a get request to /node/comment/{uuid} when getSingle is called", async () => {
     myNock.get("/node/comment/1").reply(200, successMessage);
 
     const res = await NodeComment.read("1");
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make a patch request to /node/comment/{uuid} when updateSingle is called", async () => {
@@ -86,7 +87,7 @@ describe("NodeComment API calls", () => {
       .reply(200, successMessage);
 
     const res = await NodeComment.update("1", { uuid: "1", value: "New Name" });
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will throw an error if a request fails", async () => {
@@ -96,7 +97,9 @@ describe("NodeComment API calls", () => {
       await NodeComment.read("1");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 404");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 404",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/services/api/nodeTree.spec.ts
+++ b/frontend/tests/unit/src/services/api/nodeTree.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { describe, it, expect } from "vitest";
 import { NodeTree } from "@/services/api/nodeTree";
 import myNock from "./nock";
 
@@ -23,6 +24,6 @@ describe("nodeTree API calls", () => {
       .reply(200, mockObjectReadArray);
 
     const res = await NodeTree.readNodesOfNodeTree(["1", "2"], "observable");
-    expect(res).to.eql(mockObjectReadArray);
+    expect(res).toEqual(mockObjectReadArray);
   });
 });

--- a/frontend/tests/unit/src/services/api/queue.spec.ts
+++ b/frontend/tests/unit/src/services/api/queue.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment node
  */
 
+import { describe, it, expect } from "vitest";
 import snakecaseKeys from "snakecase-keys";
 import { queue } from "@/services/api/queue";
 import myNock from "@unit/services/api/nock";
@@ -27,7 +28,7 @@ describe("queue API calls", () => {
       .reply(200, successMessage);
 
     const res = await queue.create(mockObjectCreate, false);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make only a post request when create is called and return create results if getAfterCreate is false and there is a content-location header", async () => {
@@ -38,7 +39,7 @@ describe("queue API calls", () => {
       });
 
     const res = await queue.create(mockObjectCreate, false);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make only a post request when create is called and return create results if getAfterCreate is true and there is NOT a content-location header", async () => {
@@ -47,7 +48,7 @@ describe("queue API calls", () => {
       .reply(200, successMessage);
 
     const res = await queue.create(mockObjectCreate);
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make a post and get request when create is called and return GET results if getAfterCreate is true and there is a content-location header", async () => {
@@ -60,14 +61,14 @@ describe("queue API calls", () => {
       .reply(200, secondSuccessMessage);
 
     const res = await queue.create(mockObjectCreate, true);
-    expect(res).to.eql(secondSuccessMessage);
+    expect(res).toEqual(secondSuccessMessage);
   });
 
   it("will make a get request to /queue/{uuid} when getSingle is called", async () => {
     myNock.get("/queue/1").reply(200, successMessage);
 
     const res = await queue.read("1");
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will make a get request to /queue/ when readAll is called", async () => {
@@ -76,7 +77,7 @@ describe("queue API calls", () => {
       .reply(200, JSON.stringify({ items: [mockObjectRead, mockObjectRead] }));
 
     const res = await queue.readAll();
-    expect(res).to.eql([mockObjectRead, mockObjectRead]);
+    expect(res).toEqual([mockObjectRead, mockObjectRead]);
   });
 
   it("will make a patch request to /queue/{uuid} when updateSingle is called", async () => {
@@ -85,7 +86,7 @@ describe("queue API calls", () => {
       .reply(200, successMessage);
 
     const res = await queue.update("1", { value: "New Name" });
-    expect(res).to.eql(successMessage);
+    expect(res).toEqual(successMessage);
   });
 
   it("will throw an error if a request fails", async () => {
@@ -95,7 +96,9 @@ describe("queue API calls", () => {
       await queue.read("1");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 404");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 404",
+      );
     }
   });
 });

--- a/frontend/tests/unit/src/store/alert.spec.ts
+++ b/frontend/tests/unit/src/store/alert.spec.ts
@@ -1,8 +1,8 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import myNock from "@unit/services/api/nock";
 import snakecaseKeys from "snakecase-keys";
 import { useAlertStore } from "@/stores/alert";
 import { createCustomPinia } from "@unit/helpers";
-import { describe, it, beforeEach, expect } from "vitest";
 
 import {
   alertCreateFactory,
@@ -26,9 +26,9 @@ describe("alert Actions", () => {
   });
 
   it("will have openAlertSummary return the current opensummary if there is one, otherwise it will return null", () => {
-    expect(store.openAlertSummary).to.equal(null);
+    expect(store.openAlertSummary).toStrictEqual(null);
     store.open = mockAlertTree;
-    expect(store.openAlertSummary).to.eql(mockAlertSummary);
+    expect(store.openAlertSummary).toEqual(mockAlertSummary);
   });
 
   it("will request to create an alert with a given AlertCreate object, and set the opento result on success", async () => {
@@ -38,26 +38,26 @@ describe("alert Actions", () => {
 
     await store.create(mockAlertCreate);
 
-    expect(mockRequest.isDone()).to.eql(true);
-    expect(store.open).to.eql(JSON.parse(JSON.stringify(mockAlert)));
+    expect(mockRequest.isDone()).toEqual(true);
+    expect(store.open).toEqual(JSON.parse(JSON.stringify(mockAlert)));
   });
 
   it("will fetch alert data given an alert ID", async () => {
     const mockRequest = myNock.get("/alert/uuid1").reply(200, mockAlert);
     await store.read("uuid1");
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
 
-    expect(store.open).to.eql(JSON.parse(JSON.stringify(mockAlert)));
+    expect(store.open).toEqual(JSON.parse(JSON.stringify(mockAlert)));
   });
 
   it("will make a request to update an alert given the UUID and update data upon the updateAlert action", async () => {
     const mockRequest = myNock.patch("/alert/").reply(200);
     await store.update([{ uuid: "uuid1", disposition: "test" }]);
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.open).to.equal(null);
+    expect(store.open).toStrictEqual(null);
   });
 
   it("will throw an error when a request fails in any action", async () => {
@@ -74,21 +74,27 @@ describe("alert Actions", () => {
       await store.create(mockAlertCreate);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
     try {
       await store.read("uuid1");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
     try {
       await store.update([{ uuid: "uuid1", disposition: "test" }]);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
     mockRequest.persist(false); // cleanup persisted nock request

--- a/frontend/tests/unit/src/store/alertTable.spec.ts
+++ b/frontend/tests/unit/src/store/alertTable.spec.ts
@@ -1,4 +1,5 @@
 // TODO: Move to alertTable store tests
+import { describe, it, beforeEach, expect } from "vitest";
 import myNock from "@unit/services/api/nock";
 import { alertFilterParams } from "@/models/alert";
 import { useAlertTableStore } from "@/stores/alertTable";
@@ -9,8 +10,6 @@ import {
   alertSummaryFactory,
   alertReadPageFactory,
 } from "@mocks/alert";
-
-import { describe, it, expect, beforeEach } from "vitest";
 
 createCustomPinia();
 const store = useAlertTableStore();
@@ -34,8 +33,8 @@ describe("alertTable helpers", () => {
   it("will correctly parse an alert received from the backend using parseAlertSummary", () => {
     const resA = parseAlertSummary(mockAlertTreeReadA);
     const resB = parseAlertSummary(mockAlertTreeReadC);
-    expect(resA).to.eql(mockAlertReadASummary);
-    expect(resB).to.eql(mockAlertReadCSummary);
+    expect(resA).toEqual(mockAlertReadASummary);
+    expect(resB).toEqual(mockAlertReadCSummary);
   });
 });
 
@@ -50,7 +49,7 @@ describe("alertTable getters", () => {
       mockAlertTreeReadB,
       mockAlertTreeReadC,
     ];
-    expect(store.visibleQueriedItemSummaries).to.eql([
+    expect(store.visibleQueriedItemSummaries).toEqual([
       mockAlertReadASummary,
       mockAlertReadBSummary,
       mockAlertReadCSummary,
@@ -63,7 +62,7 @@ describe("alertTable getters", () => {
       mockAlertTreeReadB,
       mockAlertTreeReadC,
     ];
-    expect(store.visibleQueriedItemsUuids).to.eql(["uuid1", "uuid2", "uuid3"]);
+    expect(store.visibleQueriedItemsUuids).toEqual(["uuid1", "uuid2", "uuid3"]);
   });
 
   it("will correctly return  visibleQueriedItemById", () => {
@@ -72,22 +71,22 @@ describe("alertTable getters", () => {
       mockAlertTreeReadB,
       mockAlertTreeReadC,
     ];
-    expect(store.visibleQueriedItemById("uuid1")).to.eql(mockAlertTreeReadA);
+    expect(store.visibleQueriedItemById("uuid1")).toEqual(mockAlertTreeReadA);
   });
 
   it("will correctly return sortFilter", () => {
-    expect(store.sortFilter).to.eql("event_time|desc");
+    expect(store.sortFilter).toEqual("event_time|desc");
   });
 
   it("will correctly return allFiltersLoaded", () => {
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = false;
     store.routeFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(true);
+    expect(store.allFiltersLoaded).toStrictEqual(true);
   });
 });
 
@@ -103,14 +102,14 @@ describe("alertTable actions", () => {
 
     await store.readPage(mockParams);
 
-    expect(mockRequest.isDone()).to.eql(true);
-    expect(store.visibleQueriedItems).to.eql([
+    expect(mockRequest.isDone()).toEqual(true);
+    expect(store.visibleQueriedItems).toEqual([
       JSON.parse(JSON.stringify(mockAlertTreeReadA)),
       JSON.parse(JSON.stringify(mockAlertTreeReadB)),
       JSON.parse(JSON.stringify(mockAlertTreeReadC)),
     ]);
-    expect(store.totalItems).to.eql(3);
-    expect(store.requestReload).to.eql(false);
+    expect(store.totalItems).toEqual(3);
+    expect(store.requestReload).toEqual(false);
   });
 
   it("will throw an error if request fails on readPage", async () => {
@@ -120,12 +119,14 @@ describe("alertTable actions", () => {
       await store.readPage(mockParams);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
-    expect(store.visibleQueriedItems).to.eql([]);
-    expect(store.totalItems).to.eql(0);
-    expect(store.requestReload).to.eql(false);
+    expect(store.visibleQueriedItems).toEqual([]);
+    expect(store.totalItems).toEqual(0);
+    expect(store.requestReload).toEqual(false);
   });
   it("will reset the sort order and sort field to written defaults on resetSort", () => {
     store.sortField = "exampleSort";
@@ -133,7 +134,7 @@ describe("alertTable actions", () => {
 
     store.resetSort();
 
-    expect(store.sortField).to.eql("eventTime");
-    expect(store.sortOrder).to.eql("desc");
+    expect(store.sortField).toEqual("eventTime");
+    expect(store.sortOrder).toEqual("desc");
   });
 });

--- a/frontend/tests/unit/src/store/auth.spec.ts
+++ b/frontend/tests/unit/src/store/auth.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import { useAuthStore } from "@/stores/auth";
 import { userRead } from "@/models/user";
 import { createCustomPinia } from "@unit/helpers";
@@ -25,12 +26,12 @@ describe("auth Getters", () => {
   });
 
   it("will return isAuthenticated state when not logged in", () => {
-    expect(store.isAuthenticated).to.equal(false);
+    expect(store.isAuthenticated).toStrictEqual(false);
   });
 
   it("will return isAuthenticated state when logged in", () => {
     store.user = mockUser;
 
-    expect(store.isAuthenticated).to.equal(true);
+    expect(store.isAuthenticated).toStrictEqual(true);
   });
 });

--- a/frontend/tests/unit/src/store/event.spec.ts
+++ b/frontend/tests/unit/src/store/event.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import myNock from "@unit/services/api/nock";
 import { useEventStore } from "@/stores/event";
 import { eventReadFactory } from "@mocks/events";
@@ -18,10 +19,10 @@ describe("event Actions", () => {
     const mockRequest = myNock.get("/event/uuid1").reply(200, mockEvent);
     await store.read("uuid1");
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
 
     // The open is not parsed at all when received, so any dates will be in string format
-    expect(store.open).to.eql(JSON.parse(JSON.stringify(mockEvent)));
+    expect(store.open).toEqual(JSON.parse(JSON.stringify(mockEvent)));
   });
 
   it("will throw an error if read fails", async () => {
@@ -31,19 +32,21 @@ describe("event Actions", () => {
       await store.read("uuid1");
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
   });
 
   it("will make a request to update an event given the UUID and update data upon the updateEvent action", async () => {
     const mockRequest = myNock.patch("/event/").reply(200);
     await store.update([{ uuid: "uuid1", name: "test" }]);
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.open).to.equal(null);
+    expect(store.open).toStrictEqual(null);
   });
 
   it("will throw an error if update fails", async () => {
@@ -53,11 +56,13 @@ describe("event Actions", () => {
       await store.update([{ uuid: "uuid1", name: "test" }]);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
-    expect(mockRequest.isDone()).to.eql(true);
+    expect(mockRequest.isDone()).toEqual(true);
     // None of these should be changed
-    expect(store.open).to.equal(null);
+    expect(store.open).toStrictEqual(null);
   });
 });

--- a/frontend/tests/unit/src/store/eventTable.spec.ts
+++ b/frontend/tests/unit/src/store/eventTable.spec.ts
@@ -1,4 +1,5 @@
 // TODO: Move to eventTable store tests
+import { describe, it, beforeEach, expect } from "vitest";
 import myNock from "@unit/services/api/nock";
 import { eventFilterParams } from "@/models/event";
 import { parseEventSummary, useEventTableStore } from "@/stores/eventTable";
@@ -62,8 +63,8 @@ describe("eventTable helpers", () => {
   it("will correctly parse an event received from the backend using parseEventSummary", () => {
     const resA = parseEventSummary(mockEventReadA);
     const resB = parseEventSummary(mockEventReadC);
-    expect(resA).to.eql(mockEventReadASummary);
-    expect(resB).to.eql(mockEventReadCSummary);
+    expect(resA).toEqual(mockEventReadASummary);
+    expect(resB).toEqual(mockEventReadCSummary);
   });
 });
 
@@ -78,7 +79,7 @@ describe("eventTable getters", () => {
       mockEventReadB,
       mockEventReadC,
     ];
-    expect(store.visibleQueriedItemSummaries).to.eql([
+    expect(store.visibleQueriedItemSummaries).toEqual([
       mockEventReadASummary,
       mockEventReadBSummary,
       mockEventReadCSummary,
@@ -91,7 +92,7 @@ describe("eventTable getters", () => {
       mockEventReadB,
       mockEventReadC,
     ];
-    expect(store.visibleQueriedItemsUuids).to.eql(["uuid1", "uuid2", "uuid3"]);
+    expect(store.visibleQueriedItemsUuids).toEqual(["uuid1", "uuid2", "uuid3"]);
   });
 
   it("will correctly return  visibleQueriedItemById", () => {
@@ -100,26 +101,26 @@ describe("eventTable getters", () => {
       mockEventReadB,
       mockEventReadC,
     ];
-    expect(store.visibleQueriedItemById("uuid1")).to.eql(mockEventReadA);
+    expect(store.visibleQueriedItemById("uuid1")).toEqual(mockEventReadA);
   });
 
   it("will correctly return sortFilter", () => {
-    expect(store.sortFilter).to.eql("created_time|desc");
+    expect(store.sortFilter).toEqual("created_time|desc");
 
     store.sortField = null;
     store.sortOrder = null;
-    expect(store.sortFilter).to.equal(null);
+    expect(store.sortFilter).toStrictEqual(null);
   });
 
   it("will correctly return allFiltersLoaded", () => {
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = false;
     store.routeFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(false);
+    expect(store.allFiltersLoaded).toStrictEqual(false);
     store.stateFiltersLoaded = true;
-    expect(store.allFiltersLoaded).to.equal(true);
+    expect(store.allFiltersLoaded).toStrictEqual(true);
   });
 });
 
@@ -136,14 +137,14 @@ describe("eventTable actions", () => {
 
     await store.readPage(mockParams);
 
-    expect(mockRequest.isDone()).to.eql(true);
-    expect(store.visibleQueriedItems).to.eql([
+    expect(mockRequest.isDone()).toEqual(true);
+    expect(store.visibleQueriedItems).toEqual([
       JSON.parse(JSON.stringify(mockEventReadA)),
       JSON.parse(JSON.stringify(mockEventReadB)),
       JSON.parse(JSON.stringify(mockEventReadC)),
     ]);
-    expect(store.totalItems).to.eql(3);
-    expect(store.requestReload).to.eql(false);
+    expect(store.totalItems).toEqual(3);
+    expect(store.requestReload).toEqual(false);
   });
 
   it("will throw an error if request fails on readPage", async () => {
@@ -153,12 +154,14 @@ describe("eventTable actions", () => {
       await store.readPage(mockParams);
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.equal("Request failed with status code 403");
+      expect(error.message).toStrictEqual(
+        "Request failed with status code 403",
+      );
     }
 
-    expect(store.visibleQueriedItems).to.eql([]);
-    expect(store.totalItems).to.eql(0);
-    expect(store.requestReload).to.eql(false);
+    expect(store.visibleQueriedItems).toEqual([]);
+    expect(store.totalItems).toEqual(0);
+    expect(store.requestReload).toEqual(false);
   });
   it("will reset the sort order and sort field to written defaults on resetSort", () => {
     store.sortField = "exampleSort";
@@ -166,7 +169,7 @@ describe("eventTable actions", () => {
 
     store.resetSort();
 
-    expect(store.sortField).to.eql("createdTime");
-    expect(store.sortOrder).to.eql("desc");
+    expect(store.sortField).toEqual("createdTime");
+    expect(store.sortOrder).toEqual("desc");
   });
 });

--- a/frontend/tests/unit/src/store/filter.spec.ts
+++ b/frontend/tests/unit/src/store/filter.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import { useFilterStore, isEmpty } from "@/stores/filter";
 import { createCustomPinia } from "@unit/helpers";
 
@@ -7,15 +8,15 @@ const store = useFilterStore();
 
 describe("filters helpers", () => {
   it("will correctly identify if a given variable is empty / falsy on isEmpty", () => {
-    expect(isEmpty({})).to.equal(true);
-    expect(isEmpty({ test: "test" })).to.equal(false);
-    expect(isEmpty([])).to.equal(true);
-    expect(isEmpty(["test"])).to.equal(false);
-    expect(isEmpty(false)).to.equal(true);
-    expect(isEmpty(true)).to.equal(false);
-    expect(isEmpty("")).to.equal(true);
-    expect(isEmpty("test")).to.equal(false);
-    expect(isEmpty(new Date())).to.equal(false);
+    expect(isEmpty({})).toStrictEqual(true);
+    expect(isEmpty({ test: "test" })).toStrictEqual(false);
+    expect(isEmpty([])).toStrictEqual(true);
+    expect(isEmpty(["test"])).toStrictEqual(false);
+    expect(isEmpty(false)).toStrictEqual(true);
+    expect(isEmpty(true)).toStrictEqual(false);
+    expect(isEmpty("")).toStrictEqual(true);
+    expect(isEmpty("test")).toStrictEqual(false);
+    expect(isEmpty(new Date())).toStrictEqual(false);
   });
 });
 
@@ -26,7 +27,7 @@ describe("filters Actions", () => {
   });
 
   it("will set the given nodeTypes filter object to the given filter object argument upon the bulkSetFilters action", () => {
-    expect(localStorage.getItem("aceFilters")).to.eql(null);
+    expect(localStorage.getItem("aceFilters")).toEqual(null);
 
     store.bulkSetFilters({
       nodeType: "alerts",
@@ -40,8 +41,8 @@ describe("filters Actions", () => {
       events: {},
     };
 
-    expect(store.$state).to.eql(expectedState);
-    expect(localStorage.getItem("aceFilters")).to.eql(
+    expect(store.$state).toEqual(expectedState);
+    expect(localStorage.getItem("aceFilters")).toEqual(
       JSON.stringify(expectedState),
     );
   });
@@ -57,7 +58,7 @@ describe("filters Actions", () => {
       },
     });
 
-    expect(store.$state).to.eql({
+    expect(store.$state).toEqual({
       alerts: {
         testFilterName4: "testFilterValue",
       },
@@ -66,7 +67,7 @@ describe("filters Actions", () => {
   });
 
   it("will add a new property and specified to a given filter object upon the setFilter action", () => {
-    expect(localStorage.getItem("aceFilters")).to.equal(null);
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(null);
 
     store.setFilter({
       nodeType: "alerts",
@@ -81,8 +82,8 @@ describe("filters Actions", () => {
       events: {},
     };
 
-    expect(store.$state).to.eql(expectedState);
-    expect(localStorage.getItem("aceFilters")).to.eql(
+    expect(store.$state).toEqual(expectedState);
+    expect(localStorage.getItem("aceFilters")).toEqual(
       JSON.stringify(expectedState),
     );
   });
@@ -94,7 +95,7 @@ describe("filters Actions", () => {
       filterValue: [],
     });
 
-    expect(store.$state).to.eql({
+    expect(store.$state).toEqual({
       alerts: {},
       events: {},
     });
@@ -105,7 +106,7 @@ describe("filters Actions", () => {
       filterValue: "",
     });
 
-    expect(store.$state).to.eql({
+    expect(store.$state).toEqual({
       alerts: {},
       events: {},
     });
@@ -118,8 +119,8 @@ describe("filters Actions", () => {
       JSON.stringify({ alerts: { name: "test" }, events: {} }),
     );
 
-    expect(store.alerts).to.eql({ name: "test" });
-    expect(localStorage.getItem("aceFilters")).to.equal(
+    expect(store.alerts).toEqual({ name: "test" });
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
       JSON.stringify({ alerts: { name: "test" }, events: {} }),
     );
 
@@ -128,12 +129,12 @@ describe("filters Actions", () => {
       filterName: "name",
     });
 
-    expect(store.$state).to.eql({
+    expect(store.$state).toEqual({
       alerts: {},
       events: {},
     });
 
-    expect(localStorage.getItem("aceFilters")).to.equal(
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
       JSON.stringify({ alerts: {}, events: {} }),
     );
   });
@@ -151,8 +152,8 @@ describe("filters Actions", () => {
       }),
     );
 
-    expect(store.alerts).to.eql({ name: "test", description: "test" });
-    expect(localStorage.getItem("aceFilters")).to.equal(
+    expect(store.alerts).toEqual({ name: "test", description: "test" });
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
       JSON.stringify({
         alerts: { name: "test", description: "test" },
         events: {},
@@ -163,12 +164,12 @@ describe("filters Actions", () => {
       nodeType: "alerts",
     });
 
-    expect(store.$state).to.eql({
+    expect(store.$state).toEqual({
       alerts: {},
       events: {},
     });
 
-    expect(localStorage.getItem("aceFilters")).to.equal(
+    expect(localStorage.getItem("aceFilters")).toStrictEqual(
       JSON.stringify({ alerts: {}, events: {} }),
     );
   });

--- a/frontend/tests/unit/src/store/helpers.spec.ts
+++ b/frontend/tests/unit/src/store/helpers.spec.ts
@@ -1,5 +1,5 @@
+import { describe, it, beforeEach, expect, vi } from "vitest";
 import { setUserDefaults, loadFiltersFromStorage } from "@/stores/helpers";
-import { beforeEach, expect } from "vitest";
 import { useAlertTableStore } from "@/stores/alertTable";
 import { useAuthStore } from "@/stores/auth";
 import { useCurrentUserSettingsStore } from "@/stores/currentUserSettings";
@@ -7,7 +7,6 @@ import { useEventTableStore } from "@/stores/eventTable";
 import { useFilterStore } from "@/stores/filter";
 import { genericObjectReadFactory } from "@mocks/genericObject";
 import { userReadFactory } from "@mocks/user";
-import { vi, describe, it } from "vitest";
 import { createTestingPinia } from "@pinia/testing";
 
 createTestingPinia({ createSpy: vi.fn });
@@ -28,11 +27,11 @@ describe("setUserDefaults", () => {
 
   it("will do nothing when there is no authStore user set", () => {
     setUserDefaults();
-    expect(currentUserSettingsStore.queues.events).to.equal(null);
-    expect(currentUserSettingsStore.queues.alerts).to.equal(null);
+    expect(currentUserSettingsStore.queues.events).toStrictEqual(null);
+    expect(currentUserSettingsStore.queues.alerts).toStrictEqual(null);
 
-    expect(filterStore.events).to.eql({});
-    expect(filterStore.alerts).to.eql({});
+    expect(filterStore.events).toEqual({});
+    expect(filterStore.alerts).toEqual({});
   });
 
   it("will correctly set all user defaults when nodeType == 'all'", () => {
@@ -41,12 +40,12 @@ describe("setUserDefaults", () => {
       defaultEventQueue: eventQueue,
     });
     setUserDefaults();
-    expect(currentUserSettingsStore.queues.events).to.eql(eventQueue);
-    expect(currentUserSettingsStore.queues.alerts).to.eql(alertQueue);
-    expect(filterStore.events).to.eql({
+    expect(currentUserSettingsStore.queues.events).toEqual(eventQueue);
+    expect(currentUserSettingsStore.queues.alerts).toEqual(alertQueue);
+    expect(filterStore.events).toEqual({
       queue: eventQueue,
     });
-    expect(filterStore.alerts).to.eql({
+    expect(filterStore.alerts).toEqual({
       queue: alertQueue,
     });
   });
@@ -56,12 +55,12 @@ describe("setUserDefaults", () => {
       defaultEventQueue: eventQueue,
     });
     setUserDefaults("events");
-    expect(currentUserSettingsStore.queues.events).to.eql(eventQueue);
-    expect(currentUserSettingsStore.queues.alerts).to.equal(null);
-    expect(filterStore.events).to.eql({
+    expect(currentUserSettingsStore.queues.events).toEqual(eventQueue);
+    expect(currentUserSettingsStore.queues.alerts).toStrictEqual(null);
+    expect(filterStore.events).toEqual({
       queue: eventQueue,
     });
-    expect(filterStore.alerts).to.eql({});
+    expect(filterStore.alerts).toEqual({});
   });
   it("will correctly set alert user defaults when nodeType == 'alerts'", () => {
     authStore.user = userReadFactory({
@@ -69,21 +68,21 @@ describe("setUserDefaults", () => {
       defaultEventQueue: eventQueue,
     });
     setUserDefaults("alerts");
-    expect(currentUserSettingsStore.queues.events).to.equal(null);
-    expect(currentUserSettingsStore.queues.alerts).to.eql(alertQueue);
-    expect(filterStore.events).to.eql({});
-    expect(filterStore.alerts).to.eql({
+    expect(currentUserSettingsStore.queues.events).toStrictEqual(null);
+    expect(currentUserSettingsStore.queues.alerts).toEqual(alertQueue);
+    expect(filterStore.events).toEqual({});
+    expect(filterStore.alerts).toEqual({
       queue: alertQueue,
     });
   });
 
   it("will not set any user defaults when nodeType is unknown", () => {
     setUserDefaults("unknown");
-    expect(currentUserSettingsStore.queues.events).to.equal(null);
-    expect(currentUserSettingsStore.queues.alerts).to.equal(null);
+    expect(currentUserSettingsStore.queues.events).toStrictEqual(null);
+    expect(currentUserSettingsStore.queues.alerts).toStrictEqual(null);
 
-    expect(filterStore.events).to.eql({});
-    expect(filterStore.alerts).to.eql({});
+    expect(filterStore.events).toEqual({});
+    expect(filterStore.alerts).toEqual({});
   });
 });
 
@@ -105,13 +104,13 @@ describe("loadFiltersFromStorage", () => {
 
     loadFiltersFromStorage();
 
-    expect(filterStore.$state).to.eql({
+    expect(filterStore.$state).toEqual({
       alerts: {},
       events: {
         queue: { description: null, value: "external", uuid: "uuid1" },
       },
     });
-    expect(alertTableStore.stateFiltersLoaded).to.equal(true);
-    expect(eventTableStore.stateFiltersLoaded).to.equal(true);
+    expect(alertTableStore.stateFiltersLoaded).toStrictEqual(true);
+    expect(eventTableStore.stateFiltersLoaded).toStrictEqual(true);
   });
 });

--- a/frontend/tests/unit/src/store/modal.spec.ts
+++ b/frontend/tests/unit/src/store/modal.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import { useModalStore } from "@/stores/modal";
 import { createCustomPinia } from "@unit/helpers";
 
@@ -11,13 +12,13 @@ describe("modal Getters", () => {
   });
 
   it("will return null when there is no open/active modal", () => {
-    expect(store.active).to.equal(null);
+    expect(store.active).toStrictEqual(null);
   });
 
   it("will return the name of the currently active modal (first in the list)", () => {
     store.openModals = ["modal1", "modal2"];
 
-    expect(store.active).to.equal("modal1");
+    expect(store.active).toStrictEqual("modal1");
   });
 });
 
@@ -27,19 +28,19 @@ describe("modal Actions", () => {
   });
 
   it("will add a new modal to the front of the open list upon the open action", () => {
-    expect(store.openModals.length).to.equal(0);
+    expect(store.openModals.length).toStrictEqual(0);
     store.open("modal1");
-    expect(store.openModals.length).to.equal(1);
-    expect(store.openModals[0]).to.equal("modal1");
+    expect(store.openModals.length).toStrictEqual(1);
+    expect(store.openModals[0]).toStrictEqual("modal1");
     store.open("modal2");
-    expect(store.openModals.length).to.equal(2);
-    expect(store.openModals[0]).to.equal("modal2");
+    expect(store.openModals.length).toStrictEqual(2);
+    expect(store.openModals[0]).toStrictEqual("modal2");
   });
   it("will remove the given modal from the open list upon the close action", () => {
     store.openModals = ["modal1"];
 
-    expect(store.openModals.length).to.equal(1);
+    expect(store.openModals.length).toStrictEqual(1);
     store.close("modal1");
-    expect(store.openModals.length).to.equal(0);
+    expect(store.openModals.length).toStrictEqual(0);
   });
 });

--- a/frontend/tests/unit/src/store/selectedAlert.spec.ts
+++ b/frontend/tests/unit/src/store/selectedAlert.spec.ts
@@ -1,3 +1,4 @@
+import { describe, it, beforeEach, expect } from "vitest";
 import { useSelectedAlertStore } from "@/stores/selectedAlert";
 import { createCustomPinia } from "@unit/helpers";
 
@@ -13,23 +14,23 @@ describe("selectedAlert Getters", () => {
   it("multipleSelected will return true when multiple alerts are selected", () => {
     store.selected = ["id1", "id2"];
 
-    expect(store.multipleSelected).to.equal(true);
+    expect(store.multipleSelected).toStrictEqual(true);
   });
 
   it("will have multipleSelected return false when one or fewer alerts are selected", () => {
     store.selected = ["id1"];
 
-    expect(store.multipleSelected).to.equal(false);
+    expect(store.multipleSelected).toStrictEqual(false);
   });
 
   it("will have anySelected return true when any alerts are selected", () => {
     store.selected = ["id1"];
 
-    expect(store.anySelected).to.equal(true);
+    expect(store.anySelected).toStrictEqual(true);
   });
 
   it("will have anySelected return false when no alerts are selected", () => {
-    expect(store.anySelected).to.equal(false);
+    expect(store.anySelected).toStrictEqual(false);
   });
 });
 
@@ -37,33 +38,33 @@ describe("selectedAlert Actions", () => {
   it("will add a given string to the selected list upon the select action", () => {
     store.select("id1");
 
-    expect(store.selected.length).to.equal(1);
-    expect(store.selected[0]).to.equal("id1");
+    expect(store.selected.length).toStrictEqual(1);
+    expect(store.selected[0]).toStrictEqual("id1");
   });
 
   it("will remove a given string from the selected list upon the unselect action", () => {
     store.selected = ["id1", "id2"];
 
-    expect(store.selected.length).to.equal(2);
+    expect(store.selected.length).toStrictEqual(2);
     store.unselect("id1");
-    expect(store.selected.length).to.equal(1);
-    expect(store.selected[0]).to.equal("id2");
+    expect(store.selected.length).toStrictEqual(1);
+    expect(store.selected[0]).toStrictEqual("id2");
   });
 
   it("will add a list of strings to the selected list upon the selected action", () => {
     store.selectAll(["id1", "id2", "id3"]);
 
-    expect(store.selected.length).to.equal(3);
-    expect(store.selected[0]).to.equal("id1");
-    expect(store.selected[1]).to.equal("id2");
-    expect(store.selected[2]).to.equal("id3");
+    expect(store.selected.length).toStrictEqual(3);
+    expect(store.selected[0]).toStrictEqual("id1");
+    expect(store.selected[1]).toStrictEqual("id2");
+    expect(store.selected[2]).toStrictEqual("id3");
   });
 
   it("will remove all from the selected list upon the unselectAll action", () => {
     store.selected = ["id1", "id2", "id3"];
 
-    expect(store.selected.length).to.equal(3);
+    expect(store.selected.length).toStrictEqual(3);
     store.unselectAll();
-    expect(store.selected.length).to.equal(0);
+    expect(store.selected.length).toStrictEqual(0);
   });
 });

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -16,7 +16,7 @@
       "@unit/*": ["./tests/unit/src/*"],
       "@mocks/*": ["./tests/mocks/*"]
     },
-    "types": ["vite/client", "vitest/globals"],
+    "types": ["vite/client"],
     "allowJs": true,
     "skipLibCheck": true
   },

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
   },
   plugins: [vue()],
   test: {
-    globals: true,
+    globals: false,
     environment: "jsdom",
     include: ["**/unit/**/*.spec.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
     reporters: ["verbose"],


### PR DESCRIPTION
This disables the Vitest "globals" setting, which apparently wasn't doing quite what we thought it did. Since the globals setting is off, all of the unit tests now import what they need from the vitest package.

We had previously switched to using the Chai API for expect assertions to fix some TypeScript related errors seen in GitHub Actions, but after importing things from the vitest package, we can now go back to using the Jest API that we are more familiar with.