### PR TITLE
Initial observable validation

### DIFF
--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -143,33 +143,20 @@
                   />
                 </div>
                 <div class="field col-3 px-1" name="observable-value">
-                  <div
-                    v-if="observables[index].type == 'file'"
-                    name="observable-file-upload"
-                  >
-                    <FileUpload
-                      mode="basic"
-                      class="inputfield w-full"
-                    ></FileUpload>
-                  </div>
-                  <div v-else class="p-inputgroup">
-                    <InputText
-                      v-if="!observables[index].multiAdd"
-                      v-model="observables[index].value"
-                      placeholder="Enter a value"
-                      class="inputfield w-full"
-                      type="text"
-                    ></InputText>
-                    <Textarea
-                      v-else
-                      v-model="observables[index].value"
-                      placeholder="Enter a comma or newline-delimited list of values"
-                      class="inputfield w-full"
-                    ></Textarea>
-                    <Button
-                      icon="pi pi-list"
-                      @click="toggleMultiObservable(index)"
-                    />
+                  <div class="inputfield w-full" style="display: inline-block">
+                    <span style="display: inline">
+                      <ObservableInput
+                        v-model="observables[index].value"
+                        :multi-add="observables[index].multiAdd"
+                        :type="observables[index].type"
+                      ></ObservableInput>
+                    </span>
+                    <span style="float: right">
+                      <Button
+                        icon="pi pi-list"
+                        @click="toggleMultiObservable(index)"
+                      />
+                    </span>
                   </div>
                 </div>
                 <div class="field col-3 px-1">
@@ -263,6 +250,8 @@
   import TabView from "primevue/tabview";
   import Textarea from "primevue/textarea";
   import { DatePicker } from "v-calendar";
+
+  import ObservableInput from "@/components/Observables/ObservableInput.vue";
 
   import { useAlertStore } from "@/stores/alert";
   import { useQueueStore } from "@/stores/queue";

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -146,7 +146,8 @@
                   <div class="inputfield w-full" style="display: inline-block">
                     <span style="display: inline">
                       <ObservableInput
-                        v-model="observables[index].value"
+                        v-model:modelValue="observables[index].value"
+                        v-model:invalid="observables[index].invalid"
                         :multi-add="observables[index].multiAdd"
                         :type="observables[index].type"
                       ></ObservableInput>
@@ -197,11 +198,14 @@
       <br />
     </TabPanel>
   </TabView>
+  <small v-if="anyObservablesInvalid" class="p-error"
+    >Please check observable input</small
+  >
   <div class="pl-3">
     <SplitButton
       label="Analyze!"
       :loading="alertCreateLoading"
-      :disabled="showContinueButton"
+      :disabled="anyObservablesInvalid"
       :model="splitButtonOptions"
       class="p-button-lg"
       @click="submitSingleAlert"
@@ -237,18 +241,15 @@
   import { useRouter } from "vue-router";
 
   import Button from "primevue/button";
-  import Calendar from "primevue/calendar";
   import Card from "primevue/card";
   import Dropdown from "primevue/dropdown";
   import Fieldset from "primevue/fieldset";
-  import FileUpload from "primevue/fileupload";
   import InputText from "primevue/inputtext";
   import Message from "primevue/message";
   import MultiSelect from "primevue/multiselect";
   import SplitButton from "primevue/splitbutton";
   import TabPanel from "primevue/tabpanel";
   import TabView from "primevue/tabview";
-  import Textarea from "primevue/textarea";
   import { DatePicker } from "v-calendar";
 
   import ObservableInput from "@/components/Observables/ObservableInput.vue";
@@ -301,6 +302,11 @@
     return observables.value.length - 1;
   });
 
+  const anyObservablesInvalid = computed(() => {
+    const invalid = observables.value.filter((obs) => obs.invalid);
+    return invalid.length;
+  });
+
   onMounted(() => {
     initData();
   });
@@ -322,6 +328,7 @@
       multiAdd: false,
       value: null,
       directives: [],
+      invalid: false,
     });
   };
 

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -142,8 +142,8 @@
                     :options="observableTypeStore.items"
                   />
                 </div>
-                <div class="field col-3 px-1" name="observable-value">
-                  <div class="inputfield w-full" style="display: inline-block">
+                <div class="field px-1" name="observable-value">
+                  <span class="inputfield">
                     <span style="display: inline">
                       <ObservableInput
                         v-model:modelValue="observables[index].value"
@@ -152,13 +152,13 @@
                         :type="observables[index].type"
                       ></ObservableInput>
                     </span>
-                    <span style="float: right">
+                    <span>
                       <Button
                         icon="pi pi-list"
                         @click="toggleMultiObservable(index)"
                       />
                     </span>
-                  </div>
+                  </span>
                 </div>
                 <div class="field col-3 px-1">
                   <MultiSelect

--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -146,7 +146,7 @@
                   <span class="inputfield">
                     <span style="display: inline">
                       <ObservableInput
-                        v-model:modelValue="observables[index].value"
+                        v-model:observableValue="observables[index].value"
                         v-model:invalid="observables[index].invalid"
                         :multi-add="observables[index].multiAdd"
                         :type="observables[index].type"
@@ -326,7 +326,7 @@
       time: null,
       type: "file",
       multiAdd: false,
-      value: null,
+      value: "",
       directives: [],
       invalid: false,
     });

--- a/frontend/src/components/Observables/ObservableInput.vue
+++ b/frontend/src/components/Observables/ObservableInput.vue
@@ -36,11 +36,15 @@
 
   const config = inject("config") as Record<string, any>;
 
-  const emit = defineEmits(["update:modelValue"]);
+  const emit = defineEmits(["update:observableValue", "update:invalid"]);
 
   const props = defineProps({
-    modelValue: {
+    observableValue: {
       type: null as PropType<string | null>,
+      required: true,
+    },
+    invalid: {
+      type: Boolean,
       required: true,
     },
     multiAdd: {
@@ -53,7 +57,7 @@
     },
   });
 
-  const value = ref(props.modelValue);
+  const value = ref(props.observableValue);
 
   const styleClasses = computed(() => {
     if (!inputIsValid.value) {
@@ -94,6 +98,11 @@
   });
 
   watch(value, () => {
-    emit("update:modelValue", value);
+    emit("update:observableValue", value);
+    if (inputIsValid.value) {
+      emit("update:invalid", false);
+    } else {
+      emit("update:invalid", true);
+    }
   });
 </script>

--- a/frontend/src/components/Observables/ObservableInput.vue
+++ b/frontend/src/components/Observables/ObservableInput.vue
@@ -1,0 +1,73 @@
+<template>
+  <FileUpload
+    v-if="type == 'file'"
+    mode="basic"
+    class="inputfield"
+  ></FileUpload>
+  <span v-else>
+    <InputText
+      v-if="!multiAdd"
+      v-model="value"
+      placeholder="Enter a value"
+      class="inputfield"
+      type="text"
+    ></InputText>
+    <Textarea
+      v-else
+      v-model="value"
+      placeholder="Enter a comma or newline-delimited list of values"
+      class="inputfield"
+    ></Textarea>
+  </span>
+</template>
+<script setup lang="ts">
+  import {
+    defineEmits,
+    defineProps,
+    computed,
+    ref,
+    watch,
+    inject,
+    PropType,
+  } from "vue";
+
+  import FileUpload from "primevue/fileupload";
+  import InputText from "primevue/inputtext";
+  import Textarea from "primevue/textarea";
+
+  const config = inject("config") as Record<string, any>;
+
+  const emit = defineEmits(["update:modelValue"]);
+
+  const props = defineProps({
+    modelValue: {
+      type: null as PropType<string | null>,
+      required: true,
+    },
+    multiAdd: {
+      type: Boolean,
+      required: true,
+    },
+    type: {
+      type: String,
+      required: true,
+    },
+  });
+
+  const value = ref(props.modelValue);
+
+  const observableMetadata = computed(() => {
+    const observableMetadata = config.observables.observableMetadata;
+
+    // Check whether there is specific metadata config for this observable type
+    if (props.type in observableMetadata) {
+      // If so, add any available actions
+      return observableMetadata[props.type];
+    }
+    return {};
+  });
+
+  watch(value, () => {
+    emit("update:modelValue", value);
+  });
+</script>

--- a/frontend/src/components/Observables/ObservableInput.vue
+++ b/frontend/src/components/Observables/ObservableInput.vue
@@ -1,6 +1,12 @@
 <template>
   <span v-if="type == 'file'" name="observable-file-upload">
-    <FileUpload mode="basic" class="inputfield"></FileUpload>
+    <FileUpload
+      mode="basic"
+      class="inputfield"
+      :multiple="multiAdd"
+      :choose-label="fileUploadLabel"
+    >
+    </FileUpload>
   </span>
   <span v-else>
     <InputText
@@ -40,7 +46,7 @@
 
   const props = defineProps({
     observableValue: {
-      type: null as PropType<string | null>,
+      type: String as PropType<string | undefined>,
       required: true,
     },
     invalid: {
@@ -64,6 +70,13 @@
       return ["inputfield", "p-invalid"];
     }
     return ["inputfield"];
+  });
+
+  const fileUploadLabel = computed(() => {
+    if (!props.multiAdd) {
+      return "Choose";
+    }
+    return "Choose multiple";
   });
 
   const inputIsValid = computed(() => {

--- a/frontend/src/components/Observables/ObservableInput.vue
+++ b/frontend/src/components/Observables/ObservableInput.vue
@@ -1,23 +1,22 @@
 <template>
-  <FileUpload
-    v-if="type == 'file'"
-    mode="basic"
-    class="inputfield"
-  ></FileUpload>
+  <span v-if="type == 'file'" name="observable-file-upload">
+    <FileUpload mode="basic" class="inputfield"></FileUpload>
+  </span>
   <span v-else>
     <InputText
       v-if="!multiAdd"
       v-model="value"
-      placeholder="Enter a value"
-      class="inputfield"
+      :placeholder="placeholder"
+      :class="styleClasses"
       type="text"
     ></InputText>
     <Textarea
       v-else
       v-model="value"
-      placeholder="Enter a comma or newline-delimited list of values"
-      class="inputfield"
+      :placeholder="placeholder"
+      :class="styleClasses"
     ></Textarea>
+    <small v-if="!inputIsValid" class="p-error">{{ type }} is malformed</small>
   </span>
 </template>
 <script setup lang="ts">
@@ -55,6 +54,33 @@
   });
 
   const value = ref(props.modelValue);
+
+  const styleClasses = computed(() => {
+    if (!inputIsValid.value) {
+      return ["inputfield", "p-invalid"];
+    }
+    return ["inputfield"];
+  });
+
+  const inputIsValid = computed(() => {
+    if (value.value == null || value.value.length == 0) {
+      return true;
+    }
+    if (observableMetadata.value.validator) {
+      return observableMetadata.value.validator(value.value);
+    }
+    return true;
+  });
+
+  const placeholder = computed(() => {
+    if (observableMetadata.value.placeholder && !props.multiAdd) {
+      return observableMetadata.value.placeholder;
+    } else if (props.multiAdd) {
+      return "Enter a comma or newline-delimited list of values";
+    } else {
+      return "Enter a value";
+    }
+  });
 
   const observableMetadata = computed(() => {
     const observableMetadata = config.observables.observableMetadata;

--- a/frontend/src/etc/configuration/observables.ts
+++ b/frontend/src/etc/configuration/observables.ts
@@ -32,5 +32,16 @@ export const observableMetadata: PartialRecord<
   },
   ipv4: {
     style: { color: "blue" },
+    placeholder: "ex. 1.2.3.4",
+    validator: (ipv4: string) => {
+      const regex = new RegExp(
+        "((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(.|$)){4}",
+      );
+      return regex.test(ipv4);
+    },
+  },
+  url: {
+    style: { color: "blue" },
+    placeholder: "ex. https://www.google.com",
   },
 };

--- a/frontend/src/etc/configuration/test/observables.ts
+++ b/frontend/src/etc/configuration/test/observables.ts
@@ -57,5 +57,12 @@ export const observableMetadata: PartialRecord<
   ipv4: {
     actions: [{ items: [ipv4SpecificObservableAction], label: "Subheader" }],
     style: { color: "blue" },
+    placeholder: "ex. 1.2.3.4",
+    validator: (ipv4: string) => {
+      const regex = new RegExp(
+        "((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)(.|$)){4}",
+      );
+      return regex.test(ipv4);
+    },
   },
 };

--- a/frontend/src/models/observableType.ts
+++ b/frontend/src/models/observableType.ts
@@ -19,5 +19,7 @@ export type observableTypeUpdate = genericObjectUpdate;
 
 export type observableTypeMetaData = {
   actions?: observableAction[] | observableActionSection[];
+  placeholder?: string;
+  validator?: (value: string) => boolean;
   style?: CSS.Properties;
 };

--- a/frontend/tests/component/src/components/Alerts/AnalyzeAlertForm.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AnalyzeAlertForm.spec.ts
@@ -11,6 +11,7 @@ import { userReadFactory } from "@mocks/user";
 import { alertReadFactory } from "@mocks/alert";
 import { Alert } from "@/services/api/alert";
 import { TestingOptions } from "@pinia/testing";
+import { testConfiguration } from "@/etc/configuration/test/index";
 
 const testAlertTypeA = "testAlertTypeA";
 const testAlertTypeB = "testAlertTypeB";
@@ -59,6 +60,7 @@ function factory(options: TestingOptions = {}) {
         PrimeVue,
         router,
       ],
+      provide: { config: testConfiguration },
     },
   });
 }
@@ -156,10 +158,7 @@ describe("AnalyzeAlertForm - Observables", () => {
 
     // Should be input box
     cy.get("[name=observable-type]").should("have.text", "ipv4");
-    cy.get("[name=observable-value] input")
-      .should("be.visible")
-      .invoke("attr", "placeholder")
-      .should("contain", "Enter a value");
+    cy.get("[name=observable-value] input").should("be.visible");
     cy.get("[name=observable-file-upload]").should("not.exist");
 
     // Switch back to 'file,' should be the file input again

--- a/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
@@ -1,0 +1,19 @@
+import { mount } from "@cypress/vue";
+import { createPinia } from "pinia";
+import PrimeVue from "primevue/config";
+
+import ObservableInput from "@/components/Observables/ObservableInput.vue";
+
+function factory(args = {}) {
+  return mount(ObservableInput, {
+    global: {
+      plugins: [PrimeVue, createPinia()],
+    },
+  });
+}
+
+describe("ObservableInput", () => {
+  it("renders correctly with no given style or header props", () => {
+    factory();
+  });
+});

--- a/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
@@ -6,9 +6,10 @@ import { testConfiguration } from "@/etc/configuration/test/index";
 import ObservableInput from "@/components/Observables/ObservableInput.vue";
 
 interface ObservableInputProps {
-  modelValue: null | string;
+  observableValue: undefined | string;
   multiAdd: boolean;
   type: string;
+  invalid: boolean;
 }
 
 function factory(props: ObservableInputProps) {
@@ -23,7 +24,12 @@ function factory(props: ObservableInputProps) {
 
 describe("ObservableInput", () => {
   it("renders with FileUpload component if given prop 'type' == 'file and prop 'multiAdd' == false'", () => {
-    factory({ modelValue: null, multiAdd: false, type: "file" });
+    factory({
+      observableValue: undefined,
+      multiAdd: false,
+      type: "file",
+      invalid: false,
+    });
     cy.contains("Choose").should("be.visible");
     cy.contains("Enter a value").should("not.exist");
     cy.contains("Enter a comma or newline-delimited list of values").should(
@@ -31,7 +37,12 @@ describe("ObservableInput", () => {
     );
   });
   it("renders with FileUpload component if given prop 'type' == 'file and prop 'multiAdd' == true'", () => {
-    factory({ modelValue: null, multiAdd: true, type: "file" });
+    factory({
+      observableValue: undefined,
+      multiAdd: true,
+      type: "file",
+      invalid: false,
+    });
     cy.contains("Choose").should("be.visible");
     cy.contains("Enter a value").should("not.exist");
     cy.contains("Enter a comma or newline-delimited list of values").should(
@@ -39,7 +50,12 @@ describe("ObservableInput", () => {
     );
   });
   it("renders with TextArea component if given prop 'type' !== 'file' and prop 'multiAdd' == true", () => {
-    factory({ modelValue: null, multiAdd: true, type: "ipv4" });
+    factory({
+      observableValue: undefined,
+      multiAdd: true,
+      type: "ipv4",
+      invalid: false,
+    });
     cy.findByPlaceholderText(
       "Enter a comma or newline-delimited list of values",
     ).should("be.visible");
@@ -47,7 +63,12 @@ describe("ObservableInput", () => {
     cy.contains("Choose").should("not.exist");
   });
   it("displays expected placeholder for InputText if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata does not exist", () => {
-    factory({ modelValue: null, multiAdd: false, type: "unknown" });
+    factory({
+      observableValue: undefined,
+      multiAdd: false,
+      type: "unknown",
+      invalid: false,
+    });
     cy.findByPlaceholderText("Enter a value").should("be.visible");
     cy.contains("Choose").should("not.exist");
     cy.contains("Enter a comma or newline-delimited list of values").should(
@@ -55,7 +76,12 @@ describe("ObservableInput", () => {
     );
   });
   it("displays expected placeholder if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata exists", () => {
-    factory({ modelValue: null, multiAdd: false, type: "ipv4" });
+    factory({
+      observableValue: undefined,
+      multiAdd: false,
+      type: "ipv4",
+      invalid: false,
+    });
     cy.findByPlaceholderText("ex. 1.2.3.4").should("be.visible");
     cy.contains("Choose").should("not.exist");
     cy.contains("Enter a comma or newline-delimited list of values").should(
@@ -63,7 +89,12 @@ describe("ObservableInput", () => {
     );
   });
   it("displays validation error when expected if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata exists", () => {
-    factory({ modelValue: null, multiAdd: false, type: "ipv4" });
+    factory({
+      observableValue: undefined,
+      multiAdd: false,
+      type: "ipv4",
+      invalid: false,
+    });
     cy.contains("ipv4 is malformed").should("not.exist");
     cy.findByPlaceholderText("ex. 1.2.3.4").type("1234");
     cy.contains("ipv4 is malformed").should("be.visible");

--- a/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableInput.spec.ts
@@ -1,19 +1,73 @@
 import { mount } from "@cypress/vue";
 import { createPinia } from "pinia";
 import PrimeVue from "primevue/config";
+import { testConfiguration } from "@/etc/configuration/test/index";
 
 import ObservableInput from "@/components/Observables/ObservableInput.vue";
 
-function factory(args = {}) {
+interface ObservableInputProps {
+  modelValue: null | string;
+  multiAdd: boolean;
+  type: string;
+}
+
+function factory(props: ObservableInputProps) {
   return mount(ObservableInput, {
     global: {
       plugins: [PrimeVue, createPinia()],
+      provide: { config: testConfiguration },
     },
+    propsData: props,
   });
 }
 
 describe("ObservableInput", () => {
-  it("renders correctly with no given style or header props", () => {
-    factory();
+  it("renders with FileUpload component if given prop 'type' == 'file and prop 'multiAdd' == false'", () => {
+    factory({ modelValue: null, multiAdd: false, type: "file" });
+    cy.contains("Choose").should("be.visible");
+    cy.contains("Enter a value").should("not.exist");
+    cy.contains("Enter a comma or newline-delimited list of values").should(
+      "not.exist",
+    );
+  });
+  it("renders with FileUpload component if given prop 'type' == 'file and prop 'multiAdd' == true'", () => {
+    factory({ modelValue: null, multiAdd: true, type: "file" });
+    cy.contains("Choose").should("be.visible");
+    cy.contains("Enter a value").should("not.exist");
+    cy.contains("Enter a comma or newline-delimited list of values").should(
+      "not.exist",
+    );
+  });
+  it("renders with TextArea component if given prop 'type' !== 'file' and prop 'multiAdd' == true", () => {
+    factory({ modelValue: null, multiAdd: true, type: "ipv4" });
+    cy.findByPlaceholderText(
+      "Enter a comma or newline-delimited list of values",
+    ).should("be.visible");
+    cy.contains("Enter a value").should("not.exist");
+    cy.contains("Choose").should("not.exist");
+  });
+  it("displays expected placeholder for InputText if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata does not exist", () => {
+    factory({ modelValue: null, multiAdd: false, type: "unknown" });
+    cy.findByPlaceholderText("Enter a value").should("be.visible");
+    cy.contains("Choose").should("not.exist");
+    cy.contains("Enter a comma or newline-delimited list of values").should(
+      "not.exist",
+    );
+  });
+  it("displays expected placeholder if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata exists", () => {
+    factory({ modelValue: null, multiAdd: false, type: "ipv4" });
+    cy.findByPlaceholderText("ex. 1.2.3.4").should("be.visible");
+    cy.contains("Choose").should("not.exist");
+    cy.contains("Enter a comma or newline-delimited list of values").should(
+      "not.exist",
+    );
+  });
+  it("displays validation error when expected if given prop 'type' !== 'file' and prop 'multiAdd' == false and observable metadata exists", () => {
+    factory({ modelValue: null, multiAdd: false, type: "ipv4" });
+    cy.contains("ipv4 is malformed").should("not.exist");
+    cy.findByPlaceholderText("ex. 1.2.3.4").type("1234");
+    cy.contains("ipv4 is malformed").should("be.visible");
+    cy.findByDisplayValue("1234").clear().type("1.2.3.4");
+    cy.contains("ipv4 is malformed").should("not.exist");
   });
 });

--- a/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
+++ b/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
@@ -61,48 +61,6 @@ describe("AnalyzeAlert.vue", () => {
     cy.get("div[name='observable-input']").should("have.length", 0);
   });
 
-  it("Changes the observable input box based on observable type", () => {
-    // Check that initial observable is a file observable & doesn't have a multi-input button
-    cy.get("div[name='observable-value']")
-      .find("[type='file']")
-      .should("exist");
-    cy.get("div[name='observable-value']").find("button").should("not.exist");
-    cy.get("div[name='observable-value']").find("textarea").should("not.exist");
-    // Check dropdown options and select 'ipv4'
-    cy.get("div[name='observable-type']").click();
-    cy.get("div[name='observable-input']")
-      .get(".p-dropdown-item")
-      .should("have.length", 3)
-      .contains("ipv4")
-      .click();
-    // Check that input switched to text input
-    cy.get("div[name='observable-value']")
-      .find("[type='text']")
-      .should("exist");
-    // Find and click the multi-input button and check that input changes to text area
-    cy.get("div[name='observable-value']").find("button").click();
-    cy.get("div[name='observable-value']")
-      .find("[type='text']")
-      .should("not.exist");
-    cy.get("div[name='observable-value']").find("textarea").should("exist");
-    // Find and click multi-input again and check that input switches back to text input
-    cy.get("div[name='observable-value']").find("button").click();
-    cy.get("div[name='observable-value']")
-      .find("[type='text']")
-      .should("exist");
-    cy.get("div[name='observable-value']").find("textarea").should("not.exist");
-    // Switch back to file observable type and check that input switches back to file input
-    cy.get("div[name='observable-type']").click();
-    cy.get("div[name='observable-input']")
-      .get(".p-dropdown-item")
-      .contains("file")
-      .click();
-    cy.get("div[name='observable-value']")
-      .find("[type='file']")
-      .should("exist");
-    cy.get("div[name='observable-value']").find("button").should("not.exist");
-  });
-
   it("submits alert/observable data to API and routes user to new alert page after submission", () => {
     cy.intercept("POST", "/api/alert").as("createAlert");
     cy.intercept("GET", "/api/alert/*").as("getAlert");


### PR DESCRIPTION
This PR extends the observable config added in #184 to add simple 'validation' functions and placeholder text for observable inputs. It also updates the analyze page to only allow submission if there are no validation errors. 

Currently, the only validation being provided is for the IPV4 observable type. While the 'validation' is not extensive (just using regex), it works and can be changed/extended as needed. 


![image](https://user-images.githubusercontent.com/31867815/168600944-e94b1557-a450-41c9-8d05-1b9e05f5fea3.png)

Note: I'm aware the styling for the validation error messages is extremely ugly. Will fix in future.
 