### PR TITLE
'Add Tag' observable action

### DIFF
--- a/frontend/src/components/Events/TheEventDetailsMenuBar.vue
+++ b/frontend/src/components/Events/TheEventDetailsMenuBar.vue
@@ -13,6 +13,7 @@
   <TagModal
     name="TagModal"
     reload-object="node"
+    node-type="events"
     @request-reload="requestReload"
   />
   <EditEventModal

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -55,6 +55,7 @@
         />
         <TagModal
           name="TagModal"
+          :node-type="nodeType"
           :reload-object="props.reloadObject"
           @request-reload="requestReload"
         />

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -58,7 +58,7 @@
         :name="componentName"
         :observable="observable"
         reload-object="node"
-        @request-reload="alertStore.requestReload = true"
+        @request-reload="reload"
       ></component>
     </span>
     <span v-if="showTags && observable.tags.length" class="leaf-element">
@@ -270,6 +270,10 @@
       detail: args.detail,
       life: 6000,
     });
+  };
+
+  const reload = () => {
+    alertStore.requestReload = true;
   };
 
   const toggle = (event: unknown) => {

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -57,6 +57,7 @@
         :is="component"
         :name="componentName"
         :observable="observable"
+        node-type="observable"
         reload-object="node"
         @request-reload="reload"
       ></component>

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -57,6 +57,8 @@
         :is="component"
         :name="componentName"
         :observable="observable"
+        reload-object="node"
+        @request-reload="alertStore.requestReload = true"
       ></component>
     </span>
     <span v-if="showTags && observable.tags.length" class="leaf-element">

--- a/frontend/src/etc/configuration/observables.ts
+++ b/frontend/src/etc/configuration/observables.ts
@@ -3,6 +3,7 @@ import {
   enableDetection,
   disableDetection,
   updateDetectionExpiration,
+  addTag,
 } from "../constants/observables";
 
 type FILE = "file";
@@ -14,6 +15,7 @@ type knownObservables = FILE | URL | IPV4;
 type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>;
 
 export const commonObservableActions = [
+  addTag,
   enableDetection,
   disableDetection,
   updateDetectionExpiration,

--- a/frontend/src/etc/configuration/test/observables.ts
+++ b/frontend/src/etc/configuration/test/observables.ts
@@ -1,5 +1,8 @@
+import BaseModalVue from "@/components/Modals/BaseModal.vue";
+import TagModalVue from "@/components/Modals/TagModal.vue";
 import {
   observableActionCommand,
+  observableActionModal,
   observableTreeRead,
 } from "@/models/observable";
 import { observableTypeMetaData } from "@/models/observableType";
@@ -17,7 +20,17 @@ type knownObservables = FILE | URL | IPV4;
 
 type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>;
 
+export const testModalAction: observableActionModal = {
+  label: "Test Action",
+  description: "Test Modal Action",
+  icon: "pi pi-tag",
+  type: "modal",
+  modal: TagModalVue,
+  modalName: "testModal",
+};
+
 export const commonObservableActions = [
+  testModalAction,
   enableDetection,
   disableDetection,
   updateDetectionExpiration,

--- a/frontend/src/etc/constants/observables.ts
+++ b/frontend/src/etc/constants/observables.ts
@@ -1,4 +1,5 @@
 import UpdateDetectionExpirationVue from "@/components/Observables/ObservableActions/UpdateDetectionExpiration.vue";
+import TagModalVue from "@/components/Modals/TagModal.vue";
 import {
   observableActionModal,
   observableActionCommand,
@@ -38,4 +39,13 @@ export const updateDetectionExpiration: observableActionModal = {
   modal: UpdateDetectionExpirationVue,
   modalName: "UpdateDetectionExpiration",
   requirements: (obs: observableTreeRead) => obs.forDetection,
+};
+
+export const addTag: observableActionModal = {
+  label: "Add Tag",
+  description: "Add a tag to a given observable",
+  icon: "pi pi-tag",
+  type: "modal",
+  modal: TagModalVue,
+  modalName: "ObservableTagModal",
 };

--- a/frontend/src/stores/observable.ts
+++ b/frontend/src/stores/observable.ts
@@ -1,0 +1,21 @@
+import { defineStore } from "pinia";
+import { observableRead, observableUpdate } from "@/models/observable";
+import { ObservableInstance } from "@/services/api/observable";
+import { UUID } from "@/models/base";
+
+export const useObservableStore = defineStore({
+  id: "observableStore",
+  actions: {
+    async read(uuid: UUID): Promise<observableRead> {
+      return await ObservableInstance.read(uuid).catch((error) => {
+        throw error;
+      });
+    },
+
+    async update(uuid: UUID, data: observableUpdate) {
+      await ObservableInstance.update(uuid, data).catch((error) => {
+        throw error;
+      });
+    },
+  },
+});

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -202,7 +202,7 @@ describe("TagModal", () => {
 
     cy.stub(NodeTag, "readAll")
       .as("readAllTags")
-      .rejects(new Error("404 request failed"));
+      .rejects(new Error("404 request failed !"));
 
     cy.stub(Alert, "update").as("updateAlert").resolves();
 
@@ -222,7 +222,7 @@ describe("TagModal", () => {
     cy.get("@createTag").should("have.been.calledOnce");
     cy.get("@readAllTags").should("have.been.calledOnce");
     cy.get("@updateAlert").should("not.have.been.called");
-    cy.contains("404 request failed").should("be.visible");
+    cy.contains("404 request failed !").should("be.visible");
   });
   it("shows error if request to create a new tag fails", () => {
     cy.stub(NodeTag, "create")
@@ -230,7 +230,7 @@ describe("TagModal", () => {
         value: "testTag",
       })
       .as("createTag")
-      .rejects(new Error("404 request failed"));
+      .rejects(new Error("404 request failed !"));
 
     cy.stub(NodeTag, "readAll").as("readAllTags").resolves();
 
@@ -252,7 +252,7 @@ describe("TagModal", () => {
     cy.get("@createTag").should("have.been.calledOnce");
     cy.get("@readAllTags").should("not.have.been");
     cy.get("@updateAlert").should("not.have.been");
-    cy.contains("404 request failed").should("be.visible");
+    cy.contains("404 request failed !").should("be.visible");
   });
   it("shows error if request to update node tags fails", () => {
     cy.stub(NodeTag, "create")
@@ -274,7 +274,7 @@ describe("TagModal", () => {
         },
       ])
       .as("updateAlert")
-      .rejects(new Error("404 request failed"));
+      .rejects(new Error("404 request failed !"));
 
     factory({
       selected: ["uuid"],
@@ -292,6 +292,6 @@ describe("TagModal", () => {
     cy.get("@createTag").should("have.been.calledOnce");
     cy.get("@readAllTags").should("have.been.calledOnce");
     cy.get("@updateAlert").should("have.been.calledOnce");
-    cy.contains("404 request failed").should("be.visible");
+    cy.contains("404 request failed !").should("be.visible");
   });
 });

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -29,7 +29,7 @@ function factory(
             alertStore: {
               open: alertReadFactory({
                 uuid: "uuid",
-                tags: [existingTag],
+                tags: args.existingTags,
               }),
             },
             selectedAlertStore: {
@@ -107,20 +107,20 @@ describe("TagModal", () => {
   it("attempts to create new tags and update selected nodes with new and existing tags and 'Add' clicked", () => {
     cy.stub(NodeTag, "create")
       .withArgs({
-        value: "testTag",
+        value: "newTag",
       })
       .as("createTag")
       .resolves();
 
     cy.stub(NodeTag, "readAll")
       .as("readAllTags")
-      .resolves([testTag, existingTag, newTag]);
+      .resolves([testTag, existingTag]);
 
     cy.stub(Alert, "update")
       .withArgs([
         {
           uuid: "uuid",
-          tags: ["existingTag", "testTag", "newTag"],
+          tags: ["testTag", "existingTag", "newTag"],
         },
       ])
       .as("updateAlert")
@@ -213,13 +213,13 @@ describe("TagModal", () => {
 
     cy.stub(NodeTag, "readAll")
       .as("readAllTags")
-      .resolves([testTag, existingTag, newTag]);
+      .resolves([testTag, existingTag]);
 
     cy.stub(Alert, "update")
       .withArgs([
         {
           uuid: "uuid",
-          tags: ["existingTag", "testTag", "newTag"],
+          tags: ["testTag", "existingTag", "newTag"],
         },
       ])
       .as("updateAlert")

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -19,10 +19,12 @@ function factory(
   args: {
     selected: string[];
     existingTags: nodeTagRead[];
+    nodeType: "alerts" | "events" | "observable";
     observable: undefined | observableTreeRead;
   } = {
     selected: [],
     existingTags: [],
+    nodeType: "alerts",
     observable: undefined,
   },
 ) {
@@ -48,13 +50,11 @@ function factory(
           },
         }),
       ],
-      provide: {
-        nodeType: "alerts",
-      },
     },
     propsData: {
       name: "TagModal",
       reloadObject: "node",
+      nodeType: args.nodeType,
       observable: args.observable,
     },
   }).then((wrapper) => {
@@ -81,6 +81,8 @@ describe("TagModal", () => {
     factory({
       selected: [],
       existingTags: [testTag],
+      nodeType: "alerts",
+
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -91,6 +93,8 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [],
+      nodeType: "alerts",
+
       observable: undefined,
     });
     cy.get('[data-cy="chips-container"]')
@@ -111,6 +115,8 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [],
+      nodeType: "alerts",
+
       observable: undefined,
     });
     cy.findByText("Add").parent().should("be.disabled");
@@ -140,6 +146,8 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
+      nodeType: "alerts",
+
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -177,6 +185,7 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
+      nodeType: "observable",
       observable: observableTreeReadFactory({ tags: [testTag, existingTag] }),
     });
     cy.contains("Select from existing tags").click();
@@ -209,6 +218,7 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
+      nodeType: "alerts",
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -239,6 +249,7 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
+      nodeType: "alerts",
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -279,6 +290,7 @@ describe("TagModal", () => {
     factory({
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
+      nodeType: "alerts",
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();

--- a/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
@@ -129,11 +129,16 @@ describe("ObservableLeaf", () => {
       config: testConfiguration,
     });
 
-    const expectedMenuItems = ["Enable Detection", "Subheader", "IPV4 Command"];
+    const expectedMenuItems = [
+      "Test Action",
+      "Enable Detection",
+      "Subheader",
+      "IPV4 Command",
+    ];
 
     cy.get("[data-cy='show-actions-menu-button']").click();
     cy.findAllByRole("menuitem")
-      .should("have.length", 3)
+      .should("have.length", 4)
       .each((menuItem, index) => {
         cy.wrap(menuItem).should("have.text", expectedMenuItems[index]);
       });

--- a/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
@@ -251,7 +251,7 @@ describe("ObservableLeaf", () => {
       },
     });
   });
-  it.only("attempts to requestReload on the alert store when child component emits 'requestReload", () => {
+  it("attempts to requestReload on the alert store when child component emits 'requestReload", () => {
     let alertStore: any;
     factory({
       props: { observable: observableWithTags },

--- a/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
@@ -12,6 +12,9 @@ import { testConfiguration } from "@/etc/configuration/test";
 import { ObservableInstance } from "@/services/api/observable";
 import ToastService from "primevue/toastservice";
 import Tooltip from "primevue/tooltip";
+import BaseModalVue from "@/components/Modals/BaseModal.vue";
+import TagModalVue from "@/components/Modals/TagModal.vue";
+import ObservableLeafVue from "@/components/Observables/ObservableLeaf.vue";
 
 interface ObservableLeafProps {
   observable: observableTreeRead;
@@ -33,7 +36,7 @@ function factory(
     config: testConfiguration,
   },
 ) {
-  mount(ObservableLeaf, {
+  return mount(ObservableLeaf, {
     global: {
       directives: { tooltip: Tooltip },
       plugins: [PrimeVue, ToastService, createCustomCypressPinia(), router],
@@ -247,6 +250,23 @@ describe("ObservableLeaf", () => {
         },
       },
     });
+  });
+  it.only("attempts to requestReload on the alert store when child component emits 'requestReload", () => {
+    let alertStore: any;
+    factory({
+      props: { observable: observableWithTags },
+      config: testConfiguration,
+    }).then((wrapper) => {
+      alertStore = wrapper.vm.alertStore;
+      cy.wrap(alertStore.requestReload).should("be.false");
+    });
+    cy.get('[data-cy="show-actions-menu-button"]').click();
+    cy.contains("Test Action")
+      .click()
+      .then(() => {
+        Cypress.vueWrapper.findComponent(TagModalVue).vm.$emit("requestReload");
+        cy.wrap(alertStore.requestReload).should("be.true");
+      });
   });
 });
 


### PR DESCRIPTION
This PR adds an observable action to add tags via the TagModal, and also includes some refactoring to the TagModal to allow adding tags to observables (rather than just "alerts" or "events" nodes).

Part of issue #213 