### PR TITLE
Remove Tags Modal

### DIFF
--- a/frontend/src/components/Modals/BaseModal.vue
+++ b/frontend/src/components/Modals/BaseModal.vue
@@ -38,7 +38,7 @@
 
   const store = useModalStore();
 
-  const emit = defineEmits(["dialogClose", "show"]);
+  const emit = defineEmits(["dialogClose"]);
 
   const props = defineProps({
     name: { type: String, required: true },

--- a/frontend/src/components/Modals/BaseModal.vue
+++ b/frontend/src/components/Modals/BaseModal.vue
@@ -38,7 +38,7 @@
 
   const store = useModalStore();
 
-  const emit = defineEmits(["dialogClose"]);
+  const emit = defineEmits(["dialogClose", "show"]);
 
   const props = defineProps({
     name: { type: String, required: true },

--- a/frontend/src/components/Modals/RemoveTagModal.vue
+++ b/frontend/src/components/Modals/RemoveTagModal.vue
@@ -1,0 +1,200 @@
+<!-- RemoveTagModal.vue -->
+<!-- 'Remove Tag' action modal, agnostic to what is being tagged -->
+
+<template>
+  <BaseModal :name="name" header="Remove Tag(s)" @show="initTagOptions">
+    <div>
+      <div v-if="error" class="p-col">
+        <Message severity="error" @close="handleError">{{ error }}</Message>
+      </div>
+    </div>
+    <span class="p-fluid">
+      <Chips v-model="formTagValues" data-cy="chips-container" />
+      <Dropdown
+        :options="tagOptions"
+        option-label="value"
+        :filter="true"
+        placeholder="Select from existing tags"
+        filter-placeholder="Search tags"
+        @change="addExistingTagToForm($event as unknown as tagEvent)"
+      />
+    </span>
+    <template #footer>
+      <Button
+        label="Nevermind"
+        icon="pi pi-times"
+        class="p-button-text"
+        @click="close"
+      />
+      <Button
+        data-cy="remove-button"
+        label="Remove"
+        icon="pi pi-check"
+        :disabled="!allowSubmit"
+        @click="removeTags"
+      />
+    </template>
+  </BaseModal>
+</template>
+
+<script setup lang="ts">
+  import { computed, defineEmits, defineProps, ref, PropType } from "vue";
+
+  import Button from "primevue/button";
+  import Message from "primevue/message";
+  import Chips from "primevue/chips";
+  import Dropdown from "primevue/dropdown";
+
+  import BaseModal from "@/components/Modals/BaseModal.vue";
+
+  import {
+    nodeStores,
+    nodeSelectedStores,
+    nodeTableStores,
+  } from "@/stores/index";
+  import { useModalStore } from "@/stores/modal";
+  import { useNodeTagStore } from "@/stores/nodeTag";
+  import { nodeTagRead } from "@/models/nodeTag";
+  import { observableTreeRead } from "@/models/observable";
+  import { useObservableStore } from "@/stores/observable";
+
+  const props = defineProps({
+    name: { type: String, required: true },
+    reloadObject: { type: String, required: true },
+    nodeType: {
+      type: String as PropType<"alerts" | "events" | "observable">,
+      required: true,
+    },
+    observable: {
+      type: Object as PropType<observableTreeRead>,
+      required: false,
+      default: undefined,
+    },
+  });
+
+  let nodeStore: any;
+  let tableStore: any;
+  let selectedStore: any;
+  if (!(props.nodeType === "observable")) {
+    nodeStore = nodeStores[props.nodeType]();
+    selectedStore = nodeSelectedStores[props.nodeType]();
+    tableStore = nodeTableStores[props.nodeType]();
+  }
+
+  const modalStore = useModalStore();
+  const nodeTagStore = useNodeTagStore();
+
+  const emit = defineEmits(["requestReload"]);
+
+  const formTagValues = ref<string[]>([]);
+  const tagOptions = ref<nodeTagRead[]>([]);
+  const error = ref<string>();
+  const isLoading = ref(false);
+
+  const initTagOptions = async () => {
+    if (props.nodeType === "observable" && props.observable) {
+      tagOptions.value = props.observable.tags;
+    } else if (props.reloadObject == "node") {
+      tagOptions.value = nodeStore.open.tags;
+    } else {
+      try {
+        await nodeTagStore.readAll();
+        tagOptions.value = nodeTagStore.allItems;
+      } catch (e: unknown) {
+        if (typeof e === "string") {
+          error.value = e;
+        } else if (e instanceof Error) {
+          error.value = e.message;
+        }
+      }
+    }
+  };
+
+  async function removeTags() {
+    isLoading.value = true;
+    try {
+      if (props.nodeType == "observable") {
+        await removeObservableTags();
+      } else {
+        await removeNodeTags();
+      }
+    } catch (e: unknown) {
+      if (typeof e === "string") {
+        error.value = e;
+      } else if (e instanceof Error) {
+        error.value = e.message;
+      }
+    }
+
+    isLoading.value = false;
+    if (!error.value) {
+      close();
+      emit("requestReload");
+    }
+  }
+
+  const removeNodeTags = async () => {
+    const updateData = selectedStore.selected.map((uuid: any) => ({
+      uuid: uuid,
+      tags: deduped([
+        ...existingNodeTagValues(uuid),
+        ...formTagValues.value,
+      ]).filter((tag) => !formTagValues.value.includes(tag)),
+    }));
+
+    await nodeStore.update(updateData);
+  };
+
+  const existingNodeTagValues = (uuid: string) => {
+    let nodeTags: nodeTagRead[] = [];
+    if (props.reloadObject == "table") {
+      const node = tableStore.visibleQueriedItemById(uuid);
+      nodeTags = node ? node.tags : [];
+    } else if (props.reloadObject == "node") {
+      nodeTags = nodeStore.open.tags;
+    }
+    return nodeTags.map((tag) => tag.value);
+  };
+
+  const removeObservableTags = async () => {
+    const observableStore = useObservableStore();
+
+    if (props.observable) {
+      await observableStore.update(props.observable.uuid, {
+        tags: deduped([
+          ...props.observable.tags.map((tag) => tag.value),
+          ...formTagValues.value,
+        ]).filter((tag) => !formTagValues.value.includes(tag)),
+      });
+    }
+  };
+
+  interface tagEvent {
+    value: nodeTagRead;
+  }
+  function addExistingTagToForm(tagEvent: tagEvent) {
+    // Add an existing tag to the list of tags to be added
+    formTagValues.value.push(tagEvent.value.value);
+  }
+
+  const allowSubmit = computed(() => {
+    if (props.nodeType == "observable") {
+      return formTagValues.value.length;
+    }
+    return selectedStore.selected.length && formTagValues.value.length;
+  });
+
+  const deduped = (arr: string[]) => {
+    return [...new Set(arr)];
+  };
+
+  const handleError = () => {
+    error.value = undefined;
+    close();
+  };
+
+  function close() {
+    formTagValues.value = [];
+    modalStore.close(props.name);
+  }
+</script>

--- a/frontend/src/components/Modals/TagModal.vue
+++ b/frontend/src/components/Modals/TagModal.vue
@@ -81,10 +81,10 @@
 
   let nodeStore: any;
   let tableStore: any;
-  let selected: string[];
+  let selectedStore: any;
   if (!(props.nodeType === "observable")) {
     nodeStore = nodeStores[props.nodeType]();
-    selected = nodeSelectedStores[props.nodeType]().selected;
+    selectedStore = nodeSelectedStores[props.nodeType]();
     tableStore = nodeTableStores[props.nodeType]();
   }
 
@@ -94,19 +94,19 @@
   const emit = defineEmits(["requestReload"]);
 
   const formTagValues = ref<string[]>([]);
-  const existingTagValues = ref<string[]>([]);
   const error = ref<string>();
   const isLoading = ref(false);
 
   async function loadAllExistingTags() {
     await nodeTagStore.readAll();
-    existingTagValues.value = nodeTagStore.allItems.map((tag) => tag.value);
   }
 
   async function createAndAddTags() {
     isLoading.value = true;
     try {
-      await createNewTags();
+      if (uniqueNewTags.value.length) {
+        await createNewTags();
+      }
       if (props.nodeType == "observable") {
         await addObservableTags();
       } else {
@@ -128,7 +128,7 @@
   }
 
   const addNodeTags = async () => {
-    const updateData = selected.map((uuid) => ({
+    const updateData = selectedStore.selected.map((uuid: any) => ({
       uuid: uuid,
       tags: deduped([...existingNodeTagValues(uuid), ...formTagValues.value]),
     }));
@@ -173,6 +173,10 @@
     );
   });
 
+  const existingTagValues = computed(() => {
+    return nodeTagStore.allItems.map((tag) => tag.value);
+  });
+
   interface tagEvent {
     value: nodeTagRead;
   }
@@ -185,7 +189,7 @@
     if (props.nodeType == "observable") {
       return formTagValues.value.length;
     }
-    return selected.length && formTagValues.value.length;
+    return selectedStore.selected.length && formTagValues.value.length;
   });
 
   const deduped = (arr: string[]) => {

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -61,7 +61,7 @@
         />
       </div>
       <!--      REMOVE TAG MODAL -->
-      <div v-if="props.tag">
+      <div v-if="props.removeTag">
         <Button
           data-cy="tag-button"
           class="p-m-1 p-button-sm"
@@ -112,6 +112,7 @@
     assign: { type: Boolean, default: true },
     comment: { type: Boolean, default: true },
     tag: { type: Boolean, default: true },
+    removeTag: { type: Boolean, default: true },
     takeOwnership: { type: Boolean, default: true },
   });
 

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -60,6 +60,23 @@
           @request-reload="requestReload"
         />
       </div>
+      <!--      REMOVE TAG MODAL -->
+      <div v-if="props.tag">
+        <Button
+          data-cy="tag-button"
+          class="p-m-1 p-button-sm"
+          icon="pi pi-tags"
+          label="Remove Tag(s)"
+          @click="open('RemoveTagModal')"
+          @request-reload="requestReload"
+        />
+        <RemoveTagModal
+          name="RemoveTagModal"
+          :node-type="nodeType"
+          :reload-object="props.reloadObject"
+          @request-reload="requestReload"
+        />
+      </div>
     </template>
     <template #end>
       <slot name="end"></slot>
@@ -77,6 +94,7 @@
   import AssignModal from "@/components/Modals/AssignModal.vue";
   import CommentModal from "@/components/Modals/CommentModal.vue";
   import TagModal from "@/components/Modals/TagModal.vue";
+  import RemoveTagModal from "@/components/Modals/RemoveTagModal.vue";
 
   import {
     nodeStores,

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -63,7 +63,7 @@
       <!--      REMOVE TAG MODAL -->
       <div v-if="props.removeTag">
         <Button
-          data-cy="tag-button"
+          data-cy="remove-tag-button"
           class="p-m-1 p-button-sm"
           icon="pi pi-tags"
           label="Remove Tag(s)"

--- a/frontend/src/etc/configuration/observables.ts
+++ b/frontend/src/etc/configuration/observables.ts
@@ -4,6 +4,7 @@ import {
   disableDetection,
   updateDetectionExpiration,
   addTag,
+  removeTag,
 } from "../constants/observables";
 
 type FILE = "file";
@@ -16,6 +17,7 @@ type PartialRecord<K extends keyof any, T> = Partial<Record<K, T>>;
 
 export const commonObservableActions = [
   addTag,
+  removeTag,
   enableDetection,
   disableDetection,
   updateDetectionExpiration,

--- a/frontend/src/etc/constants/observables.ts
+++ b/frontend/src/etc/constants/observables.ts
@@ -6,6 +6,7 @@ import {
   observableTreeRead,
 } from "@/models/observable";
 import { ObservableInstance } from "@/services/api/observable";
+import RemoveTagModalVue from "@/components/Modals/RemoveTagModal.vue";
 
 export const enableDetection: observableActionCommand = {
   label: "Enable Detection",
@@ -48,4 +49,13 @@ export const addTag: observableActionModal = {
   type: "modal",
   modal: TagModalVue,
   modalName: "ObservableTagModal",
+};
+
+export const removeTag: observableActionModal = {
+  label: "Remove Tag(s)",
+  description: "Remove a tag from this observable",
+  icon: "pi pi-tag",
+  type: "modal",
+  modal: RemoveTagModalVue,
+  modalName: "ObservableRemoveTagModal",
 };

--- a/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
@@ -1,0 +1,372 @@
+import { mount } from "@cypress/vue";
+import PrimeVue from "primevue/config";
+
+import RemoveTagModal from "@/components/Modals/RemoveTagModal.vue";
+import BaseModal from "@/components/Modals/BaseModal.vue";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import { genericObjectReadFactory } from "@mocks/genericObject";
+import { nodeTagRead } from "@/models/nodeTag";
+import { alertReadFactory } from "@mocks/alert";
+import { NodeTag } from "@/services/api/nodeTag";
+import { Alert } from "@/services/api/alert";
+import { observableTreeRead } from "@/models/observable";
+import { ObservableInstance } from "@/services/api/observable";
+import { observableTreeReadFactory } from "@mocks/observable";
+
+const existingTag = genericObjectReadFactory({ value: "existingTag" });
+const testTag = genericObjectReadFactory({ value: "testTag" });
+const otherTag = genericObjectReadFactory({ value: "otherTag" });
+
+function factory(
+  args: {
+    selected: string[];
+    openAlertTags: nodeTagRead[];
+    existingTags: nodeTagRead[];
+    nodeType: "alerts" | "events" | "observable";
+    reloadObject: "node" | "table";
+    observable: undefined | observableTreeRead;
+  } = {
+    selected: [],
+    openAlertTags: [],
+    existingTags: [],
+    nodeType: "alerts",
+    reloadObject: "node",
+    observable: undefined,
+  },
+) {
+  return mount(RemoveTagModal, {
+    global: {
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          stubActions: false,
+          initialState: {
+            alertStore: {
+              open: alertReadFactory({
+                uuid: "uuid",
+                tags: args.openAlertTags,
+              }),
+            },
+            alertTableStore: {
+              visibleQueriedItems: [
+                alertReadFactory({ uuid: "uuidA", tags: [testTag, otherTag] }),
+                alertReadFactory({
+                  uuid: "uuidB",
+                  tags: [existingTag, testTag],
+                }),
+                alertReadFactory({ uuid: "uuidC", tags: [] }),
+              ],
+              totalItems: 0,
+              sortField: "eventTime",
+              sortOrder: "desc",
+              pageSize: 10,
+              requestReload: false,
+              stateFiltersLoaded: false,
+              routeFiltersLoaded: false,
+            },
+            selectedAlertStore: {
+              selected: args.selected,
+            },
+            nodeTagStore: {
+              items: args.existingTags,
+            },
+          },
+        }),
+      ],
+    },
+    propsData: {
+      name: "RemoveTagModal",
+      reloadObject: args.reloadObject,
+      nodeType: args.nodeType,
+      observable: args.observable,
+    },
+  }).then((wrapper) => {
+    wrapper.vm.modalStore.open("RemoveTagModal");
+    cy.get("[data-cy=RemoveTagModal]").should("be.visible");
+    cy.contains("Remove Tag(s)").should("be.visible");
+    cy.get('[data-cy="chips-container"]').should("be.visible");
+    cy.contains("Select from existing tags").should("be.visible");
+    cy.contains("Nevermind").should("be.visible");
+    cy.findByText("Remove").should("be.visible");
+    Cypress.vueWrapper.findComponent(BaseModal).vm.$emit("show");
+  });
+}
+
+describe("RemoveTagModal", () => {
+  it("renders", () => {
+    factory();
+  });
+  it("will use given observable's current tags as existing tag options if the given nodeType is 'observable'", () => {
+    factory({
+      selected: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "observable",
+      reloadObject: "node",
+      observable: observableTreeReadFactory({
+        tags: [existingTag, testTag],
+      }),
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("existingTag").should("be.visible");
+    cy.contains("testTag").should("be.visible");
+    cy.contains("otherTag").should("not.exist");
+  });
+  it("will use selected node's current tags as existing tag options if the given nodeType is not 'observable' and reloadObject is 'node'", () => {
+    factory({
+      selected: ["uuid"],
+      openAlertTags: [testTag, otherTag],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("existingTag").should("not.exist");
+    cy.contains("testTag").should("be.visible");
+    cy.contains("otherTag").should("be.visible");
+  });
+  it("enables 'Add' button when given nodeType is 'observable' and 1 or more tags added", () => {
+    factory({
+      selected: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "observable",
+      reloadObject: "node",
+      observable: observableTreeReadFactory({
+        tags: [existingTag, testTag],
+      }),
+    });
+    cy.get('[data-cy="chips-container"]')
+      .click()
+      .type("newTag")
+      .type("{enter}");
+    cy.get("[data-cy='remove-button']").should("not.be.disabled");
+  });
+  it("enables 'Add' button when given nodeType is not 'observable', selectedStore has 1 or more nodes selected, and 1 or more tags added", () => {
+    factory({
+      selected: ["uuid"],
+      openAlertTags: [testTag, otherTag],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+    cy.get('[data-cy="chips-container"]')
+      .click()
+      .type("newTag")
+      .type("{enter}");
+    cy.get("[data-cy='remove-button']").should("not.be.disabled");
+  });
+  it("disables 'Add' button when given nodeType is 'observable' and no tags are added to form", () => {
+    factory({
+      selected: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "observable",
+      reloadObject: "node",
+      observable: observableTreeReadFactory({
+        tags: [existingTag, testTag],
+      }),
+    });
+    cy.get("[data-cy='remove-button']").should("be.disabled");
+  });
+  it("disables 'Add' button when given nodeType is not 'observable', selectedStore has 1 or more nodes selected, and no tags added", () => {
+    factory({
+      selected: ["uuid"],
+      existingTags: [],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+    cy.get("[data-cy='remove-button']").should("be.disabled");
+  });
+  it("disables 'Add' button when given nodeType is not 'observable', selectedStore has no nodes selected, and 1 or more tags added", () => {
+    factory({
+      selected: [],
+      existingTags: [],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+    cy.get('[data-cy="chips-container"]')
+      .click()
+      .type("newTag")
+      .type("{enter}");
+    cy.get("[data-cy='remove-button']").should("be.disabled");
+  });
+  it("will fetch and use all available tags in nodeTagStore as as existing tag options if the given nodeType is not 'observable' and reloadObject is not 'node'", () => {
+    cy.stub(NodeTag, "readAll")
+      .as("readAllTags")
+      .resolves([existingTag, testTag, otherTag]);
+
+    factory({
+      selected: ["uuidA", "uuidB"],
+      openAlertTags: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "table",
+      observable: undefined,
+    });
+
+    cy.get("@readAllTags").should("have.been.calledOnce");
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("existingTag").should("be.visible");
+    cy.contains("testTag").should("be.visible");
+    cy.contains("otherTag").should("be.visible");
+  });
+  it("will make the expected call to update an observable's tags w/o tags in form when 'Remove' is clicked and the given nodeType is 'observable'", async () => {
+    cy.stub(ObservableInstance, "update")
+      .withArgs("observableUuid1", {
+        tags: ["testTag"],
+      })
+      .as("updateObservable")
+      .resolves();
+
+    factory({
+      selected: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "observable",
+      reloadObject: "node",
+      observable: observableTreeReadFactory({
+        tags: [existingTag, testTag],
+      }),
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("existingTag").click();
+    cy.get("[data-cy='remove-button']").click();
+    cy.get("@updateObservable").should("have.been.calledOnce");
+  });
+  it("will make the expected call to update a single node's tags w/o tags in form when 'Remove' is clicked and the given nodeType is not 'observable' and reloadObject is 'node'", () => {
+    cy.stub(Alert, "update")
+      .withArgs([
+        {
+          uuid: "uuid",
+          tags: ["otherTag"],
+        },
+      ])
+      .as("updateAlert")
+      .resolves();
+
+    factory({
+      selected: ["uuid"],
+      openAlertTags: [testTag, otherTag],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("testTag").click();
+    cy.get("[data-cy='remove-button']").click();
+    cy.get("@updateAlert").should("have.been.calledOnce");
+  });
+  it("will make the expected call to update multiple node's tags w/o tags in form when 'Remove' is clicked and the given nodeType is not 'observable' and reloadObject is not 'node'", () => {
+    cy.stub(NodeTag, "readAll")
+      .as("readAllTags")
+      .resolves([existingTag, testTag, otherTag]);
+
+    cy.stub(Alert, "update")
+      .withArgs([
+        {
+          uuid: "uuidA",
+          tags: ["otherTag"],
+        },
+        {
+          uuid: "uuidB",
+          tags: ["existingTag"],
+        },
+        {
+          uuid: "uuidC",
+          tags: [],
+        },
+      ])
+      .as("updateAlerts")
+      .resolves();
+
+    factory({
+      selected: ["uuidA", "uuidB", "uuidC"],
+      openAlertTags: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "table",
+      observable: undefined,
+    });
+
+    cy.get("@readAllTags").should("have.been.calledOnce");
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("testTag").click();
+    cy.get("[data-cy='remove-button']").click();
+    cy.get("@updateAlerts").should("have.been.calledOnce");
+  });
+  it("will show an error if attempt to fetch all node tags fails", () => {
+    cy.stub(NodeTag, "readAll")
+      .as("readAllTags")
+      .rejects(new Error("404 request failed !"));
+
+    factory({
+      selected: ["uuidA", "uuidB", "uuidC"],
+      openAlertTags: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "table",
+      observable: undefined,
+    });
+
+    cy.get("@readAllTags").should("have.been.calledOnce");
+    cy.contains("404 request failed !").should("be.visible");
+  });
+  it("will show an error if attempt to update an observable's tags fails", () => {
+    cy.stub(ObservableInstance, "update")
+      .withArgs("observableUuid1", {
+        tags: ["testTag"],
+      })
+      .as("updateObservable")
+      .rejects(new Error("404 request failed !"));
+
+    factory({
+      selected: [],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "observable",
+      reloadObject: "node",
+      observable: observableTreeReadFactory({
+        tags: [existingTag, testTag],
+      }),
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("existingTag").click();
+    cy.get("[data-cy='remove-button']").click();
+    cy.get("@updateObservable").should("have.been.calledOnce");
+    cy.contains("404 request failed !").should("be.visible");
+  });
+  it("will show an error if attempt to update one or more node's tags fails", () => {
+    cy.stub(Alert, "update")
+      .withArgs([
+        {
+          uuid: "uuid",
+          tags: ["otherTag"],
+        },
+      ])
+      .as("updateAlert")
+      .rejects(new Error("404 request failed !"));
+
+    factory({
+      selected: ["uuid"],
+      openAlertTags: [testTag, otherTag],
+      existingTags: [existingTag, testTag, otherTag],
+      nodeType: "alerts",
+      reloadObject: "node",
+      observable: undefined,
+    });
+
+    cy.contains("Select from existing tags").click();
+    cy.contains("testTag").click();
+    cy.get("[data-cy='remove-button']").click();
+    cy.get("@updateAlert").should("have.been.calledOnce");
+    cy.contains("404 request failed !").should("be.visible");
+  });
+});

--- a/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
@@ -100,6 +100,7 @@ describe("RemoveTagModal", () => {
     factory({
       selected: [],
       existingTags: [existingTag, testTag, otherTag],
+      openAlertTags: [],
       nodeType: "observable",
       reloadObject: "node",
       observable: observableTreeReadFactory({
@@ -130,6 +131,7 @@ describe("RemoveTagModal", () => {
   it("enables 'Add' button when given nodeType is 'observable' and 1 or more tags added", () => {
     factory({
       selected: [],
+      openAlertTags: [],
       existingTags: [existingTag, testTag, otherTag],
       nodeType: "observable",
       reloadObject: "node",
@@ -161,6 +163,7 @@ describe("RemoveTagModal", () => {
   it("disables 'Add' button when given nodeType is 'observable' and no tags are added to form", () => {
     factory({
       selected: [],
+      openAlertTags: [],
       existingTags: [existingTag, testTag, otherTag],
       nodeType: "observable",
       reloadObject: "node",
@@ -173,6 +176,7 @@ describe("RemoveTagModal", () => {
   it("disables 'Add' button when given nodeType is not 'observable', selectedStore has 1 or more nodes selected, and no tags added", () => {
     factory({
       selected: ["uuid"],
+      openAlertTags: [],
       existingTags: [],
       nodeType: "alerts",
       reloadObject: "node",
@@ -183,6 +187,7 @@ describe("RemoveTagModal", () => {
   it("disables 'Add' button when given nodeType is not 'observable', selectedStore has no nodes selected, and 1 or more tags added", () => {
     factory({
       selected: [],
+      openAlertTags: [],
       existingTags: [],
       nodeType: "alerts",
       reloadObject: "node",
@@ -226,6 +231,7 @@ describe("RemoveTagModal", () => {
     factory({
       selected: [],
       existingTags: [existingTag, testTag, otherTag],
+      openAlertTags: [],
       nodeType: "observable",
       reloadObject: "node",
       observable: observableTreeReadFactory({
@@ -329,6 +335,7 @@ describe("RemoveTagModal", () => {
 
     factory({
       selected: [],
+      openAlertTags: [],
       existingTags: [existingTag, testTag, otherTag],
       nodeType: "observable",
       reloadObject: "node",

--- a/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/RemoveTagModal.spec.ts
@@ -2,7 +2,7 @@ import { mount } from "@cypress/vue";
 import PrimeVue from "primevue/config";
 
 import RemoveTagModal from "@/components/Modals/RemoveTagModal.vue";
-import BaseModal from "@/components/Modals/BaseModal.vue";
+import Dialog from "primevue/dialog";
 import { createCustomCypressPinia } from "@tests/cypressHelpers";
 import { genericObjectReadFactory } from "@mocks/genericObject";
 import { nodeTagRead } from "@/models/nodeTag";
@@ -88,7 +88,7 @@ function factory(
     cy.contains("Select from existing tags").should("be.visible");
     cy.contains("Nevermind").should("be.visible");
     cy.findByText("Remove").should("be.visible");
-    Cypress.vueWrapper.findComponent(BaseModal).vm.$emit("show");
+    Cypress.vueWrapper.findComponent(Dialog).vm.$emit("show");
   });
 }
 

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -46,7 +46,7 @@ function factory(
             alertTableStore: {
               visibleQueriedItems: [
                 alertReadFactory({ uuid: "uuidA" }),
-                alertReadFactory({ uuid: "uuidA" }),
+                alertReadFactory({ uuid: "uuidB" }),
               ],
               totalItems: 0,
               sortField: "eventTime",
@@ -237,7 +237,7 @@ describe("TagModal", () => {
       .withArgs("observableUuid1", {
         tags: ["testTag", "existingTag", "newTag"],
       })
-      .as("updateAlert")
+      .as("updateObservable")
       .resolves();
 
     factory({

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -20,11 +20,13 @@ function factory(
     selected: string[];
     existingTags: nodeTagRead[];
     nodeType: "alerts" | "events" | "observable";
+    reloadObject: "node" | "table";
     observable: undefined | observableTreeRead;
   } = {
     selected: [],
     existingTags: [],
     nodeType: "alerts",
+    reloadObject: "node",
     observable: undefined,
   },
 ) {
@@ -41,6 +43,19 @@ function factory(
                 tags: args.existingTags,
               }),
             },
+            alertTableStore: {
+              visibleQueriedItems: [
+                alertReadFactory({ uuid: "uuidA" }),
+                alertReadFactory({ uuid: "uuidA" }),
+              ],
+              totalItems: 0,
+              sortField: "eventTime",
+              sortOrder: "desc",
+              pageSize: 10,
+              requestReload: false,
+              stateFiltersLoaded: false,
+              routeFiltersLoaded: false,
+            },
             selectedAlertStore: {
               selected: args.selected,
             },
@@ -53,7 +68,7 @@ function factory(
     },
     propsData: {
       name: "TagModal",
-      reloadObject: "node",
+      reloadObject: args.reloadObject,
       nodeType: args.nodeType,
       observable: args.observable,
     },
@@ -82,6 +97,7 @@ describe("TagModal", () => {
       selected: [],
       existingTags: [testTag],
       nodeType: "alerts",
+      reloadObject: "node",
 
       observable: undefined,
     });
@@ -94,6 +110,7 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [],
       nodeType: "alerts",
+      reloadObject: "node",
 
       observable: undefined,
     });
@@ -116,6 +133,7 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [],
       nodeType: "alerts",
+      reloadObject: "node",
 
       observable: undefined,
     });
@@ -147,6 +165,7 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
       nodeType: "alerts",
+      reloadObject: "node",
 
       observable: undefined,
     });
@@ -161,6 +180,45 @@ describe("TagModal", () => {
     cy.get("@createTag").should("have.been.calledOnce");
     cy.get("@readAllTags").should("have.been.calledOnce");
     cy.get("@updateAlert").should("have.been.calledOnce");
+    cy.get("[data-cy=TagModal]").should("not.exist");
+  });
+  it("attempts to update multiple alerts if multiple are selected in 'table' mode, tags are added to form, and 'Add' clicked", () => {
+    const updateStub = cy.stub(Alert, "update");
+    updateStub
+      .withArgs([
+        {
+          uuid: "uuidA",
+          tags: ["testTag", "existingTag"],
+        },
+        {
+          uuid: "uuidB",
+          tags: ["testTag", "existingTag"],
+        },
+      ])
+      .as("updateAlerts")
+      .resolves();
+
+    factory({
+      selected: ["uuidA", "uuidB"],
+      existingTags: [testTag, existingTag],
+      nodeType: "alerts",
+      reloadObject: "table",
+      observable: undefined,
+    });
+    // test that the tags are dedup'd with testTag
+    cy.contains("Select from existing tags").click();
+    cy.contains("testTag").click();
+    cy.get('[data-cy="chips-container"]')
+      .click()
+      .type("testTag")
+      .type("{enter}");
+    cy.get('[data-cy="chips-container"]')
+      .click()
+      .type("existingTag")
+      .type("{enter}");
+    cy.findByText("Add").click();
+
+    cy.get("@updateAlerts").should("have.been.calledOnce");
     cy.get("[data-cy=TagModal]").should("not.exist");
   });
   it("attempts to create new tags and update a given observable with new and existing tags and 'Add' clicked", () => {
@@ -186,6 +244,8 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
       nodeType: "observable",
+      reloadObject: "node",
+
       observable: observableTreeReadFactory({ tags: [testTag, existingTag] }),
     });
     cy.contains("Select from existing tags").click();
@@ -204,7 +264,7 @@ describe("TagModal", () => {
   it("shows error if existing tags cannot be fetched", () => {
     cy.stub(NodeTag, "create")
       .withArgs({
-        value: "testTag",
+        value: "newTag",
       })
       .as("createTag")
       .resolves();
@@ -219,6 +279,8 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
       nodeType: "alerts",
+      reloadObject: "node",
+
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -237,7 +299,7 @@ describe("TagModal", () => {
   it("shows error if request to create a new tag fails", () => {
     cy.stub(NodeTag, "create")
       .withArgs({
-        value: "testTag",
+        value: "newTag",
       })
       .as("createTag")
       .rejects(new Error("404 request failed !"));
@@ -250,6 +312,8 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
       nodeType: "alerts",
+      reloadObject: "node",
+
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();
@@ -268,7 +332,7 @@ describe("TagModal", () => {
   it("shows error if request to update node tags fails", () => {
     cy.stub(NodeTag, "create")
       .withArgs({
-        value: "testTag",
+        value: "newTag",
       })
       .as("createTag")
       .resolves();
@@ -291,6 +355,8 @@ describe("TagModal", () => {
       selected: ["uuid"],
       existingTags: [testTag, existingTag],
       nodeType: "alerts",
+      reloadObject: "node",
+
       observable: undefined,
     });
     cy.contains("Select from existing tags").click();

--- a/frontend/tests/component/src/components/Modals/TagModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/TagModal.spec.ts
@@ -258,7 +258,7 @@ describe("TagModal", () => {
 
     cy.get("@createTag").should("have.been.calledOnce");
     cy.get("@readAllTags").should("have.been.calledOnce");
-    cy.get("@updateAlert").should("have.been.calledOnce");
+    cy.get("@updateObservable").should("have.been.calledOnce");
     cy.get("[data-cy=TagModal]").should("not.exist");
   });
   it("shows error if existing tags cannot be fetched", () => {

--- a/frontend/tests/component/src/components/Node/TheNodeActionToolbar.spec.ts
+++ b/frontend/tests/component/src/components/Node/TheNodeActionToolbar.spec.ts
@@ -11,6 +11,7 @@ interface TheNodeActionToolbarProps {
   assign?: boolean;
   comment?: boolean;
   tag?: boolean;
+  removeTag?: boolean;
   takeOwnership?: boolean;
 }
 
@@ -48,6 +49,8 @@ describe("TheNodeActionToolbar", () => {
     cy.get("@stub-14").should("have.been.calledWith", "AssignModal");
     cy.contains("Tag").should("be.visible").click();
     cy.get("@stub-14").should("have.been.calledWith", "TagModal");
+    cy.contains("Remove Tag").should("be.visible").click();
+    cy.get("@stub-14").should("have.been.calledWith", "RemoveTagModal");
   });
   it("correctly attempts to assign owner if 'Take Ownership' button clicked", () => {
     factory({
@@ -94,6 +97,7 @@ describe("TheNodeActionToolbar", () => {
         reloadObject: "node",
         assign: false,
         tag: false,
+        removeTag: false,
         comment: false,
         takeOwnership: false,
       },


### PR DESCRIPTION
This PR adds a new modal/toolbar action/observable action to remove one or more tags from a given alert/event/observable.

It also includes some small fixes for the TagModal found during development.

Closes #220 

![removeTagObservableAction](https://user-images.githubusercontent.com/31867815/167706966-3ff870af-b68c-4c95-bd06-edbac580220b.gif)
![removeTagAlerts](https://user-images.githubusercontent.com/31867815/167707037-4379da9c-7c98-4515-9e01-026f4ad1d3ec.gif)

