### PR TITLE
Hide TheHeader links/icons when not auth'd

### DIFF
--- a/frontend/src/components/UserInterface/TheHeader.vue
+++ b/frontend/src/components/UserInterface/TheHeader.vue
@@ -5,28 +5,32 @@
   <Menubar>
     <template #start>
       <img alt="ACE logo" src="../../assets/logo.jpg" />
-      <router-link class="p-m-1" to="/analyze"
-        ><Button label="Analyze" class="p-button-raised"
-      /></router-link>
-      <router-link class="p-m-1" to="/manage_alerts"
-        ><Button label="Alerts" class="p-button-raised"
-      /></router-link>
-      <router-link class="p-m-1" to="/manage_events"
-        ><Button label="Events" class="p-button-raised"
-      /></router-link>
+      <span v-if="authStore.isAuthenticated" name="logged-in-links">
+        <router-link class="p-m-1" to="/analyze"
+          ><Button label="Analyze" class="p-button-raised"
+        /></router-link>
+        <router-link class="p-m-1" to="/manage_alerts"
+          ><Button label="Alerts" class="p-button-raised"
+        /></router-link>
+        <router-link class="p-m-1" to="/manage_events"
+          ><Button label="Events" class="p-button-raised"
+        /></router-link>
+      </span>
     </template>
     <template #end>
-      <Button icon="pi pi-bell" class="p-button-rounded p-m-1" />
-      <router-link to="/"
-        ><Button icon="pi pi-cog" class="p-button-rounded p-m-1"
-      /></router-link>
-      <Button icon="pi pi-user" class="p-button-rounded p-m-1" />
-      <router-link :to="{ name: 'Login' }">
-        <Button
-          icon="pi pi-sign-out"
-          class="p-button-rounded p-m-1"
-          @click="logout"
-      /></router-link>
+      <span v-if="authStore.isAuthenticated" name="logged-in-buttons">
+        <Button icon="pi pi-bell" class="p-button-rounded p-m-1" />
+        <router-link to="/"
+          ><Button icon="pi pi-cog" class="p-button-rounded p-m-1"
+        /></router-link>
+        <Button icon="pi pi-user" class="p-button-rounded p-m-1" />
+        <router-link :to="{ name: 'Login' }">
+          <Button
+            icon="pi pi-sign-out"
+            class="p-button-rounded p-m-1"
+            @click="logout"
+        /></router-link>
+      </span>
     </template>
   </Menubar>
 </template>
@@ -36,9 +40,14 @@
 
   import Menubar from "primevue/menubar";
   import Button from "primevue/button";
+
+  import { useAuthStore } from "@/stores/auth";
+
   import authApi from "@/services/api/auth";
 
   const router = useRouter();
+
+  const authStore = useAuthStore();
 
   async function logout() {
     await authApi.logout().catch((error) => {

--- a/frontend/tests/component/src/components/UserInterface/TheHeader.spec.ts
+++ b/frontend/tests/component/src/components/UserInterface/TheHeader.spec.ts
@@ -1,22 +1,42 @@
 import { mount } from "@cypress/vue";
-import { createPinia } from "pinia";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import { userReadFactory } from "@mocks/user";
+
 import PrimeVue from "primevue/config";
 import router from "@/router/index";
 import authApi from "@/services/api/auth";
 
 import TheHeader from "@/components/UserInterface/TheHeader.vue";
 
-function factory() {
+function factory(user: any) {
   mount(TheHeader, {
     global: {
-      plugins: [PrimeVue, createPinia(), router],
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          initialState: {
+            authStore: {
+              user: user,
+            },
+          },
+        }),
+        router,
+      ],
     },
   });
 }
 
 describe("TheHeader", () => {
-  it("renders with expected elements", () => {
-    factory();
+  it("renders with expected elements when not auth'd", () => {
+    factory(null);
+    cy.get("img").should("be.visible");
+    cy.contains("Analyze").should("not.exist");
+    cy.contains("Alerts").should("not.exist");
+    cy.contains("Events").should("not.exist");
+    cy.get(".pi").should("have.length", 1);
+  });
+  it("renders with expected elements when auth'd", () => {
+    factory(userReadFactory());
     cy.get("img").should("be.visible");
     cy.contains("Analyze").should("be.visible");
     cy.contains("Alerts").should("be.visible");
@@ -25,7 +45,7 @@ describe("TheHeader", () => {
   });
   it("should attempt to logout when logout button clicked", () => {
     cy.stub(authApi, "logout").as("logout").resolves();
-    factory();
+    factory(userReadFactory());
     cy.get(".pi").last().click();
     cy.get("@logout").should("have.been.calledOnce");
   });

--- a/frontend/tests/e2e/specs/ManageAlerts.spec.js
+++ b/frontend/tests/e2e/specs/ManageAlerts.spec.js
@@ -305,7 +305,7 @@ describe("Manage Alerts - No Database Changes", () => {
       cy.get(".flex ").children().should("have.length", 4);
 
       // Delete one
-      cy.get(":nth-child(2) > :nth-child(3) > .p-button").click();
+      cy.get("[data-cy='property-input-delete']").last().click();
       cy.get(".flex ").children().should("have.length", 3);
 
       // Clear all of them


### PR DESCRIPTION
This PR does exactly as stated, showing links/icons to other pages in the header only when a user is authenticated.

Closes #191 