### PR TITLE
Add detection point symbols to observables

### DIFF
--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -7,6 +7,17 @@
       @click="filterByObservable(observable)"
       >{{ displayValue }}
     </span>
+    <span
+      v-for="detection in observable.detectionPoints"
+      :key="detection.uuid"
+      v-tooltip.right="{
+        value: detection.value,
+      }"
+      class="detection-point"
+      data-cy="detection-point-symbol"
+    >
+      &#128293;</span
+    >
     <Button
       v-if="showCopyToClipboard"
       data-cy="copy-to-clipboard-button"
@@ -260,5 +271,9 @@
     cursor: pointer;
     text-decoration: underline;
     font-weight: bold;
+  }
+
+  .detection-point:hover {
+    cursor: pointer;
   }
 </style>


### PR DESCRIPTION
This PR adds detection points symbols to observables, and will display the detection value on hover.

Closes #210 

![image](https://user-images.githubusercontent.com/31867815/166977493-7ae7719b-3c7c-4560-bfe5-22f22706dfb4.png)
