### PR TITLE
'Node' Toolbar Improvements

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -2,7 +2,7 @@
 <!-- Main Entrypoint to the app -->
 
 <template>
-  <TheHeader />
+  <TheHeader style="position: sticky; top: 0; z-index: 1" />
   <router-view />
 </template>
 

--- a/frontend/src/components/Alerts/TheAlertActionToolbar.vue
+++ b/frontend/src/components/Alerts/TheAlertActionToolbar.vue
@@ -2,50 +2,52 @@
 <!-- Toolbar containing alert-specific actions, such as Disposition and Remediation -->
 
 <template>
-  <TheNodeActionToolbarVue ref="toolbar" :reload-object="props.reloadObject">
-    <template #start>
-      <!-- FALSE POSITIVE -->
-      <Button
-        v-if="showFalsePositiveShortcut"
-        data-cy="false-positive-button"
-        class="p-m-1 p-button-normal p-button-success"
-        icon="pi pi-thumbs-up"
-        label="FP"
-        @click="emit('falsePositiveClicked')"
-      />
-      <!-- IGNORE -->
-      <Button
-        v-if="showIgnoreShortcut"
-        data-cy="ignore-button"
-        class="p-m-1 p-button-sm"
-        icon="pi pi-check"
-        label="Ignore"
-        @click="emit('ignoreClicked')"
-      />
-      <!-- DISPOSITION -->
-      <Button
-        data-cy="disposition-button"
-        class="p-m-1 p-button-sm"
-        icon="pi pi-thumbs-up"
-        label="Disposition"
-        @click="open('DispositionModal')"
-      />
-      <DispositionModal
-        name="DispositionModal"
-        @request-reload="requestReload"
-      />
-      <!-- REMEDIATE MODAL -->
-      <Button
-        data-cy="remediate-button"
-        class="p-m-1 p-button-sm"
-        icon="pi pi-times-circle"
-        label="Remediate"
-        disabled
-        @click="open('RemediationModal')"
-      />
-      <RemediationModal />
-    </template>
-  </TheNodeActionToolbarVue>
+  <div>
+    <TheNodeActionToolbarVue ref="toolbar" :reload-object="props.reloadObject">
+      <template #start>
+        <!-- FALSE POSITIVE -->
+        <Button
+          v-if="showFalsePositiveShortcut"
+          data-cy="false-positive-button"
+          class="p-m-1 p-button-normal p-button-success"
+          icon="pi pi-thumbs-up"
+          label="FP"
+          @click="emit('falsePositiveClicked')"
+        />
+        <!-- IGNORE -->
+        <Button
+          v-if="showIgnoreShortcut"
+          data-cy="ignore-button"
+          class="p-m-1 p-button-sm"
+          icon="pi pi-check"
+          label="Ignore"
+          @click="emit('ignoreClicked')"
+        />
+        <!-- DISPOSITION -->
+        <Button
+          data-cy="disposition-button"
+          class="p-m-1 p-button-sm"
+          icon="pi pi-thumbs-up"
+          label="Disposition"
+          @click="open('DispositionModal')"
+        />
+        <DispositionModal
+          name="DispositionModal"
+          @request-reload="requestReload"
+        />
+        <!-- REMEDIATE MODAL -->
+        <Button
+          data-cy="remediate-button"
+          class="p-m-1 p-button-sm"
+          icon="pi pi-times-circle"
+          label="Remediate"
+          disabled
+          @click="open('RemediationModal')"
+        />
+        <RemediationModal />
+      </template>
+    </TheNodeActionToolbarVue>
+  </div>
 </template>
 
 <script setup lang="ts">

--- a/frontend/src/components/Alerts/TheAlertActionToolbar.vue
+++ b/frontend/src/components/Alerts/TheAlertActionToolbar.vue
@@ -4,7 +4,7 @@
 <template>
   <div>
     <TheNodeActionToolbarVue ref="toolbar" :reload-object="props.reloadObject">
-      <template #start>
+      <template #start-left>
         <!-- FALSE POSITIVE -->
         <Button
           v-if="showFalsePositiveShortcut"
@@ -18,7 +18,7 @@
         <Button
           v-if="showIgnoreShortcut"
           data-cy="ignore-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-normal p-button-secondary"
           icon="pi pi-check"
           label="Ignore"
           @click="emit('ignoreClicked')"
@@ -26,7 +26,7 @@
         <!-- DISPOSITION -->
         <Button
           data-cy="disposition-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-normal p-button-secondary"
           icon="pi pi-thumbs-up"
           label="Disposition"
           @click="open('DispositionModal')"
@@ -35,10 +35,12 @@
           name="DispositionModal"
           @request-reload="requestReload"
         />
+      </template>
+      <template #start-right>
         <!-- REMEDIATE MODAL -->
         <Button
           data-cy="remediate-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-sm p-button-secondary p-button-outlined"
           icon="pi pi-times-circle"
           label="Remediate"
           disabled

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -14,10 +14,10 @@
       <div v-if="props.takeOwnership">
         <Button
           data-cy="take-ownership-button"
-          class="p-m-1 p-button-normal p-button-secondary"
-          style="width: 170px"
+          :class="takeOwnershipClasses"
+          style="width: 180px"
           icon="pi pi-briefcase"
-          label="Take Ownership"
+          :label="takeOwnershipText"
           :disabled="!selectedStore.anySelected"
           @click="takeOwnership"
         />
@@ -88,7 +88,14 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, defineProps, defineExpose, inject, PropType } from "vue";
+  import {
+    ref,
+    computed,
+    defineProps,
+    defineExpose,
+    inject,
+    PropType,
+  } from "vue";
 
   import Button from "primevue/button";
   import Message from "primevue/message";
@@ -152,6 +159,26 @@
       requestReload();
     }
   }
+
+  const ownedByCurrentUser = computed(() => {
+    if (props.reloadObject == "node" && nodeStore.open) {
+      if ("owner" in nodeStore.open) {
+        const authStore = useAuthStore();
+        return nodeStore.open.owner.uuid == authStore.user.uuid;
+      }
+    }
+    return false;
+  });
+
+  const takeOwnershipText = computed(() => {
+    return ownedByCurrentUser.value ? "Assigned to you!" : "Take Ownership";
+  });
+
+  const takeOwnershipClasses = computed(() => {
+    return ownedByCurrentUser.value
+      ? ["p-m-1", "p-button-sm", "p-button-secondary", "p-button-outlined"]
+      : ["p-m-1", "p-button-normal", "p-button-secondary"];
+  });
 
   const requestReload = () => {
     if (props.reloadObject == "table") {

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -9,34 +9,35 @@
   </div>
   <Toolbar id="ActionToolbar">
     <template #start>
-      <slot name="start"></slot>
-      <!--      COMMENT -->
-      <div v-if="props.comment">
-        <Button
-          data-cy="comment-button"
-          class="p-m-1 p-button-sm"
-          icon="pi pi-comment"
-          label="Comment"
-          @click="open('CommentModal')"
-        />
-        <CommentModal name="CommentModal" @request-reload="requestReload" />
-      </div>
+      <slot name="start-left"></slot>
       <!--      TAKE OWNERSHIP -- NO MODAL -->
       <div v-if="props.takeOwnership">
         <Button
           data-cy="take-ownership-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-normal p-button-secondary"
+          style="width: 170px"
           icon="pi pi-briefcase"
           label="Take Ownership"
           :disabled="!selectedStore.anySelected"
           @click="takeOwnership"
         />
       </div>
+      <!--      COMMENT -->
+      <div v-if="props.comment">
+        <Button
+          data-cy="comment-button"
+          class="p-m-1 p-button-sm p-button-secondary p-button-outlined"
+          icon="pi pi-comment"
+          label="Comment"
+          @click="open('CommentModal')"
+        />
+        <CommentModal name="CommentModal" @request-reload="requestReload" />
+      </div>
       <!--      ASSIGN -->
       <div v-if="props.assign">
         <Button
           data-cy="assign-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-sm p-button-secondary p-button-outlined"
           icon="pi pi-user"
           label="Assign"
           @click="open('AssignModal')"
@@ -47,7 +48,7 @@
       <div v-if="props.tag">
         <Button
           data-cy="tag-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-sm p-button-secondary p-button-outlined"
           icon="pi pi-tags"
           label="Tag"
           @click="open('TagModal')"
@@ -64,7 +65,8 @@
       <div v-if="props.removeTag">
         <Button
           data-cy="remove-tag-button"
-          class="p-m-1 p-button-sm"
+          class="p-m-1 p-button-sm p-button-secondary p-button-outlined"
+          style="width: 142px"
           icon="pi pi-tags"
           label="Remove Tag(s)"
           @click="open('RemoveTagModal')"
@@ -77,6 +79,7 @@
           @request-reload="requestReload"
         />
       </div>
+      <slot name="start-right"></slot>
     </template>
     <template #end>
       <slot name="end"></slot>

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -164,7 +164,7 @@
     if (props.reloadObject == "node" && nodeStore.open) {
       if ("owner" in nodeStore.open) {
         const authStore = useAuthStore();
-        return nodeStore.open.owner.uuid == authStore.user.uuid;
+        return nodeStore.open.owner?.uuid == authStore.user.uuid;
       }
     }
     return false;

--- a/frontend/src/components/Node/TheNodeActionToolbar.vue
+++ b/frontend/src/components/Node/TheNodeActionToolbar.vue
@@ -7,7 +7,7 @@
       <Message severity="error" @close="handleError">{{ error }}</Message>
     </div>
   </div>
-  <Toolbar id="ActionToolbar" style="overflow-x: auto">
+  <Toolbar id="ActionToolbar">
     <template #start>
       <slot name="start"></slot>
       <!--      COMMENT -->

--- a/frontend/src/pages/Alerts/ManageAlerts.vue
+++ b/frontend/src/pages/Alerts/ManageAlerts.vue
@@ -2,7 +2,7 @@
 
 <template>
   <br />
-  <div id="AlertActionToolbar">
+  <div id="AlertActionToolbar" style="position: sticky; top: 3.5em; z-index: 1">
     <TheAlertActionToolbar reload-object="table" />
   </div>
   <br />

--- a/frontend/src/pages/Alerts/ViewAlert.vue
+++ b/frontend/src/pages/Alerts/ViewAlert.vue
@@ -2,17 +2,19 @@
 
 <template>
   <div v-if="error" class="p-col">
-    <Message severity="error" @close="handleError" data-cy="error-message">{{
+    <Message severity="error" data-cy="error-message" @close="handleError">{{
       error
     }}</Message>
   </div>
-  <TheAlertActionToolbar
-    reload-object="node"
-    :show-false-positive-shortcut="true"
-    :show-ignore-shortcut="true"
-    @false-positive-clicked="dispositionAlert('falsePositive')"
-    @ignore-clicked="dispositionAlert('ignore')"
-  />
+  <div style="position: sticky; top: 3.5em; z-index: 1">
+    <TheAlertActionToolbar
+      reload-object="node"
+      :show-false-positive-shortcut="true"
+      :show-ignore-shortcut="true"
+      @false-positive-clicked="dispositionAlert('falsePositive')"
+      @ignore-clicked="dispositionAlert('ignore')"
+    />
+  </div>
   <div v-if="alertStore.open">
     <TheAlertDetails />
     <br />

--- a/frontend/src/pages/Events/ManageEvents.vue
+++ b/frontend/src/pages/Events/ManageEvents.vue
@@ -2,7 +2,7 @@
 
 <template>
   <br />
-  <div id="EventActionToolbar">
+  <div id="EventActionToolbar" style="position: sticky; top: 3.5em; z-index: 1">
     <TheNodeActionToolbarVue reload-object="table" />
   </div>
   <br />

--- a/frontend/tests/component/src/components/Node/TheNodeActionToolbar.spec.ts
+++ b/frontend/tests/component/src/components/Node/TheNodeActionToolbar.spec.ts
@@ -3,6 +3,7 @@ import PrimeVue from "primevue/config";
 
 import TheNodeActionToolbar from "@/components/Node/TheNodeActionToolbar.vue";
 import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import { alertTreeReadFactory } from "@mocks/alert";
 import { userReadFactory } from "@mocks/user";
 import CommentModalVue from "@/components/Modals/CommentModal.vue";
 
@@ -70,6 +71,18 @@ describe("TheNodeActionToolbar", () => {
         owner: "analyst",
       },
     ]);
+  });
+  it("displays correct alternate text if reloadObject is node, and the open node's owner is the current user", () => {
+    factory({
+      props: { reloadObject: "node" },
+      initialState: {
+        authStore: { user: userReadFactory() },
+        alertStore: {
+          open: alertTreeReadFactory({ owner: userReadFactory() }),
+        },
+      },
+    });
+    cy.contains("Assigned to you!").should("be.visible");
   });
   it("attempts to reload the node if the given 'reloadObject' is 'node'", () => {
     factory({

--- a/frontend/tests/component/src/pages/Alerts/ViewAlert.spec.ts
+++ b/frontend/tests/component/src/pages/Alerts/ViewAlert.spec.ts
@@ -14,13 +14,21 @@ import { alertTreeReadFactory } from "@mocks/alert";
 import TheAlertActionToolbarVue from "@/components/Alerts/TheAlertActionToolbar.vue";
 import TheAlertDetailsVue from "@/components/Alerts/TheAlertDetails.vue";
 import AlertTreeVue from "@/components/Alerts/AlertTree.vue";
+import { userReadFactory } from "@mocks/user";
 
 function factory(stubActions = true) {
   return mount(ViewAlert, {
     global: {
       plugins: [
         PrimeVue,
-        createCustomCypressPinia({ stubActions: stubActions }),
+        createCustomCypressPinia({
+          stubActions: stubActions,
+          initialState: {
+            authStore: {
+              user: userReadFactory(),
+            },
+          },
+        }),
         router,
       ],
       provide: { config: testConfiguration },


### PR DESCRIPTION
This PR updates TheNodeActionToolbar component to have a few improvements, including:  

- now being sticky (so the toolbar will remain visible while scrolling down longer pages)
- making the most commonly used buttons more prominent (specifically, making the take ownership button more prominent)
- updating the 'Take Ownership' button to have a slightly different display if currently opened alert or event is already owned by the current user 
    - hopefully, this will signal better to users if they do not own an alert yet

![image](https://user-images.githubusercontent.com/31867815/169153473-b0f3f6c1-ff31-4578-b786-594b8b048a8c.png)
![image](https://user-images.githubusercontent.com/31867815/169153512-a4ec7bf8-1b27-4aac-97c9-e74a45fd051e.png)
