### PR TITLE
Refactor/breakout multialert button

### DIFF
--- a/frontend/src/components/Alerts/AnalyzeAlertForm.vue
+++ b/frontend/src/components/Alerts/AnalyzeAlertForm.vue
@@ -90,12 +90,21 @@
     >Please check observable input</small
   >
   <div class="pl-3">
-    <SplitButton
-      label="Analyze!"
+    <Button
+      v-tooltip="'Create a new alert for each observable'"
+      label="Submit Multiple Alerts"
+      :loading="alertCreateLoading"
+      :disabled="anyObservablesInvalid || !formContainsMultipleObservables"
+      class="p-button-lg p-button-outlined m-1"
+      icon="pi pi-question-circle"
+      icon-pos="right"
+      @click="submitMultipleAlerts"
+    />
+    <Button
+      label="Submit Alert"
       :loading="alertCreateLoading"
       :disabled="anyObservablesInvalid"
-      :model="splitButtonOptions"
-      class="p-button-lg"
+      class="p-button-lg m-1"
       @click="submitSingleAlert"
     />
   </div>
@@ -134,7 +143,6 @@
   import Fieldset from "primevue/fieldset";
   import InputText from "primevue/inputtext";
   import Message from "primevue/message";
-  import SplitButton from "primevue/splitbutton";
   import TabPanel from "primevue/tabpanel";
   import TabView from "primevue/tabview";
   import { DatePicker } from "v-calendar";
@@ -161,15 +169,6 @@
   const alertType = ref("manual");
   const queue = ref();
   const errors = ref([]);
-  const splitButtonOptions = ref([
-    {
-      label: "Create multiple alerts",
-      icon: "pi pi-copy",
-      command: async () => {
-        await submitMultipleAlerts();
-      },
-    },
-  ]);
   const observables = ref([]);
   const showContinueButton = ref(false);
 
@@ -180,6 +179,13 @@
   const anyObservablesInvalid = computed(() => {
     const invalid = observables.value.filter((obs) => obs.invalid);
     return invalid.length;
+  });
+
+  const formContainsMultipleObservables = computed(() => {
+    if (observables.value.length > 1) {
+      return true;
+    }
+    return observables.value.some((obs) => obs.multiAdd);
   });
 
   onMounted(() => {
@@ -237,7 +243,6 @@
     alertType.value = alertTypeStore.items.length
       ? alertTypeStore.items[0].value
       : "manual";
-    // TODO: This needs to be based on the current user's preferred queue
     queue.value = authStore.user
       ? authStore.user.defaultAlertQueue.value
       : "default";

--- a/frontend/src/components/Observables/NewObservableForm.vue
+++ b/frontend/src/components/Observables/NewObservableForm.vue
@@ -73,7 +73,11 @@
               ></ObservableInput>
             </span>
             <span>
-              <Button icon="pi pi-list" @click="toggleMultiObservable(index)" />
+              <Button
+                name="toggle-multi-observable"
+                icon="pi pi-list"
+                @click="toggleMultiObservable(index)"
+              />
             </span>
           </span>
         </div>

--- a/frontend/tests/component/src/components/Alerts/AnalyzeAlertForm.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AnalyzeAlertForm.spec.ts
@@ -74,7 +74,22 @@ describe("AnalyzeAlertForm Setup", () => {
     cy.get("div").contains("Alert Details");
     cy.get("div").contains("Advanced");
     cy.get("div").contains("Observables");
-    cy.get("button").contains("Analyze!");
+    cy.get("button").contains("Submit Alert");
+    cy.get("button").contains("Submit Multiple Alerts");
+  });
+  it("disables 'Submit Multiple Alerts' button unless >1 (or at least 1 multiAdd) observables are in form", () => {
+    factory();
+    // Initial state
+    cy.contains("Submit Multiple Alerts").should("be.disabled");
+    // Add one observable
+    cy.contains("Add").click();
+    cy.contains("Submit Multiple Alerts").should("not.be.disabled");
+    // Delete observable to return to initial state
+    cy.get('[name="delete-observable"]').last().click();
+    cy.contains("Submit Multiple Alerts").should("be.disabled");
+    // Switch to multiple observable input
+    cy.get('[name="toggle-multi-observable"]').click();
+    cy.contains("Submit Multiple Alerts").should("not.be.disabled");
   });
 });
 
@@ -151,7 +166,7 @@ describe("AnalyzeAlertForm - Form submission", () => {
     cy.get("[name=observable-value] input").eq(1).type(testObservableValueB);
 
     // Submit
-    cy.contains("Analyze!").eq(0).click();
+    cy.contains("Submit Alert").click();
     cy.get("@CreateAlertA").should("have.been.called");
 
     // Should route to last created alert
@@ -188,7 +203,7 @@ describe("AnalyzeAlertForm - Form submission", () => {
     cy.contains("testNodeDirective").click();
 
     // Submit
-    cy.contains("Analyze!").eq(0).click();
+    cy.contains("Submit Alert").eq(0).click();
     cy.get("@CreateAlertA").should("have.been.called");
 
     // Should route to last created alert
@@ -223,7 +238,7 @@ describe("AnalyzeAlertForm - Form submission", () => {
     cy.get("[name=observable-value] textarea").type(testObservableValueMultiA);
 
     // Submit
-    cy.contains("Analyze!").eq(0).click();
+    cy.contains("Submit Alert").click();
 
     cy.get("@CreateAlertA").should("have.been.called");
 
@@ -269,8 +284,7 @@ describe("AnalyzeAlertForm - Form submission", () => {
     cy.get("[name=observable-value] input").eq(1).type(testObservableValueB);
 
     // Submit using multi-add
-    cy.get(".p-splitbutton > .p-button-icon-only").click();
-    cy.contains("Create multiple alerts").click();
+    cy.contains("Submit Multiple Alerts").click();
 
     cy.get("@CreateAlertA").should("have.been.called");
     cy.get("@CreateAlertB").should("have.been.called");
@@ -329,8 +343,7 @@ describe("AnalyzeAlertForm - Form submission", () => {
     cy.get("[name=observable-value] textarea").type(testObservableValueMultiA);
 
     // Submit using multi-add
-    cy.get(".p-splitbutton > .p-button-icon-only").click();
-    cy.contains("Create multiple alerts").click();
+    cy.contains("Submit Multiple Alerts").click();
 
     cy.get("@CreateAlertA").should("have.been.called");
     cy.get("@CreateAlertB").should("have.been.called");

--- a/frontend/tests/component/src/pages/Alerts/AnalyzeAlert.spec.ts
+++ b/frontend/tests/component/src/pages/Alerts/AnalyzeAlert.spec.ts
@@ -4,6 +4,7 @@
 import { mount } from "@cypress/vue";
 import { createPinia } from "pinia";
 import PrimeVue from "primevue/config";
+import Tooltip from "primevue/tooltip";
 
 import AnalyzeAlert from "@/pages/Alerts/AnalyzeAlert.vue";
 
@@ -11,6 +12,7 @@ describe("AnalyzeAlert", () => {
   it("renders", () => {
     mount(AnalyzeAlert, {
       global: {
+        directives: { tooltip: Tooltip },
         plugins: [PrimeVue, createPinia()],
       },
     });

--- a/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
+++ b/frontend/tests/e2e/specs/AnalyzeAlert.spec.js
@@ -65,7 +65,7 @@ describe("AnalyzeAlert.vue", () => {
     cy.intercept("POST", "/api/alert").as("createAlert");
     cy.intercept("GET", "/api/alert/*").as("getAlert");
     addMultipleObservables();
-    cy.get(".p-splitbutton-defaultbutton").click();
+    cy.contains("Submit Alert").click();
     cy.wait("@createAlert").its("state").should("eq", "Complete");
     cy.wait("@getAlert").its("state").should("eq", "Complete");
     cy.wait("@getAlert").its("state").should("eq", "Complete");
@@ -78,7 +78,7 @@ describe("AnalyzeAlert.vue", () => {
       statusCode: 500,
       body: "Server error",
     }).as("createAlert");
-    cy.get(".p-splitbutton-defaultbutton").click();
+    cy.contains("Submit Alert").click();
     cy.wait("@createAlert").its("state").should("eq", "Complete");
     cy.get(".p-message-wrapper").should("exist");
     cy.url().should("include", "/analyze");
@@ -88,8 +88,7 @@ describe("AnalyzeAlert.vue", () => {
     cy.intercept("POST", "/api/alert").as("createAlert");
     cy.intercept("GET", "/api/alert/*").as("getAlert");
     addMultipleObservables();
-    cy.get(".p-splitbutton > .p-button-icon-only").click();
-    cy.get(".p-menuitem-link").click();
+    cy.contains("Submit Multiple Alerts").click();
 
     // 5 alerts and 5 respsective observables should be created
     cy.wait("@createAlert").its("state").should("eq", "Complete");
@@ -118,8 +117,7 @@ describe("AnalyzeAlert.vue", () => {
       statusCode: 500,
       body: "Server error",
     }).as("createAlert");
-    cy.get(".p-splitbutton > .p-button-icon-only").click();
-    cy.get(".p-menuitem-link").click();
+    cy.contains("Submit Alert").click();
     cy.wait("@createAlert").its("state").should("eq", "Complete");
     cy.get(".p-message-wrapper").should("exist");
     cy.url().should("include", "/analyze");


### PR DESCRIPTION
This PR breaks out the 'multiple alerts' button on the Analyze page to be closer in similarity to 1.0, and also to reduce chances of accidentally clicking the regular submit button, as well as reduce number of needed button clicks overall.

Closes #81 

![image](https://user-images.githubusercontent.com/31867815/173362201-f9ba8203-6259-4bbf-b1f0-319373eb732b.png)
Disabled with only one observable in the form 

![image](https://user-images.githubusercontent.com/31867815/173362345-0c20fc6d-c50f-482c-99c5-a02163bd465a.png)
Enabled with multiple observables in form

![image](https://user-images.githubusercontent.com/31867815/173362459-e498b486-d7a1-4f98-bba5-220b1988df24.png)
New tooltip on hover