### PR TITLE
Disposition Tags

### DIFF
--- a/db_api/app/etc/defaults.yml
+++ b/db_api/app/etc/defaults.yml
@@ -32,8 +32,8 @@ user:
 # Dispositions added here will receive an automated rank number based on the order they appear.
 # Example: The first disposition listed here will receive rank 0 and will appear first when shown in the GUI.
 alert_disposition:
-  - FALSE_POSITIVE
   - IGNORE
+  - FALSE_POSITIVE
   - APPROVED_BUSINESS
   - APPROVED_PERSONAL
   - UNKNOWN

--- a/frontend/src/components/Alerts/AlertDispositionTag.vue
+++ b/frontend/src/components/Alerts/AlertDispositionTag.vue
@@ -1,0 +1,35 @@
+<template>
+  <span class="tag">
+    <Tag rounded :style="tagStyle"
+      ><span class="tag"> {{ disposition }} </span></Tag
+    >
+  </span>
+</template>
+
+<script setup lang="ts">
+  import { computed, defineProps, inject } from "vue";
+  import Tag from "primevue/tag";
+
+  const config = inject("config") as Record<string, any>;
+
+  const props = defineProps({
+    disposition: {
+      type: String,
+      required: true,
+    },
+  });
+
+  const tagStyle = computed(() => {
+    const dispositionLowerCase = props.disposition.toLowerCase();
+    if (dispositionLowerCase in config.alerts.alertDispositionMetadata) {
+      return {
+        backgroundColor:
+          config.alerts.alertDispositionMetadata[dispositionLowerCase],
+      };
+    }
+    return {
+      backgroundColor: "white",
+      color: "black",
+    };
+  });
+</script>

--- a/frontend/src/components/Alerts/AlertTableCell.vue
+++ b/frontend/src/components/Alerts/AlertTableCell.vue
@@ -51,6 +51,13 @@
     />
   </div>
 
+  <!-- Alert Disposition -->
+  <div v-else-if="props.field === 'disposition'">
+    <AlertDispositionTag
+      :disposition="props.data[props.field]"
+    ></AlertDispositionTag>
+  </div>
+
   <!-- Everything else -->
   <span v-else> {{ props.data[props.field] }}</span>
 </template>
@@ -58,6 +65,7 @@
 <script setup lang="ts">
   import { defineProps, PropType, inject, computed } from "vue";
 
+  import AlertDispositionTag from "@/components/Alerts/AlertDispositionTag.vue";
   import NodeTagVue from "@/components/Node/NodeTag.vue";
   import NodeComment from "@/components/Node/NodeComment.vue";
 

--- a/frontend/src/components/Modals/DispositionModal.vue
+++ b/frontend/src/components/Modals/DispositionModal.vue
@@ -16,7 +16,13 @@
           option-label="value"
           list-style="max-height:250px"
           style="width: 70vw"
-        />
+        >
+          <template #option="slotProps">
+            <AlertDispositionTag
+              :disposition="slotProps.option.value"
+            ></AlertDispositionTag>
+          </template>
+        </Listbox>
       </div>
       <div class="p-field p-col">
         <Textarea
@@ -59,6 +65,7 @@
 
   import BaseModal from "@/components/Modals/BaseModal.vue";
   import SaveToEventModal from "@/components/Modals/SaveToEventModal.vue";
+  import AlertDispositionTag from "@/components/Alerts/AlertDispositionTag.vue";
 
   import { NodeComment } from "@/services/api/nodeComment";
 

--- a/frontend/src/etc/configuration/alerts.ts
+++ b/frontend/src/etc/configuration/alerts.ts
@@ -23,6 +23,10 @@ import {
   nodeThreatActorProperty,
   nodeThreatsProperty,
   queueProperty,
+  BLUE,
+  GREEN,
+  ORANGE,
+  RED,
 } from "@/etc/constants/common";
 
 const defaultAlertFilters = [
@@ -73,3 +77,21 @@ export const FALSE_POSITIVE_DISPOSITION_STRING = "FALSE_POSITIVE";
 export const IGNORE_DISPOSITION_STRING = "IGNORE";
 
 export const alertIconTypeMapping = {};
+
+export const alertDispositionMetadata: Record<string, string> = {
+  false_positive: GREEN,
+  authorized: GREEN,
+  unknown: BLUE,
+  reviewed: BLUE,
+  grayware: BLUE,
+  policy_violation: ORANGE,
+  reconnaissance: ORANGE,
+  weaponization: RED,
+  delivery: RED,
+  exploitation: RED,
+  installation: RED,
+  command_and_control: RED,
+  data_control: RED,
+  exfil: RED,
+  damage: RED,
+};

--- a/frontend/src/etc/configuration/test/alerts.ts
+++ b/frontend/src/etc/configuration/test/alerts.ts
@@ -15,6 +15,7 @@ import {
   nodeThreatsProperty,
   queueProperty,
   ownerProperty,
+  BLUE,
 } from "@/etc/constants/common";
 
 const defaultAlertFilters = [
@@ -57,4 +58,6 @@ export const alertIconTypeMapping = {
   testType: "test.png",
 };
 
-export const alertDispositionMetadata: Record<string, string> = {};
+export const alertDispositionMetadata: Record<string, string> = {
+  test: BLUE,
+};

--- a/frontend/src/etc/configuration/test/alerts.ts
+++ b/frontend/src/etc/configuration/test/alerts.ts
@@ -56,3 +56,5 @@ export const IGNORE_DISPOSITION_STRING = "IGNORE";
 export const alertIconTypeMapping = {
   testType: "test.png",
 };
+
+export const alertDispositionMetadata: Record<string, string> = {};

--- a/frontend/src/etc/constants/common.ts
+++ b/frontend/src/etc/constants/common.ts
@@ -135,3 +135,9 @@ export const queueProperty: propertyOption = {
   optionProperty: "value",
   valueProperty: "value",
 };
+
+export const WHITE = "#FFFFFF";
+export const RED = "#FF0000";
+export const BLUE = "#00BFFF";
+export const GREEN = "#32CD32";
+export const ORANGE = "#FF8C00";

--- a/frontend/tests/component/src/components/Alerts/AlertDispositionTag.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AlertDispositionTag.spec.ts
@@ -1,0 +1,45 @@
+import { mount } from "@cypress/vue";
+import { createPinia } from "pinia";
+import PrimeVue from "primevue/config";
+import { testConfiguration } from "@/etc/configuration/test/index";
+
+import AlertDispositionTag from "@/components/Alerts/AlertDispositionTag.vue";
+
+interface AlertDispositionTagProps {
+  disposition: string;
+}
+
+const blue = "rgb(0, 191, 255)";
+const white = "rgb(255, 255, 255)";
+const black = "rgb(0, 0, 0)";
+
+function factory(props: AlertDispositionTagProps) {
+  mount(AlertDispositionTag, {
+    global: {
+      plugins: [PrimeVue, createPinia()],
+      provide: {
+        config: testConfiguration,
+      },
+    },
+    propsData: props,
+  });
+}
+
+describe("AlertDispositionTag", () => {
+  it("renders correctly when metadata config exists", () => {
+    factory({ disposition: "TEST" });
+    cy.contains("TEST")
+      .should("be.visible")
+      .parent()
+      .should("have.css", "background-color", blue)
+      .should("have.css", "color", white);
+  });
+  it("renders correctly when metadata config does not exist", () => {
+    factory({ disposition: "unknown" });
+    cy.contains("unknown")
+      .should("be.visible")
+      .parent()
+      .should("have.css", "background-color", white)
+      .should("have.css", "color", black);
+  });
+});

--- a/frontend/tests/component/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/TheAlertsTable.spec.ts
@@ -11,6 +11,7 @@ import { NodeTree } from "@/services/api/nodeTree";
 import { observableReadFactory } from "@mocks/observable";
 import { genericObjectReadFactory } from "@mocks/genericObject";
 import ToastService from "primevue/toastservice";
+import { testConfiguration } from "@/etc/configuration/test/index";
 
 interface alertTableStoreState {
   visibleQueriedItems: alertRead[];
@@ -47,6 +48,7 @@ function factory(initialState: alertTableStoreState) {
       ],
       provide: {
         nodeType: "alerts",
+        config: testConfiguration,
       },
     },
   });

--- a/frontend/tests/component/src/components/Events/EventAlertsTable.spec.ts
+++ b/frontend/tests/component/src/components/Events/EventAlertsTable.spec.ts
@@ -9,6 +9,7 @@ import router from "@/router";
 import EventAlertsTable from "@/components/Events/EventAlertsTable.vue";
 import { Alert } from "@/services/api/alert";
 import { alertReadFactory } from "@mocks/alert";
+import { testConfiguration } from "@/etc/configuration/test";
 
 const mockAlertA = alertReadFactory({ uuid: "uuid1", name: "Test Alert A" });
 const mockAlertB = alertReadFactory({ uuid: "uuid2", name: "Test Alert B" });
@@ -18,7 +19,7 @@ function factory() {
   return mount(EventAlertsTable, {
     global: {
       plugins: [router, PrimeVue, createPinia()],
-      provide: { nodeType: "events" },
+      provide: { nodeType: "events", config: testConfiguration },
     },
     propsData: {
       eventUuid: "uuid1",

--- a/frontend/tests/component/src/components/Modals/DispositionModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/DispositionModal.spec.ts
@@ -1,15 +1,14 @@
 import { mount } from "@cypress/vue";
-import { createPinia } from "pinia";
 import PrimeVue from "primevue/config";
 
 import DispositionModal from "@/components/Modals/DispositionModal.vue";
 import { alertDispositionRead } from "@/models/alertDisposition";
 import { createCustomCypressPinia } from "@tests/cypressHelpers";
 import { genericObjectReadFactory } from "@mocks/genericObject";
-import SaveToEventModalVue from "@/components/Modals/SaveToEventModal.vue";
 import { Alert } from "@/services/api/alert";
 import { NodeComment } from "@/services/api/nodeComment";
 import { userReadFactory } from "@mocks/user";
+import { testConfiguration } from "@/etc/configuration/test";
 
 function factory(
   args: { dipsositions: alertDispositionRead[]; selected: string[] } = {
@@ -36,6 +35,7 @@ function factory(
       ],
       provide: {
         nodeType: "alerts",
+        config: testConfiguration,
       },
     },
     propsData: {

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -508,7 +508,7 @@ describe("Manage Alerts - No Database Changes", () => {
     it("will add new filters through the quick add menu", () => {
       cy.intercept(
         "GET",
-        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=FALSE_POSITIVE",
+        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=IGNORE",
       ).as("getAlerts");
 
       // Open Quick Add menu
@@ -517,7 +517,7 @@ describe("Manage Alerts - No Database Changes", () => {
       cy.get(".p-overlaypanel-content > .p-button").click();
       // Check text
       cy.get(".filter-name-text").should("have.text", "Disposition:");
-      cy.get(".link-text").should("have.text", "FALSE_POSITIVE");
+      cy.get(".link-text").should("have.text", "IGNORE");
       cy.wait("@getAlerts").its("state").should("eq", "Complete");
 
       // Open Quick Add menu again
@@ -533,7 +533,7 @@ describe("Manage Alerts - No Database Changes", () => {
       // Type in observable value and submit
       cy.intercept(
         "GET",
-        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=FALSE_POSITIVE&observable=ipv4%7C127.0.0.1",
+        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=IGNORE&observable=ipv4%7C127.0.0.1",
       ).as("getAlerts");
       cy.get(".field > .p-inputtext").click();
       cy.get(":nth-child(2) > .p-inputtext").type("127.0.0.1");
@@ -666,7 +666,7 @@ describe("Manage Alerts - No Database Changes", () => {
     it("will update filters when a given filter is edited through its filter chip", () => {
       cy.intercept(
         "GET",
-        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=FALSE_POSITIVE",
+        "/api/alert/?sort=event_time%7Cdesc&limit=10&offset=0&disposition=IGNORE",
       ).as("getAlerts");
 
       // Set the filter using the quick add default

--- a/frontend/tests/e2e/specs/TheAlertsTable.spec.js
+++ b/frontend/tests/e2e/specs/TheAlertsTable.spec.js
@@ -294,7 +294,7 @@ describe("TheAlertsTable.vue", () => {
     cy.get("td ul").should("exist").should("be.visible");
     // Find and click the first observable tag in list
     cy.get(":nth-child(1) > .tag > .p-tag")
-      .eq(0)
+      .eq(1)
       .should("contain.text", "tag0")
       .click();
     // Wait for the filtered view to be requested


### PR DESCRIPTION
This PR adds tags for dispositions that have configurable color options. These disposition tags appear in the disposition modal, and alerts tables.

![image](https://user-images.githubusercontent.com/31867815/169048758-2847872d-9a82-4177-8a73-6ed39ad47282.png)

Closes #221 