### PR TITLE
Edit Event Bugfix

### DIFF
--- a/frontend/src/components/Modals/EditEventModal.vue
+++ b/frontend/src/components/Modals/EditEventModal.vue
@@ -78,6 +78,7 @@
   import { eventRead, eventUpdate } from "@/models/event";
   import { propertyOption } from "@/models/base";
   import { nodeCommentRead } from "@/models/nodeComment";
+  import { populateEventStores } from "@/stores/helpers";
 
   const modalStore = useModalStore();
   const eventStore = useEventStore();
@@ -141,6 +142,7 @@
   const initializeData = async () => {
     isLoading.value = true;
     try {
+      await populateEventStores();
       await fetchEvent();
       if (!event.value) {
         throw new Error("Event data not saved to local store");

--- a/frontend/src/components/Modals/EditEventModal.vue
+++ b/frontend/src/components/Modals/EditEventModal.vue
@@ -72,7 +72,6 @@
   import { Event } from "@/services/api/event";
   import { useEventStore } from "@/stores/event";
   import { useModalStore } from "@/stores/modal";
-  import { populateEventStores } from "@/stores/helpers";
   import { isObject } from "@/etc/validators";
   import NodeCommentEditor from "@/components/Node/NodeCommentEditor.vue";
   import { NodeComment } from "@/services/api/nodeComment";
@@ -143,10 +142,13 @@
     isLoading.value = true;
     try {
       await fetchEvent();
-      await populateEventStores();
-
       if (!event.value) {
-        throw new Error("Event data not saved");
+        throw new Error("Event data not saved to local store");
+      }
+      if (!(event.value.queue.value in availableEditFields)) {
+        throw new Error(
+          `Could not load settings for this event queue: ${event.value.queue.value}`,
+        );
       }
 
       for (const option of availableEditFields[event.value.queue.value]) {
@@ -162,9 +164,9 @@
       await resetForm();
     } catch (e: unknown) {
       if (typeof e === "string") {
-        error.value = `Could not remove alerts: ${e}`;
+        error.value = `Could not load event data: ${e}`;
       } else if (e instanceof Error) {
-        error.value = `Could not remove alerts: ${e.message}`;
+        error.value = `Could not load event data: ${e.message}`;
       }
     }
     isLoading.value = false;
@@ -197,9 +199,9 @@
       }
     } catch (e: unknown) {
       if (typeof e === "string") {
-        error.value = `Could not remove alerts: ${e}`;
+        error.value = `Could not update event: ${e}`;
       } else if (e instanceof Error) {
-        error.value = `Could not remove alerts: ${e.message}`;
+        error.value = `Could not update event: ${e.message}`;
       }
     }
 

--- a/frontend/src/components/Node/NodePropertyInput.vue
+++ b/frontend/src/components/Node/NodePropertyInput.vue
@@ -33,6 +33,7 @@
           :options="propertyValueOptions"
           :option-label="propertyValueOptionProperty"
           type="text"
+          placeholder="None"
           @change="updateValue('propertyValue', $event.value)"
         ></Dropdown>
       </div>
@@ -44,6 +45,7 @@
           :options="propertyValueOptions"
           :option-label="propertyValueOptionProperty"
           type="text"
+          placeholder="None"
           @change="updateValue('propertyValue', $event.value)"
         ></Multiselect>
       </div>

--- a/frontend/src/etc/helpers.ts
+++ b/frontend/src/etc/helpers.ts
@@ -250,6 +250,7 @@ export function groupItemsByQueue<T extends genericObjectRead>(
 ): Record<string, T[]> {
   const itemsByQueue: Record<string, T[]> = {};
   for (const item of arr) {
+    console.log(item);
     if (item.queues) {
       for (const queue of item.queues) {
         if (queue.value in itemsByQueue) {

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -86,6 +86,7 @@ export interface eventRead extends nodeRead {
   threats: nodeThreatRead[];
   type: eventTypeRead | null;
   vectors: eventVectorRead[];
+  [key: string]: unknown;
 }
 
 export interface eventReadPage extends nodeReadPage {

--- a/frontend/src/pages/Events/ManageEvents.vue
+++ b/frontend/src/pages/Events/ManageEvents.vue
@@ -24,7 +24,7 @@
   import { useFilterStore } from "@/stores/filter";
   import { useEventTableStore } from "@/stores/eventTable";
   import { parseFilters } from "@/etc/helpers";
-  import { populateCommonStores } from "@/stores/helpers";
+  import { populateCommonStores, populateEventStores } from "@/stores/helpers";
   import { validEventFilters } from "@/etc/constants/events";
 
   const route = useRoute();
@@ -44,6 +44,7 @@
     if (Object.keys(route.query).length) {
       // Will need to load common stores in order to find filter values
       await populateCommonStores();
+      await populateEventStores();
       loadRouteQuery();
     }
     eventTableStore.routeFiltersLoaded = true;

--- a/frontend/src/pages/Events/ManageEvents.vue
+++ b/frontend/src/pages/Events/ManageEvents.vue
@@ -24,7 +24,7 @@
   import { useFilterStore } from "@/stores/filter";
   import { useEventTableStore } from "@/stores/eventTable";
   import { parseFilters } from "@/etc/helpers";
-  import { populateCommonStores, populateEventStores } from "@/stores/helpers";
+  import { populateCommonStores } from "@/stores/helpers";
   import { validEventFilters } from "@/etc/constants/events";
 
   const route = useRoute();
@@ -44,7 +44,6 @@
     if (Object.keys(route.query).length) {
       // Will need to load common stores in order to find filter values
       await populateCommonStores();
-      await populateEventStores();
       loadRouteQuery();
     }
     eventTableStore.routeFiltersLoaded = true;

--- a/frontend/tests/component/src/components/Modals/EditEventModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/EditEventModal.spec.ts
@@ -17,23 +17,19 @@ import { userReadFactory } from "@mocks/user";
 import NodeCommentEditor from "@/components/Node/NodeCommentEditor.vue";
 import NodeThreatSelector from "@/components/Node/NodeThreatSelector.vue";
 import { NodeThreat } from "@/services/api/nodeThreat";
+import { NodeThreatActor } from "@/services/api/nodeThreatActor";
+import { NodeThreatType } from "@/services/api/nodeThreatType";
+import { EventPreventionTool } from "@/services/api/eventPreventionTool";
+import { EventRemediation } from "@/services/api/eventRemediation";
+import { EventRiskLevel } from "@/services/api/eventRiskLevel";
+import { EventStatus } from "@/services/api/eventStatus";
+import { EventType } from "@/services/api/eventType";
+import { EventVector } from "@/services/api/eventVector";
+import { User } from "@/services/api/user";
 
 function factory(args = { stubActions: true }) {
   const initialState = {
     modalStore: { openModals: ["EditEventModal"] },
-    userStore: { items: [userReadFactory()] },
-    eventRemediationStore: {
-      items: [genericObjectReadFactory({ value: "Test Remediation" })],
-      itemsByQueue: {
-        external: [genericObjectReadFactory({ value: "Test Remediation" })],
-      },
-    },
-    eventPreventionToolStore: {
-      items: [genericObjectReadFactory({ value: "Test Prevention Tool" })],
-      itemsByQueue: {
-        external: [genericObjectReadFactory({ value: "Test Prevention Tool" })],
-      },
-    },
   };
   const wrapper = mount(EditEventModal, {
     global: {
@@ -59,6 +55,29 @@ function factory(args = { stubActions: true }) {
 }
 
 describe("EventAlertsTable", () => {
+  beforeEach(() => {
+    cy.stub(EventPreventionTool, "readAll").returns([
+      genericObjectReadFactory({
+        value: "Test Prevention Tool",
+        queues: [genericObjectReadFactory({ value: "external" })],
+      }),
+    ]);
+    cy.stub(EventRiskLevel, "readAll").returns([]);
+    cy.stub(EventRemediation, "readAll").returns([
+      genericObjectReadFactory({
+        value: "Test Remediation",
+        queues: [genericObjectReadFactory({ value: "external" })],
+      }),
+    ]);
+    cy.stub(EventStatus, "readAll").returns([]);
+    cy.stub(EventType, "readAll").returns([]);
+    cy.stub(NodeThreatActor, "readAll").returns([]);
+    cy.stub(NodeThreat, "readAll").returns([]);
+    cy.stub(NodeThreatType, "readAll").returns([]);
+    cy.stub(EventVector, "readAll").returns([]);
+    cy.stub(User, "readAll").returns([userReadFactory()]);
+  });
+
   it("renders", () => {
     cy.stub(Event, "read").returns(eventReadFactory());
     factory();
@@ -69,7 +88,6 @@ describe("EventAlertsTable", () => {
         queue: genericObjectReadFactory({ value: "external" }),
       }),
     );
-    cy.stub(NodeThreat, "readAll").returns([]);
     const wrapper = factory({
       stubActions: false,
     });
@@ -121,7 +139,6 @@ describe("EventAlertsTable", () => {
       ])
       .as("updateEvent")
       .resolves();
-    cy.stub(NodeThreat, "readAll").returns([]);
     const wrapper = factory({
       stubActions: false,
     });
@@ -206,7 +223,7 @@ describe("EventAlertsTable", () => {
         .should("have.length", 0);
     });
   });
-  it.only("correctly displays error if event cannot be updated", () => {
+  it("correctly displays error if event cannot be updated", () => {
     cy.stub(Event, "read").returns(
       eventReadFactory({
         queue: genericObjectReadFactory({ value: "external" }),
@@ -225,7 +242,6 @@ describe("EventAlertsTable", () => {
       ])
       .as("updateEvent")
       .rejects(new Error("404 request could not be completed"));
-    cy.stub(NodeThreat, "readAll").returns([]);
     const wrapper = factory({
       stubActions: false,
     });
@@ -257,17 +273,13 @@ describe("EventAlertsTable", () => {
         "Could not update event: 404 request could not be completed",
       ).should("be.visible");
 
-      // Checks for the modal content main content div and error div
-      cy.get('[data-cy="edit-event-modal"]')
-        .children(".p-dialog-content")
-        .should("have.length", 2);
-      // Checks that nothing is in the main content div (form shouldn't load if there was an error)
+      // Checks that the error and form elements are all visible together
       cy.get('[data-cy="edit-event-modal"]')
         .children(".p-dialog-content")
         .eq(0)
         .children()
         .children()
-        .should("have.length", 0);
+        .should("have.length", 8);
     });
   });
 });

--- a/frontend/tests/component/src/components/Modals/EditEventModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/EditEventModal.spec.ts
@@ -9,22 +9,85 @@ import EditEventModal from "@/components/Modals/EditEventModal.vue";
 import { Event } from "@/services/api/event";
 import { eventReadFactory, mockEventUUID } from "@mocks/events";
 import { testConfiguration } from "@/etc/configuration/test/index";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import { genericObjectReadFactory } from "@mocks/genericObject";
+
+function factory(args = { modalIsOpen: true, stubActions: true }) {
+  let initialState;
+  if (args.modalIsOpen) {
+    initialState = { modalStore: { openModals: ["EditEventModal"] } };
+  } else {
+    initialState = { modalStore: { openModals: [] } };
+  }
+  const wrapper = mount(EditEventModal, {
+    global: {
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          initialState: initialState,
+          stubActions: args.stubActions,
+        }),
+      ],
+      provide: {
+        availableEditFields: testConfiguration.events.eventEditableProperties,
+      },
+    },
+    propsData: {
+      eventUuid: mockEventUUID,
+      name: "EditEventModal",
+    },
+  });
+  return wrapper;
+}
 
 describe("EventAlertsTable", () => {
-  it("renders", () => {
+  it.skip("renders when modal is closed", () => {
     cy.stub(Event, "read").returns(eventReadFactory());
-
-    mount(EditEventModal, {
-      global: {
-        plugins: [PrimeVue, createPinia()],
-        provide: {
-          availableEditFields: testConfiguration.events.eventEditableProperties,
-        },
-      },
-      propsData: {
-        eventUuid: mockEventUUID,
-        name: "EditEventModal",
-      },
+    factory({ modalIsOpen: false, stubActions: true });
+  });
+  it.skip("renders when modal is open", () => {
+    cy.stub(Event, "read").returns(eventReadFactory());
+    factory();
+  });
+  it.only("correctly pre-loads the form with existing event data", () => {
+    cy.stub(Event, "read").returns(
+      eventReadFactory({
+        queue: genericObjectReadFactory({ value: "external" }),
+      }),
+    );
+    const wrapper = factory({
+      modalIsOpen: false,
+      stubActions: false,
     });
+    wrapper.then((wrapper) => {
+      wrapper.vm.modalStore.open("EditEventModal");
+    });
+  });
+  it("correctly submits updated event data and updates modal form when re-opened", () => {
+    cy.stub(Event, "read").returns(eventReadFactory());
+    factory();
+  });
+  it("correctly displays error if event attribute data (status, owners, etc.) cannot be fetched", () => {
+    cy.stub(Event, "read").rejects(
+      new Error("404 request could not be completed"),
+    );
+    factory();
+  });
+  it("correctly displays error if event queue is not valid", () => {
+    cy.stub(Event, "read").returns(eventReadFactory());
+    factory();
+  });
+  it("correctly displays error if event data cannot be fetched", () => {
+    cy.stub(Event, "read").rejects(
+      new Error("404 request could not be completed"),
+    );
+    factory();
+  });
+  it("correctly displays error if event cannot be updated", () => {
+    cy.stub(Event, "read").returns(eventReadFactory());
+    cy.stub(Event, "update").rejects(
+      new Error("404 request could not be completed"),
+    );
+    factory();
   });
 });

--- a/frontend/tests/mocks/genericObject.ts
+++ b/frontend/tests/mocks/genericObject.ts
@@ -4,8 +4,10 @@ export const genericObjectReadFactory = ({
   description = "A generic object",
   uuid = "testObject1",
   value = "testObject",
+  queues = undefined,
 }: Partial<genericObjectRead> = {}): genericObjectRead => ({
   description: description,
   uuid: uuid,
   value: value,
+  queues: queues,
 });


### PR DESCRIPTION
This PR fixes some logic in the Edit Event modal where all of the event data was being considered 'update' data, regardless of whether anything changed. This had the side effect of updating things like comment timestamps, etc. Now, only changed event data will be sent to the API as part of the update.