### PR TITLE
Update reset filters button

### DIFF
--- a/frontend/src/stores/helpers.ts
+++ b/frontend/src/stores/helpers.ts
@@ -88,6 +88,7 @@ export async function populateEventStores(): Promise<void> {
 export function setUserDefaults(nodeType = "all"): void {
   const authStore = useAuthStore();
   const filterStore = useFilterStore();
+  const eventStatusStore = useEventStatusStore();
   const currentUserSettingsStore = useCurrentUserSettingsStore();
 
   if (!authStore.user) {
@@ -102,6 +103,18 @@ export function setUserDefaults(nodeType = "all"): void {
       filterName: "queue",
       filterValue: currentUserSettingsStore.queues.events,
     });
+
+    // Set default event status filter
+    const openStatus = eventStatusStore.items.find((status) => {
+      return status.value === "OPEN";
+    });
+    if (openStatus) {
+      filterStore.setFilter({
+        nodeType: "events",
+        filterName: "status",
+        filterValue: openStatus,
+      });
+    }
   }
 
   if (nodeType === "all" || nodeType === "alerts") {

--- a/frontend/tests/e2e/specs/ManageEvents.spec.js
+++ b/frontend/tests/e2e/specs/ManageEvents.spec.js
@@ -450,6 +450,11 @@ describe("ManageEvents.vue Filtering", () => {
       "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0",
     ).as("getEventsDefault");
 
+    cy.intercept(
+      "GET",
+      "/api/event/?sort=created_time%7Cdesc&limit=10&offset=0&status=OPEN&queue=external",
+    ).as("getEventsResetFilters");
+
     // SETUP -- adding a filter
     // Open edit filter modal
     cy.get(".p-splitbutton > .p-button-icon-only").click();
@@ -470,7 +475,7 @@ describe("ManageEvents.vue Filtering", () => {
     // Click reset button
     cy.get(".p-splitbutton > .p-button-icon-only").click();
     cy.get(".p-menuitem-link").eq(1).click();
-    cy.wait("@getEventsDefault").its("state").should("eq", "Complete");
+    cy.wait("@getEventsResetFilters").its("state").should("eq", "Complete");
   });
 
   it("successfully clears filters when clear filters clicked", () => {


### PR DESCRIPTION
This PR updates the 'reset filters' button to reset the user's queue filter, as well as other applicable (and available) filters based on the node type. Ex -- default event status filter is 'OPEN.'