### PR TITLE
Add instructions to alert details

### DIFF
--- a/frontend/src/components/Alerts/TheAlertDetails.vue
+++ b/frontend/src/components/Alerts/TheAlertDetails.vue
@@ -52,6 +52,12 @@
                     {{ detection.value }}
                   </td>
                 </tr>
+                <tr v-if="alertStore.open['instructions']">
+                  <td class="header-cell">Instructions</td>
+                  <td class="content-cell">
+                    {{ alertStore.open["instructions"] }}
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>

--- a/frontend/tests/component/src/components/Alerts/TheAlertDetails.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/TheAlertDetails.spec.ts
@@ -38,7 +38,7 @@ describe("TheAlertDetails", () => {
     cy.get("@getObservables").should("not.have.been.called");
     cy.contains("Test Alert").should("not.exist");
   });
-  it("renders correctly when there is an open alert that has no observables with detection points", () => {
+  it("renders correctly when there is an open alert that has no observables with detection points or instructions", () => {
     cy.stub(NodeTree, "readNodesOfNodeTree")
       .withArgs(["testAlertUuid"], "observable")
       .as("getObservables")
@@ -72,6 +72,26 @@ describe("TheAlertDetails", () => {
     cy.contains("Owner").siblings().should("have.text", "None");
     cy.contains("Comments").siblings().should("have.text", "None");
     cy.contains("No detections found").should("be.visible");
+  });
+  it("renders correctly when there is an open alert that has instructions available", () => {
+    cy.stub(NodeTree, "readNodesOfNodeTree")
+      .withArgs(["testAlertUuid"], "observable")
+      .as("getObservables")
+      .resolves([]);
+    factory({
+      open: alertReadFactory({
+        instructions: "alert instructions example",
+        tags: [genericObjectReadFactory({ value: "TestTag" })],
+      }),
+      requestReload: false,
+    });
+
+    cy.get("@getObservables").should("have.been.calledOnce");
+
+    cy.get("tr").should("have.length", 12);
+    cy.contains("Instructions")
+      .siblings()
+      .should("have.text", "alert instructions example");
   });
   it("renders correctly when there is an open alert that does have observables with detection points", () => {
     const detectionPointA = {


### PR DESCRIPTION
This PR adds an alert's instructions to the alert details, if there are instructions available.

Closes #203

![image](https://user-images.githubusercontent.com/31867815/166686165-2b63efe5-b02c-413b-bd10-d4eca8fde355.png)
