### PR TITLE
Jump to Detection

### DIFF
--- a/frontend/src/components/Alerts/TheAlertDetails.vue
+++ b/frontend/src/components/Alerts/TheAlertDetails.vue
@@ -50,9 +50,9 @@
                   <td class="header-cell">Detection</td>
                   <td class="content-cell">
                     <span>
-                      <span style="vertical-align: baseline">
-                        {{ detection.value }}
-                      </span>
+                      <span style="vertical-align: baseline">{{
+                        detection.value
+                      }}</span>
                       <Button
                         style="vertical-align: baseline"
                         icon="pi pi-directions"

--- a/frontend/src/components/Alerts/TheAlertDetails.vue
+++ b/frontend/src/components/Alerts/TheAlertDetails.vue
@@ -49,7 +49,17 @@
                 >
                   <td class="header-cell">Detection</td>
                   <td class="content-cell">
-                    {{ detection.value }}
+                    <span>
+                      <span style="vertical-align: baseline">
+                        {{ detection.value }}
+                      </span>
+                      <Button
+                        style="vertical-align: baseline"
+                        icon="pi pi-directions"
+                        class="p-button-rounded p-button-secondary p-button-text"
+                        @click="scrollToElement(detection.uuid)"
+                      />
+                    </span>
                   </td>
                 </tr>
                 <tr v-if="alertStore.open['instructions']">
@@ -112,6 +122,15 @@
       isLoading.value = false;
     }
   });
+
+  const scrollToElement = (detectionUuid: string) => {
+    const detection = document.getElementById(detectionUuid);
+
+    if (detection) {
+      // Use el.scrollIntoView() to instantly scroll to the element
+      detection.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  };
 
   const getAllDetectionPoints = async (uuid: string) => {
     try {

--- a/frontend/src/components/Alerts/TheAlertDetails.vue
+++ b/frontend/src/components/Alerts/TheAlertDetails.vue
@@ -57,7 +57,7 @@
                         style="vertical-align: baseline"
                         icon="pi pi-directions"
                         class="p-button-rounded p-button-secondary p-button-text"
-                        @click="scrollToElement(detection.uuid)"
+                        @click="scrollToDetection(detection.uuid)"
                       />
                     </span>
                   </td>
@@ -123,11 +123,10 @@
     }
   });
 
-  const scrollToElement = (detectionUuid: string) => {
+  const scrollToDetection = (detectionUuid: string) => {
     const detection = document.getElementById(detectionUuid);
 
     if (detection) {
-      // Use el.scrollIntoView() to instantly scroll to the element
       detection.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   };

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -9,15 +9,17 @@
     </span>
     <span
       v-for="detection in observable.detectionPoints"
+      :id="detection.uuid"
       :key="detection.uuid"
       v-tooltip.right="{
         value: detection.value,
       }"
       class="detection-point"
       data-cy="detection-point-symbol"
+      style="font-size: 2rem; width: 100%"
     >
-      &#128293;</span
-    >
+      &#128293;
+    </span>
     <Button
       v-if="showCopyToClipboard"
       data-cy="copy-to-clipboard-button"

--- a/frontend/src/pages/Alerts/ViewAlert.vue
+++ b/frontend/src/pages/Alerts/ViewAlert.vue
@@ -18,7 +18,7 @@
   <div v-if="alertStore.open">
     <TheAlertDetails />
     <br />
-    <Card>
+    <Card style="overflow-x: scroll">
       <template #content>
         <div class="p-tree p-component p-tree-wrapper" style="border: none">
           <AlertTree
@@ -26,6 +26,7 @@
             :items="alertStore.open.children"
             :alert-id="alertID"
           />
+          <ScrollTop />
         </div>
       </template>
     </Card>
@@ -38,6 +39,7 @@
 
   import Card from "primevue/card";
   import Message from "primevue/message";
+  import ScrollTop from "primevue/scrolltop";
 
   import TheAlertActionToolbar from "@/components/Alerts/TheAlertActionToolbar.vue";
   import AlertTree from "@/components/Alerts/AlertTree.vue";

--- a/frontend/tests/component/src/components/Alerts/TheAlertDetails.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/TheAlertDetails.spec.ts
@@ -174,16 +174,16 @@ describe("TheAlertDetails", () => {
     cy.findAllByText("Detection")
       .eq(0)
       .siblings()
-      .should("have.text", "detectionC");
+      .should("contain.text", "detectionC");
     cy.findAllByText("Detection");
     cy.findAllByText("Detection")
       .eq(1)
       .siblings()
-      .should("have.text", "detectionB");
+      .should("contain.text", "detectionB");
     cy.findAllByText("Detection")
       .eq(2)
       .siblings()
-      .should("have.text", "detectionA");
+      .should("contain.text", "detectionA");
   });
   it("displays error if request to fetch observables fails", () => {
     cy.stub(NodeTree, "readNodesOfNodeTree")


### PR DESCRIPTION
This PR adds two new handy features, the ability to jump to a detection in the alert tree from an entry in the alert details, as well as a scroll to top botton, to quickly go back to the top of a large alert.


![scrollToDetection](https://user-images.githubusercontent.com/31867815/169358308-77252a3b-b55d-483f-a7af-42031339e633.gif)
![scrollToTop](https://user-images.githubusercontent.com/31867815/169358315-c7fef72f-c8ed-4c37-b408-20b0c37ed7ad.gif)

