### PR TITLE
Does not automatically create observable type when creating observable

### DIFF
--- a/db_api/app/db/crud/observable.py
+++ b/db_api/app/db/crud/observable.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import Session
 from typing import Optional
 from uuid import uuid4
 
-from db.crud.observable_type import create_observable_type
+from db.crud.observable_type import read_observable_type
 from db.schemas.observable import Observable
 from db.schemas.observable_type import ObservableType
 
@@ -31,7 +31,7 @@ def create_observable(
             for_detection=for_detection,
             redirection=redirection,
             time=time,
-            type=create_observable_type(value=type, db=db),
+            type=read_observable_type(value=type, db=db),
             uuid=uuid4(),
             value=value,
             version=uuid4(),

--- a/db_api/app/db/crud/observable_type.py
+++ b/db_api/app/db/crud/observable_type.py
@@ -1,6 +1,5 @@
 from sqlalchemy import select
 from sqlalchemy.orm import Session
-from typing import Optional
 
 from db.schemas.observable_type import ObservableType
 
@@ -9,5 +8,5 @@ def create_observable_type(value: str, db: Session, description: str = None) -> 
     return read_observable_type(value=value, db=db) or ObservableType(description=description, value=value)
 
 
-def read_observable_type(value: str, db: Session) -> Optional[ObservableType]:
-    return db.execute(select(ObservableType).where(ObservableType.value == value)).scalars().one_or_none()
+def read_observable_type(value: str, db: Session) -> ObservableType:
+    return db.execute(select(ObservableType).where(ObservableType.value == value)).scalars().one()

--- a/db_api/app/tests/api/analysis/test_create.py
+++ b/db_api/app/tests/api/analysis/test_create.py
@@ -301,6 +301,7 @@ def test_create_node_metadata(client, db):
     ],
 )
 def test_create_valid_optional_fields(client, db, key, value):
+    helpers.create_observable_type(value="fqdn", db=db)
     alert_tree = helpers.create_alert(db=db)
     observable_tree = helpers.create_observable(type="ipv4", value="127.0.0.1", parent_tree=alert_tree, db=db)
     analysis_module_type = helpers.create_analysis_module_type(value="test", db=db)

--- a/db_api/app/tests/db/observable.py
+++ b/db_api/app/tests/db/observable.py
@@ -1,0 +1,10 @@
+import pytest
+
+from sqlalchemy.exc import NoResultFound
+
+from db.crud.observable import create_observable
+
+
+def test_create_observable_nonexistent_type(db):
+    with pytest.raises(NoResultFound):
+        create_observable(type="asdf", value="asdf", db=db)


### PR DESCRIPTION
This PR makes a minor tweak to the new database abstraction layer in that it will no longer automatically create a new observable type if it does not already exist when creating an observable.