### PR TITLE
Save Recent Comments

### DIFF
--- a/frontend/src/components/Modals/CommentModal.vue
+++ b/frontend/src/components/Modals/CommentModal.vue
@@ -50,6 +50,7 @@
   import { useAuthStore } from "@/stores/auth";
   import { nodeSelectedStores } from "@/stores/index";
   import { useModalStore } from "@/stores/modal";
+  import { useRecentCommentsStore } from "@/stores/recentComments";
 
   const emit = defineEmits(["requestReload"]);
 
@@ -61,6 +62,7 @@
   const authStore = useAuthStore();
   const selectedStore = nodeSelectedStores[nodeType]();
   const modalStore = useModalStore();
+  const recentCommentsStore = useRecentCommentsStore();
 
   const error = ref<string>();
   const isLoading = ref(false);
@@ -86,6 +88,7 @@
 
     isLoading.value = false;
     if (!error.value) {
+      recentCommentsStore.addComment(newComment.value);
       close();
       emit("requestReload");
     }

--- a/frontend/src/components/Modals/CommentModal.vue
+++ b/frontend/src/components/Modals/CommentModal.vue
@@ -18,6 +18,9 @@
           placeholder="Add a comment..."
         />
       </div>
+      <NodeCommentAutocomplete
+        @comment-clicked="recentCommentClicked($event)"
+      ></NodeCommentAutocomplete>
     </div>
     <template #footer>
       <Button
@@ -44,6 +47,7 @@
   import Textarea from "primevue/textarea";
 
   import BaseModal from "@/components/Modals/BaseModal.vue";
+  import NodeCommentAutocomplete from "@/components/Node/NodeCommentAutocomplete.vue";
 
   import { NodeComment } from "@/services/api/nodeComment";
 
@@ -103,6 +107,10 @@
   const allowSubmit = computed(() => {
     return selectedStore.anySelected && newComment.value.length;
   });
+
+  const recentCommentClicked = (comment: string) => {
+    newComment.value = comment;
+  };
 
   const handleError = () => {
     error.value = undefined;

--- a/frontend/src/components/Modals/DispositionModal.vue
+++ b/frontend/src/components/Modals/DispositionModal.vue
@@ -74,6 +74,8 @@
   import { useAuthStore } from "@/stores/auth";
   import { useModalStore } from "@/stores/modal";
   import { useSelectedAlertStore } from "@/stores/selectedAlert";
+  import { useRecentCommentsStore } from "@/stores/recentComments";
+
   import { alertDispositionRead } from "@/models/alertDisposition";
   import { nodeCommentCreate } from "@/models/nodeComment";
 
@@ -82,6 +84,7 @@
   const authStore = useAuthStore();
   const modalStore = useModalStore();
   const selectedAlertStore = useSelectedAlertStore();
+  const recentCommentsStore = useRecentCommentsStore();
 
   const emit = defineEmits(["requestReload"]);
 
@@ -134,6 +137,9 @@
     isLoading.value = false;
 
     if (!error.value) {
+      if (dispositionComment.value) {
+        recentCommentsStore.addComment(dispositionComment.value);
+      }
       close();
       emit("requestReload");
     }

--- a/frontend/src/components/Modals/DispositionModal.vue
+++ b/frontend/src/components/Modals/DispositionModal.vue
@@ -32,6 +32,9 @@
           cols="30"
           placeholder="Add a comment..."
         />
+        <NodeCommentAutocomplete
+          @comment-clicked="recentCommentClicked($event)"
+        ></NodeCommentAutocomplete>
       </div>
     </div>
 
@@ -68,6 +71,7 @@
   import AlertDispositionTag from "@/components/Alerts/AlertDispositionTag.vue";
 
   import { NodeComment } from "@/services/api/nodeComment";
+  import NodeCommentAutocomplete from "@/components/Node/NodeCommentAutocomplete.vue";
 
   import { useAlertDispositionStore } from "@/stores/alertDisposition";
   import { useAlertStore } from "@/stores/alert";
@@ -152,6 +156,10 @@
     }
     return false;
   });
+
+  const recentCommentClicked = (comment: string) => {
+    dispositionComment.value = comment;
+  };
 
   const handleError = () => {
     error.value = undefined;

--- a/frontend/src/components/Modals/EditEventModal.vue
+++ b/frontend/src/components/Modals/EditEventModal.vue
@@ -81,10 +81,12 @@
   import { propertyOption } from "@/models/base";
   import { nodeCommentRead } from "@/models/nodeComment";
   import { populateEventStores } from "@/stores/helpers";
+  import { useRecentCommentsStore } from "@/stores/recentComments";
 
   const authStore = useAuthStore();
   const modalStore = useModalStore();
   const eventStore = useEventStore();
+  const recentCommentsStore = useRecentCommentsStore();
 
   const props = defineProps({
     name: { type: String, required: true },
@@ -230,6 +232,7 @@
           username: authStore.user.username,
           value: comment.value,
         });
+        recentCommentsStore.addComment(comment.value!);
       }
     }
   };

--- a/frontend/src/components/Modals/SaveToEventModal.vue
+++ b/frontend/src/components/Modals/SaveToEventModal.vue
@@ -45,6 +45,9 @@
                   cols="30"
                 />
                 <label for="newEventComment">Event Comment</label>
+                <NodeCommentAutocomplete
+                  @comment-clicked="recentCommentClicked($event)"
+                ></NodeCommentAutocomplete>
               </span>
             </div>
           </div>
@@ -98,6 +101,7 @@
   import Textarea from "primevue/textarea";
 
   import BaseModal from "@/components/Modals/BaseModal.vue";
+  import NodeCommentAutocomplete from "@/components/Node/NodeCommentAutocomplete.vue";
 
   import { Event } from "@/services/api/event";
   import { NodeComment } from "@/services/api/nodeComment";
@@ -301,6 +305,10 @@
   const newEventSelected = computed(() => {
     return selectedEventStatusOption.value === 0;
   });
+
+  const recentCommentClicked = (comment: string) => {
+    newEventComment.value = comment;
+  };
 
   const handleError = () => {
     error.value = undefined;

--- a/frontend/src/components/Modals/SaveToEventModal.vue
+++ b/frontend/src/components/Modals/SaveToEventModal.vue
@@ -108,6 +108,8 @@
   import { useEventStatusStore } from "@/stores/eventStatus";
   import { useModalStore } from "@/stores/modal";
   import { useSelectedAlertStore } from "@/stores/selectedAlert";
+  import { useRecentCommentsStore } from "@/stores/recentComments";
+
   import { eventRead, eventSummary } from "@/models/event";
   import { eventStatusRead } from "@/models/eventStatus";
 
@@ -116,6 +118,7 @@
   const eventStatusStore = useEventStatusStore();
   const modalStore = useModalStore();
   const selectedAlertStore = useSelectedAlertStore();
+  const recentCommentsStore = useRecentCommentsStore();
 
   const props = defineProps({
     name: { type: String, required: true },
@@ -240,6 +243,9 @@
               return;
             }
           }
+        }
+        if (newEventComment.value) {
+          recentCommentsStore.addComment(newEventComment.value);
         }
       }
     } else {

--- a/frontend/src/components/Node/NodeCommentAutocomplete.vue
+++ b/frontend/src/components/Node/NodeCommentAutocomplete.vue
@@ -6,6 +6,7 @@
       :dropdown="true"
       :disabled="!recentCommentStore.recentComments.length"
       force-selection
+      auto-highlight
       @complete="searchComment($event)"
       @item-select="itemSelect($event.value)"
     >
@@ -61,7 +62,10 @@
   });
 
   const itemSelect = (comment: string) => {
-    emit("commentClicked", comment);
+    if (recentCommentStore.recentComments.includes(selected.value)) {
+      emit("commentClicked", comment);
+    }
+    selected.value = undefined;
   };
 
   const removeComment = (comment: string) => {

--- a/frontend/src/components/Node/NodeCommentAutocomplete.vue
+++ b/frontend/src/components/Node/NodeCommentAutocomplete.vue
@@ -41,7 +41,7 @@
   const recentCommentStore = useRecentCommentsStore();
   const filteredComments = ref<string[]>();
 
-  const searchComment = (event) => {
+  const searchComment = (event: { query: string }) => {
     setTimeout(() => {
       if (!event.query.trim().length) {
         filteredComments.value = [...recentCommentStore.recentComments];
@@ -56,13 +56,19 @@
   };
 
   watch(recentCommentStore, () => {
-    if (!recentCommentStore.recentComments.includes(selected.value)) {
+    if (
+      selected.value &&
+      !recentCommentStore.recentComments.includes(selected.value)
+    ) {
       selected.value = undefined;
     }
   });
 
   const itemSelect = (comment: string) => {
-    if (recentCommentStore.recentComments.includes(selected.value)) {
+    if (
+      selected.value &&
+      recentCommentStore.recentComments.includes(selected.value)
+    ) {
       emit("commentClicked", comment);
     }
     selected.value = undefined;
@@ -70,6 +76,10 @@
 
   const removeComment = (comment: string) => {
     recentCommentStore.removeComment(comment);
-    filteredComments.value = filteredComments.value.filter((c) => c != comment);
+    if (filteredComments.value) {
+      filteredComments.value = filteredComments.value.filter(
+        (c) => c != comment,
+      );
+    }
   };
 </script>

--- a/frontend/src/components/Node/NodeCommentAutocomplete.vue
+++ b/frontend/src/components/Node/NodeCommentAutocomplete.vue
@@ -1,0 +1,67 @@
+<template>
+  <span class="p-float-label">
+    <AutoComplete
+      v-model="selected"
+      :suggestions="filteredComments"
+      :dropdown="true"
+      :disabled="!recentCommentStore.recentComments.length"
+      force-selection
+      @complete="searchComment($event)"
+      @dropdown-click="emit('commentClicked', $event.query)"
+    >
+      <template #item="slotProps">
+        <div>
+          <span class="ml-2">{{ slotProps.item }}</span>
+          <span
+            class="delete-comment"
+            style="float: right"
+            @click="removeComment(slotProps.item)"
+            ><span class="pi pi-times"></span
+          ></span>
+        </div>
+      </template>
+    </AutoComplete>
+    <label v-if="recentCommentStore.recentComments.length" for="autocomplete"
+      >Choose a recent comment</label
+    >
+    <label v-if="!recentCommentStore.recentComments.length" for="autocomplete"
+      >No recent comments available</label
+    >
+  </span>
+</template>
+<script setup lang="ts">
+  import { ref, defineEmits, watch } from "vue";
+
+  import AutoComplete from "primevue/autocomplete";
+
+  import { useRecentCommentsStore } from "@/stores/recentComments";
+  const emit = defineEmits(["commentClicked"]);
+  const selected = ref<string>();
+  const recentCommentStore = useRecentCommentsStore();
+  const filteredComments = ref<string[]>();
+
+  const searchComment = (event) => {
+    setTimeout(() => {
+      if (!event.query.trim().length) {
+        filteredComments.value = [...recentCommentStore.recentComments];
+      } else {
+        filteredComments.value = recentCommentStore.recentComments.filter(
+          (comment) => {
+            return comment.toLowerCase().startsWith(event.query.toLowerCase());
+          },
+        );
+      }
+    }, 250);
+  };
+
+  watch(recentCommentStore, () => {
+    if (!recentCommentStore.recentComments.includes(selected.value)) {
+      selected.value = undefined;
+    }
+  });
+
+  const removeComment = (comment: string) => {
+    recentCommentStore.removeComment(comment);
+    filteredComments.value = filteredComments.value.filter((c) => c != comment);
+  };
+</script>

--- a/frontend/src/components/Node/NodeCommentAutocomplete.vue
+++ b/frontend/src/components/Node/NodeCommentAutocomplete.vue
@@ -7,7 +7,7 @@
       :disabled="!recentCommentStore.recentComments.length"
       force-selection
       @complete="searchComment($event)"
-      @dropdown-click="emit('commentClicked', $event.query)"
+      @item-select="itemSelect($event.value)"
     >
       <template #item="slotProps">
         <div>
@@ -59,6 +59,10 @@
       selected.value = undefined;
     }
   });
+
+  const itemSelect = (comment: string) => {
+    emit("commentClicked", comment);
+  };
 
   const removeComment = (comment: string) => {
     recentCommentStore.removeComment(comment);

--- a/frontend/src/components/Node/NodeCommentEditor.vue
+++ b/frontend/src/components/Node/NodeCommentEditor.vue
@@ -42,6 +42,9 @@
         data-cy="updated-comment-value"
       />
     </div>
+    <NodeCommentAutocomplete
+      @comment-clicked="recentCommentClicked($event)"
+    ></NodeCommentAutocomplete>
     <div class="field col-fixed">
       <Button
         icon="pi pi-times"
@@ -65,6 +68,7 @@
   import Button from "primevue/button";
   import InputText from "primevue/inputtext";
   import NodeComment from "@/components/Node/NodeComment.vue";
+  import NodeCommentAutocomplete from "@/components/Node/NodeCommentAutocomplete.vue";
   import { nodeCommentRead } from "@/models/nodeComment";
 
   const props = defineProps({
@@ -99,5 +103,9 @@
       emit("update:modelValue", comments.value);
       closeEditCommentPanel();
     }
+  };
+
+  const recentCommentClicked = (comment: string) => {
+    editingCommentValue.value = comment;
   };
 </script>

--- a/frontend/src/stores/recentComments.ts
+++ b/frontend/src/stores/recentComments.ts
@@ -1,0 +1,30 @@
+import { defineStore } from "pinia";
+
+export const useRecentCommentsStore = defineStore({
+  id: "recentCommentsStore",
+
+  state: () => ({
+    recentComments: JSON.parse(
+      localStorage.getItem("aceComments") || "[]",
+    ) as string[],
+  }),
+
+  actions: {
+    addComment(comment: string) {
+      // push to the front if the comment is already in the list
+      if (this.recentComments.includes(comment)) {
+        this.recentComments = this.recentComments.filter((c) => c != comment);
+      }
+      if (this.recentComments.length == 10) {
+        this.recentComments.pop();
+      }
+      this.recentComments.unshift(comment);
+      localStorage.setItem("aceComments", JSON.stringify(this.recentComments));
+    },
+
+    removeComment(comment: string) {
+      this.recentComments = this.recentComments.filter((c) => c != comment);
+      localStorage.setItem("aceComments", JSON.stringify(this.recentComments));
+    },
+  },
+});

--- a/frontend/tests/component/src/components/Modals/CommentModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/CommentModal.spec.ts
@@ -59,7 +59,7 @@ describe("CommentModal", () => {
     factory({ selected: ["uuid"] });
     cy.findAllByText("Add").parent().should("be.disabled");
   });
-  it.only("correctly makes request to create comment upon adding comment text via NodeCommentAutocomplete and submit", () => {
+  it("correctly makes request to create comment upon adding comment text via NodeCommentAutocomplete and submit", () => {
     cy.stub(NodeComment, "create")
       .withArgs([
         {

--- a/frontend/tests/component/src/components/Modals/DispositionModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/DispositionModal.spec.ts
@@ -30,6 +30,9 @@ function factory(
             selectedAlertStore: {
               selected: args.selected,
             },
+            recentCommentsStore: {
+              recentComments: ["test"],
+            },
           },
         }),
       ],
@@ -147,6 +150,34 @@ describe("DispositionModal", () => {
     cy.findAllByPlaceholderText("Add a comment...")
       .click()
       .type("Test comment");
+    cy.contains("Save").click();
+    cy.get("@setDisposition").should("have.been.calledOnce");
+    cy.get("@createComment").should("have.been.calledOnce");
+    cy.get("[data-cy=DispositionModal]").should("not.exist");
+  });
+  it("attempts to set disposition and create comment when save button clicked and comment is given using NodeCommentAutocomplete", () => {
+    cy.stub(Alert, "update")
+      .withArgs([{ uuid: "uuid", disposition: "Bad" }])
+      .as("setDisposition")
+      .resolves();
+    cy.stub(NodeComment, "create")
+      .withArgs([
+        {
+          username: "analyst",
+          nodeUuid: "uuid",
+          value: "test extra content",
+        },
+      ])
+      .as("createComment")
+      .resolves();
+    factory({
+      dipsositions: [falsePositive, badDisposition],
+      selected: ["uuid"],
+    });
+    cy.contains("Bad").click();
+    cy.get(".p-autocomplete > .p-button").click();
+    cy.contains("test").click();
+    cy.findByDisplayValue("test").click().type(" extra content");
     cy.contains("Save").click();
     cy.get("@setDisposition").should("have.been.calledOnce");
     cy.get("@createComment").should("have.been.calledOnce");

--- a/frontend/tests/component/src/components/Modals/SaveToEventModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/SaveToEventModal.spec.ts
@@ -325,7 +325,7 @@ describe("SaveToEventModal", () => {
     cy.get("@updateAlert").should("have.been.calledOnce");
     cy.get("[data-cy='save-to-event-modal']").should("not.exist");
   });
-  it.only("attempts to create and save to new event when new event, and disposition comment when is selected, comment is given using NodeCommentAutocomplete, and the 'Save' button is clicked", () => {
+  it("attempts to create and save to new event when new event, and disposition comment when is selected, comment is given using NodeCommentAutocomplete, and the 'Save' button is clicked", () => {
     cy.stub(Event, "create")
       .withArgs(
         {

--- a/frontend/tests/component/src/components/Modals/SaveToEventModal.spec.ts
+++ b/frontend/tests/component/src/components/Modals/SaveToEventModal.spec.ts
@@ -59,6 +59,9 @@ function factory(
             eventStatusStore: {
               items: [openStatus, closedStatus],
             },
+            recentCommentsStore: {
+              recentComments: ["test"],
+            },
           },
         }),
       ],
@@ -316,6 +319,59 @@ describe("SaveToEventModal", () => {
     cy.contains("NEW").click();
     cy.findByLabelText("Event Name").click().type("Test Name");
     cy.findByLabelText("Event Comment").click().type("Test Comment");
+    cy.findByText("Save").click();
+    cy.get("@createEvent").should("have.been.calledOnce");
+    cy.get("@createComment").should("have.been.calledOnce");
+    cy.get("@updateAlert").should("have.been.calledOnce");
+    cy.get("[data-cy='save-to-event-modal']").should("not.exist");
+  });
+  it.only("attempts to create and save to new event when new event, and disposition comment when is selected, comment is given using NodeCommentAutocomplete, and the 'Save' button is clicked", () => {
+    cy.stub(Event, "create")
+      .withArgs(
+        {
+          name: "Test Name",
+          queue: "testObject",
+          owner: "analyst",
+          status: "OPEN",
+        },
+        true,
+      )
+      .as("createEvent")
+      .returns(eventReadFactory());
+    cy.stub(NodeComment, "create")
+      .withArgs([
+        {
+          username: "analyst",
+          nodeUuid: "testEvent1",
+          user: "analyst",
+          value: "test extra content",
+        },
+      ])
+      .as("createComment")
+      .resolves();
+    cy.stub(Alert, "update")
+      .withArgs([
+        {
+          uuid: "uuid",
+          eventUuid: "testEvent1",
+        },
+      ])
+      .as("updateAlert")
+      .resolves();
+    factory({
+      selected: ["uuid"],
+      openEvents: [
+        eventReadFactory({ name: "Test Open Event", status: openStatus }),
+      ],
+      closedEvents: [
+        eventReadFactory({ name: "Test Closed Event", status: closedStatus }),
+      ],
+    });
+    cy.contains("NEW").click();
+    cy.findByLabelText("Event Name").click().type("Test Name");
+    cy.get(".p-autocomplete > .p-button").click();
+    cy.contains("test").click();
+    cy.findByDisplayValue("test").click().type(" extra content");
     cy.findByText("Save").click();
     cy.get("@createEvent").should("have.been.calledOnce");
     cy.get("@createComment").should("have.been.calledOnce");

--- a/frontend/tests/component/src/components/Node/NodeCommentAutocomplete.spec.ts
+++ b/frontend/tests/component/src/components/Node/NodeCommentAutocomplete.spec.ts
@@ -1,0 +1,76 @@
+import { mount } from "@cypress/vue";
+import PrimeVue from "primevue/config";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+
+import NodeCommentAutocomplete from "@/components/Node/NodeCommentAutocomplete.vue";
+
+function factory(recentComments: string[] = []) {
+  return mount(NodeCommentAutocomplete, {
+    global: {
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          stubActions: false,
+          initialState: {
+            recentCommentsStore: {
+              recentComments: recentComments,
+            },
+          },
+        }),
+      ],
+    },
+  });
+}
+
+describe("NodeCommentAutocomplete", () => {
+  it("renders correctly if there are no options available", () => {
+    factory();
+    cy.contains("No recent comments available").should("be.visible");
+    cy.get("input").should("be.disabled");
+  });
+  it("renders correctly if there are options available", () => {
+    factory(["test"]);
+    cy.contains("Choose a recent comment").should("be.visible");
+    cy.get("input").should("have.value", "");
+    cy.get("input").should("not.be.disabled");
+  });
+  it("renders options correctly", () => {
+    const comments = ["example", "test", "another one"];
+    factory(comments);
+    cy.contains("Choose a recent comment").should("be.visible");
+    cy.get(".p-button").click();
+    comments.forEach((comment) => {
+      cy.contains(comment).should("be.visible");
+    });
+  });
+  it("autocompletes as expected", () => {
+    const comments = ["example", "test", "another one"];
+    factory(comments);
+    cy.get("input").click().type("t");
+    cy.contains("test").should("be.visible");
+    cy.contains("example").should("not.exist");
+    cy.contains("another one").should("not.exist");
+  });
+  it("emits expected event suggestion is clicked", () => {
+    const comments = ["example", "test", "another one"];
+    factory(comments).then((wrapper) => {
+      cy.contains("Choose a recent comment").should("be.visible");
+      cy.get(".p-button").click();
+      cy.contains("example").click();
+      cy.get("input").should("have.value", "example");
+      expect("commentClicked" in wrapper.emitted());
+      expect(wrapper.emitted()["commentClicked"] === "example");
+    });
+  });
+  it("attempts to remove suggestions from recentComments when delete button clicked", () => {
+    const comments = ["example", "test", "another one"];
+    factory(comments);
+    cy.contains("Choose a recent comment").should("be.visible");
+    cy.get(".p-button").click();
+    cy.contains("example").siblings().click();
+    cy.get("@spy-2").should("have.been.calledOnceWith", "example");
+    cy.get("input").should("have.value", "");
+    cy.get(".p-button").click();
+    cy.contains("example").should("not.exist");
+  });
+});

--- a/frontend/tests/component/src/components/Node/NodeCommentAutocomplete.spec.ts
+++ b/frontend/tests/component/src/components/Node/NodeCommentAutocomplete.spec.ts
@@ -57,7 +57,7 @@ describe("NodeCommentAutocomplete", () => {
       cy.contains("Choose a recent comment").should("be.visible");
       cy.get(".p-button").click();
       cy.contains("example").click();
-      cy.get("input").should("have.value", "example");
+      cy.get("input").should("have.value", "");
       expect("commentClicked" in wrapper.emitted());
       expect(wrapper.emitted()["commentClicked"] === "example");
     });

--- a/frontend/tests/component/src/components/Node/NodeCommentEditor.spec.ts
+++ b/frontend/tests/component/src/components/Node/NodeCommentEditor.spec.ts
@@ -106,7 +106,7 @@ describe("NodeCommentEditor", () => {
       "be.visible",
     );
   });
-  it.only("correctly updates comment data when selecting from recent comments", () => {
+  it("correctly updates comment data when selecting from recent comments", () => {
     factory([
       commentReadFactory({ insertTime: new Date(2022, 4, 25, 12, 0, 0, 0) }),
     ]);

--- a/frontend/tests/component/src/components/Node/NodeCommentEditor.spec.ts
+++ b/frontend/tests/component/src/components/Node/NodeCommentEditor.spec.ts
@@ -1,5 +1,5 @@
 import { mount } from "@cypress/vue";
-import { createPinia } from "pinia";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
 import PrimeVue from "primevue/config";
 
 import { commentReadFactory } from "@mocks/comment";
@@ -18,7 +18,16 @@ let comments = [
 function factory(props: nodeCommentRead[] = comments) {
   mount(NodeCommentEditor, {
     global: {
-      plugins: [PrimeVue, createPinia()],
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          initialState: {
+            recentCommentsStore: {
+              recentComments: ["example"],
+            },
+          },
+        }),
+      ],
     },
     propsData: { modelValue: props },
   });
@@ -96,5 +105,23 @@ describe("NodeCommentEditor", () => {
     cy.contains("5/25/2022, 12:00:00 PM (Test Analyst) A test comment").should(
       "be.visible",
     );
+  });
+  it.only("correctly updates comment data when selecting from recent comments", () => {
+    factory([
+      commentReadFactory({ insertTime: new Date(2022, 4, 25, 12, 0, 0, 0) }),
+    ]);
+    cy.get('[data-cy="edit-comment-button"]').first().click();
+    cy.contains("5/25/2022, 12:00:00 PM (Test Analyst) A test comment").should(
+      "be.visible",
+    );
+    cy.get('[data-cy="edit-comment-panel"]').should("be.visible");
+    cy.get(".p-autocomplete > .p-button").click();
+    cy.contains("example").click();
+    cy.findAllByDisplayValue("example").type(" extra text");
+    cy.get('[data-cy="save-comment-button"]').click();
+    cy.get('[data-cy="edit-comment-panel"]').should("not.exist");
+    cy.contains(
+      "5/25/2022, 12:00:00 PM (Test Analyst) example extra text",
+    ).should("be.visible");
   });
 });

--- a/frontend/tests/unit/src/store/recentComments.spec.ts
+++ b/frontend/tests/unit/src/store/recentComments.spec.ts
@@ -1,0 +1,149 @@
+import { describe, beforeEach, it, expect } from "vitest";
+import { useRecentCommentsStore } from "@/stores/recentComments";
+import { createCustomPinia } from "@tests/unitHelpers";
+
+createCustomPinia();
+
+const store = useRecentCommentsStore();
+
+describe("recentComments initialState", () => {
+  beforeEach(() => {
+    store.$reset();
+    localStorage.removeItem("aceComments");
+  });
+  it("aceComments doesn't exist in localStorage", () => {
+    const store = useRecentCommentsStore();
+    expect(store.recentComments).toEqual([]);
+  });
+  it("aceComments does exist in localStorage", () => {
+    const expected = ["test", "example", "another one"];
+    localStorage.setItem("aceComments", JSON.stringify(expected));
+    store.$reset();
+    expect(store.recentComments).toEqual(expected);
+  });
+});
+
+describe("recentComments Actions", () => {
+  beforeEach(() => {
+    store.$reset();
+
+    localStorage.removeItem("aceComments");
+  });
+  it.each([
+    [[], "test", ["test"]],
+    [
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+      "test",
+      [
+        "test",
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+      ],
+    ],
+    [
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+      "five",
+      [
+        "five",
+        "one",
+        "two",
+        "three",
+        "four",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+    ],
+  ])("addComment", (initialState, addition, expected) => {
+    store.recentComments = initialState;
+    store.addComment(addition);
+    expect(store.recentComments).toEqual(expected);
+    expect(localStorage.getItem("aceComments")).toEqual(
+      JSON.stringify(expected),
+    );
+  });
+  it.each([
+    [[], "test", []],
+    [
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+      "test",
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+    ],
+    [
+      [
+        "one",
+        "two",
+        "three",
+        "four",
+        "five",
+        "six",
+        "seven",
+        "eight",
+        "nine",
+        "ten",
+      ],
+      "five",
+      ["one", "two", "three", "four", "six", "seven", "eight", "nine", "ten"],
+    ],
+  ])("removeComment", (initialState, addition, expected) => {
+    store.recentComments = initialState;
+    store.removeComment(addition);
+    expect(store.recentComments).toEqual(expected);
+    expect(localStorage.getItem("aceComments")).toEqual(
+      JSON.stringify(expected),
+    );
+  });
+});


### PR DESCRIPTION
This PR adds a new NodeCommentAutocomplete component and recentComments Pinia store that, together, provide functionality to save a user's 10 most recent comments (across alerts and events), and select from these comments for all comment editors (DispositionModal, SaveToEventModal, NodeCommentEditor, and CommentModal). 

A user's recent comments will also be saved to localStorage to keep their recent comments available across sessions. If a user wishes to delete one of their recent comments, that is possible in the NodeCommentAutocomplete component by clicking an item in the dropdown.

![recentComments](https://user-images.githubusercontent.com/31867815/169819342-a99cb44b-43e3-462f-a3a2-864b15281cdf.gif)

