### PR TITLE
Add FP and Ignore dispo shortcut buttons

### DIFF
--- a/frontend/src/components/Alerts/TheAlertActionToolbar.vue
+++ b/frontend/src/components/Alerts/TheAlertActionToolbar.vue
@@ -4,10 +4,28 @@
 <template>
   <TheNodeActionToolbarVue ref="toolbar" :reload-object="props.reloadObject">
     <template #start>
-      <!--      DISPOSITION -->
+      <!-- FALSE POSITIVE -->
+      <Button
+        v-if="showFalsePositiveShortcut"
+        data-cy="false-positive-button"
+        class="p-m-1 p-button-normal p-button-success"
+        icon="pi pi-thumbs-up"
+        label="FP"
+        @click="emit('falsePositiveClicked')"
+      />
+      <!-- IGNORE -->
+      <Button
+        v-if="showIgnoreShortcut"
+        data-cy="ignore-button"
+        class="p-m-1 p-button-sm"
+        icon="pi pi-check"
+        label="Ignore"
+        @click="emit('ignoreClicked')"
+      />
+      <!-- DISPOSITION -->
       <Button
         data-cy="disposition-button"
-        class="p-m-1 p-button-normal p-button-success"
+        class="p-m-1 p-button-sm"
         icon="pi pi-thumbs-up"
         label="Disposition"
         @click="open('DispositionModal')"
@@ -16,7 +34,7 @@
         name="DispositionModal"
         @request-reload="requestReload"
       />
-      <!--      REMEDIATE MODAL -->
+      <!-- REMEDIATE MODAL -->
       <Button
         data-cy="remediate-button"
         class="p-m-1 p-button-sm"
@@ -31,7 +49,7 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, defineProps, PropType } from "vue";
+  import { ref, defineEmits, defineProps, PropType } from "vue";
 
   import Button from "primevue/button";
 
@@ -41,11 +59,19 @@
 
   import { useModalStore } from "@/stores/modal";
 
+  const emit = defineEmits(["falsePositiveClicked", "ignoreClicked"]);
+
   const props = defineProps({
     reloadObject: {
       type: String as PropType<"table" | "node">,
       required: true,
     },
+    showFalsePositiveShortcut: {
+      type: Boolean,
+      required: false,
+      default: false,
+    },
+    showIgnoreShortcut: { type: Boolean, required: false, default: false },
   });
 
   const modalStore = useModalStore();

--- a/frontend/src/etc/configuration/alerts.ts
+++ b/frontend/src/etc/configuration/alerts.ts
@@ -68,3 +68,6 @@ export const alertRangeFilters = {
     end: alertPropertyTypes.DISPOSITIONED_BEFORE_PROPERTY,
   },
 };
+
+export const FALSE_POSITIVE_DISPOSITION_STRING = "FALSE_POSITIVE";
+export const IGNORE_DISPOSITION_STRING = "IGNORE";

--- a/frontend/src/etc/configuration/test/alerts.ts
+++ b/frontend/src/etc/configuration/test/alerts.ts
@@ -48,3 +48,6 @@ export const alertRangeFilters = {
     end: alertPropertyTypes.INSERT_TIME_BEFORE_PROPERTY,
   },
 };
+
+export const FALSE_POSITIVE_DISPOSITION_STRING = "FALSE_POSITIVE";
+export const IGNORE_DISPOSITION_STRING = "IGNORE";

--- a/frontend/tests/component/src/components/Alerts/TheAlertActionToolbar.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/TheAlertActionToolbar.spec.ts
@@ -8,13 +8,15 @@ import router from "@/router/index";
 
 interface TheAlertActionToolbarProps {
   reloadObject: "node" | "table";
+  showFalsePositiveShortcut?: boolean;
+  showIgnoreShortcut?: boolean;
 }
 
-const props: TheAlertActionToolbarProps = {
+const defaultProps: TheAlertActionToolbarProps = {
   reloadObject: "node",
 };
 
-function factory() {
+function factory(props = defaultProps) {
   return mount(TheAlertActionToolbar, {
     global: {
       plugins: [PrimeVue, createPinia(), router],
@@ -36,5 +38,44 @@ describe("TheAlertActionToolbar", () => {
     factory();
     cy.contains("Disposition").click();
     cy.contains("Set Disposition").should("be.visible");
+  });
+  it("renders as expected when optional button props are enabled", () => {
+    factory({
+      reloadObject: "node",
+      showFalsePositiveShortcut: true,
+      showIgnoreShortcut: true,
+    });
+    cy.contains("FP").should("be.visible");
+    cy.contains("Ignore").should("be.visible");
+    cy.contains("Disposition").should("be.visible");
+    cy.contains("Remediate").should("be.visible");
+  });
+  it("should emit 'falsePositiveClicked' when FP button clicked", () => {
+    factory({
+      reloadObject: "node",
+      showFalsePositiveShortcut: true,
+    });
+    cy.contains("FP")
+      .click()
+      .then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should(
+          "have.property",
+          "falsePositiveClicked",
+        );
+      });
+  });
+  it("should emit 'ignoreClicked' when ignore button clicked", () => {
+    factory({
+      reloadObject: "node",
+      showIgnoreShortcut: true,
+    });
+    cy.contains("Ignore")
+      .click()
+      .then(() => {
+        cy.wrap(Cypress.vueWrapper.emitted()).should(
+          "have.property",
+          "ignoreClicked",
+        );
+      });
   });
 });


### PR DESCRIPTION
This PR adds 'FP' and 'Ignore' buttons to the View Alert AlertActionToolbar to quickly disposition an alert as FP or ignored. It requires config strings to be set for each of these dispositions to map to the corresponding dispositions in the db.

Closes #199 and #198 

![dispoShortcut](https://user-images.githubusercontent.com/31867815/166463159-48013a01-1230-4e64-8b60-8e285b265fa0.gif)

