### PR TITLE
Analysis caching exclusion constraint

### DIFF
--- a/db_api/app/db/crud/__init__.py
+++ b/db_api/app/db/crud/__init__.py
@@ -318,7 +318,7 @@ def read_cached_analysis(analysis_module_type_uuid: UUID, observable_uuid: UUID,
             select(Analysis).where(
                 Analysis.analysis_module_type_uuid == analysis_module_type_uuid,
                 Analysis.parent_observable_uuid == observable_uuid,
-                datetime.utcnow() < Analysis.cached_until,
+                Analysis.cached_during.contains(datetime.now(timezone.utc)),
             )
         )
         .scalars()

--- a/db_api/app/db/schemas/analysis.py
+++ b/db_api/app/db/schemas/analysis.py
@@ -1,5 +1,5 @@
-from sqlalchemy import Column, DateTime, ForeignKey, String
-from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String
+from sqlalchemy.dialects.postgresql import ExcludeConstraint, JSONB, TSTZRANGE, UUID
 from sqlalchemy.orm import deferred, relationship
 
 from api_models.analysis import AnalysisNodeTreeRead
@@ -15,7 +15,7 @@ class Analysis(Node):
 
     analysis_module_type_uuid = Column(UUID(as_uuid=True), ForeignKey("analysis_module_type.uuid"), nullable=False)
 
-    cached_until = Column(DateTime(timezone=True), index=True, nullable=False)
+    cached_during = Column(TSTZRANGE(), nullable=False)
 
     # Using deferred means that when you query the Analysis table, you will not select the details field unless
     # you explicitly ask for it. This is so that we can more efficiently load alert trees without selecting
@@ -33,6 +33,26 @@ class Analysis(Node):
     summary = Column(String)
 
     __mapper_args__ = {"polymorphic_identity": "analysis", "polymorphic_load": "inline"}
+
+    __table_args__ = (
+        Index(
+            "analysis_module_type_observable_cached_during_idx",
+            analysis_module_type_uuid,
+            parent_observable_uuid,
+            cached_during,
+        ),
+        ExcludeConstraint(
+            ("analysis_module_type_uuid", "="),
+            ("parent_observable_uuid", "="),
+            ("cached_during", "&&"),
+            name="cached_analysis_uc",
+            using="gist",
+        ),
+    )
+
+    @property
+    def cached_until(self):
+        return self.cached_during.upper
 
     def serialize_for_node_tree(self) -> AnalysisNodeTreeRead:
         return AnalysisNodeTreeRead(**self.__dict__)

--- a/db_api/app/tests/alerts/smallWithUrls.json
+++ b/db_api/app/tests/alerts/smallWithUrls.json
@@ -176,12 +176,7 @@
                   }
                 }
               ]
-            }
-          ]
-        },
-        {
-          "type": "File Analysis",
-          "observables": [
+            },
             {
               "type": "md5",
               "value": "912ec803b2ce49e4a541068d495ab570",

--- a/db_api/app/tests/api/event/test_read.py
+++ b/db_api/app/tests/api/event/test_read.py
@@ -637,19 +637,21 @@ def test_summary_user(client, db):
     # alert1
     #   o1
     #     a1 - user1 analysis
-    #   o2
-    #     a2 - user1 analysis
     #
     # alert2
     #  o1
     #    a1 - user2 analysis
+    #
+    # alert3
+    #  o1
+    #    a1 - user1 analysis
 
     alert_tree1 = helpers.create_alert(db=db, event=event)
     alert1_o1 = helpers.create_observable(
         type="email_address", value="goodguy@company.com", parent_tree=alert_tree1, db=db
     )
     # This analysis is missing the optional "manager_email" key
-    alert1_a1 = helpers.create_analysis(
+    helpers.create_analysis(
         db=db,
         parent_tree=alert1_o1,
         parent_observable=alert1_o1.node,
@@ -663,28 +665,10 @@ def test_summary_user(client, db):
             "title": "Director",
         },
     )
-    alert1_o2 = helpers.create_observable(
-        type="email_address", value="otherguy@company.com", parent_tree=alert1_a1, db=db
-    )
-    # This analysis is missing the optional "manager_email" key
-    helpers.create_analysis(
-        db=db,
-        parent_tree=alert1_o2,
-        parent_observable=alert1_o2.node,
-        amt_value="User Analysis",
-        details={
-            "user_id": "12345",
-            "email": "goodguy@company.com",
-            "company": "Company Inc.",
-            "division": "R&D",
-            "department": "Widgets",
-            "title": "Director",
-        },
-    )
 
     alert_tree2 = helpers.create_alert(db=db, event=event)
     alert2_o1 = helpers.create_observable(
-        type="email_address", value="goodguy@company.com", parent_tree=alert_tree2, db=db
+        type="email_address", value="otherguy@company.com", parent_tree=alert_tree2, db=db
     )
     helpers.create_analysis(
         db=db,
@@ -702,15 +686,35 @@ def test_summary_user(client, db):
         },
     )
 
-    # Add a third alert that is not part of the event
-    alert_tree3 = helpers.create_alert(db=db)
+    alert_tree3 = helpers.create_alert(db=db, event=event)
     alert3_o1 = helpers.create_observable(
-        type="email_address", value="dude@company.com", parent_tree=alert_tree3, db=db
+        type="email_address", value="goodguy@company.com", parent_tree=alert_tree3, db=db
     )
+    # This analysis is missing the optional "manager_email" key
     helpers.create_analysis(
         db=db,
         parent_tree=alert3_o1,
         parent_observable=alert3_o1.node,
+        amt_value="User Analysis",
+        details={
+            "user_id": "12345",
+            "email": "goodguy@company.com",
+            "company": "Company Inc.",
+            "division": "R&D",
+            "department": "Widgets",
+            "title": "Director",
+        },
+    )
+
+    # Add a fourth alert that is not part of the event
+    alert_tree4 = helpers.create_alert(db=db)
+    alert4_o1 = helpers.create_observable(
+        type="email_address", value="dude@company.com", parent_tree=alert_tree4, db=db
+    )
+    helpers.create_analysis(
+        db=db,
+        parent_tree=alert4_o1,
+        parent_observable=alert4_o1.node,
         amt_value="User Analysis",
         details={
             "user_id": "abcde",

--- a/db_container/extensions.sh
+++ b/db_container/extensions.sh
@@ -3,6 +3,8 @@ for db in ace ace_test
 do
     echo "SELECT 'CREATE DATABASE $db' WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$db')\gexec" | psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER"
 
+    # The btree_gist extension is needed for the Analysis table ExcludeConstraint functionality since UUID cannot work with gist.
+    psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -d "$db" -c "CREATE EXTENSION IF NOT EXISTS btree_gist"
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -d "$db" -c "CREATE EXTENSION IF NOT EXISTS pg_trgm"
     psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" -d "$db" -c "CREATE EXTENSION IF NOT EXISTS pgcrypto"
 done

--- a/frontend/tests/e2e/specs/ViewAlert.spec.js
+++ b/frontend/tests/e2e/specs/ViewAlert.spec.js
@@ -79,6 +79,11 @@ describe("ViewAlert.vue", () => {
     });
 
     it("should toggle observable/analysis expanded status when icon clicked", () => {
+      // Number of expanded nodes
+      cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 17);
+      // Number of collapsed nodes (the 2nd 'evil.com' observable)
+      cy.get(".p-treenode-content .pi-chevron-right").should("have.length", 1);
+
       // Second 'fqdn: evil.com' toggle icon
       cy.get(
         '[data-cy="fqdn: evil.com"] > :nth-child(1) > :nth-child(1) > .p-link > .p-tree-toggler-icon',
@@ -98,9 +103,10 @@ describe("ViewAlert.vue", () => {
 
       // Only that icon should have changed
       // Number of expanded nodes
-      cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 19);
+      cy.get(".p-treenode-content .pi-chevron-down").should("have.length", 18);
       // Number of collapsed nodes
-      cy.get(".p-treenode-content .pi-chevron-right").should("not.exist");
+      // The 2nd 'evil.com' is now opened up, but its child analysis is still collapsed
+      cy.get(".p-treenode-content .pi-chevron-right").should("have.length", 1);
 
       // Should now have down/'expanded' toggle icon
       cy.get(


### PR DESCRIPTION
This PR makes a slight adjustment to the analysis caching implemented in #185. Specifically, it uses PostgreSQL's "exclusion constraint" functionality to ensure that you cannot add two analysis objects to the database that:

* Use the same AnalysisModuleType
* Are for the same parent observable
* Have overlapping cached_during datetime ranges