### PR TITLE
Analysis metadata (refactor)

### DIFF
--- a/api_models/analysis_metadata.py
+++ b/api_models/analysis_metadata.py
@@ -2,6 +2,9 @@ from pydantic import BaseModel, Field, UUID4
 from typing import Optional
 
 from api_models import type_str
+from api_models.metadata_display_type import MetadataDisplayTypeRead
+from api_models.metadata_display_value import MetadataDisplayValueRead
+from api_models.metadata_tag import MetadataTagRead
 
 
 class AnalysisMetadataCreate(BaseModel):
@@ -18,3 +21,13 @@ class AnalysisMetadataCreate(BaseModel):
     type: type_str = Field(description="The type of the metadata")
 
     value: type_str = Field(description="The value of the metadata")
+
+
+class AnalysisMetadataRead(BaseModel):
+    """Represents the collection of analysis metadata that was added to an observable."""
+
+    display_type: Optional[MetadataDisplayTypeRead] = Field(description="The display type of the observable")
+
+    display_value: Optional[MetadataDisplayValueRead] = Field(description="The display value of the observable")
+
+    tags: list[MetadataTagRead] = Field(default_factory=list, description="A list of tags added to the observable")

--- a/api_models/observable.py
+++ b/api_models/observable.py
@@ -4,9 +4,7 @@ from typing import Optional
 from uuid import UUID, uuid4
 
 from api_models import type_str, validators
-from api_models.analysis_metadata import AnalysisMetadataCreate
-from api_models.metadata_display_type import MetadataDisplayTypeRead
-from api_models.metadata_display_value import MetadataDisplayValueRead
+from api_models.analysis_metadata import AnalysisMetadataCreate, AnalysisMetadataRead
 from api_models.metadata_tag import MetadataTagRead
 from api_models.node import NodeBase, NodeCreate, NodeRead, NodeUpdate
 from api_models.node_comment import NodeCommentRead
@@ -123,39 +121,17 @@ class ObservableRead(NodeRead, ObservableBase):
 class ObservableSubmissionRead(ObservableRead):
     """Model used to control which information for an Observable is displayed when getting Observables contained in a list of Submissions."""
 
-    analysis_tags: list[MetadataTagRead] = Field(
-        default_factory=list, description="A list of tags added to the observable by analysis"
-    )
-
-    display_type: Optional[MetadataDisplayTypeRead] = Field(
-        description="The type that should be shown for the observable when displaying in the GUI"
-    )
-
-    display_value: Optional[MetadataDisplayValueRead] = Field(
-        description="The value that should be shown for the observable when displaying in the GUI"
-    )
+    analysis_metadata: AnalysisMetadataRead = Field(description="The analysis metadata for the observable")
 
     class Config:
         orm_mode = True
 
 
-class ObservableSubmissionTreeRead(ObservableRead):
+class ObservableSubmissionTreeRead(ObservableSubmissionRead):
     """Model used to control which information for an Observable is displayed when getting a submission tree"""
-
-    analysis_tags: list[MetadataTagRead] = Field(
-        default_factory=list, description="A list of tags added to the observable by analysis"
-    )
 
     children: "list[AnalysisSubmissionTreeRead]" = Field(
         default_factory=list, description="A list of this observable's child analysis"
-    )
-
-    display_type: Optional[MetadataDisplayTypeRead] = Field(
-        description="The type that should be shown for the observable when displaying in the GUI"
-    )
-
-    display_value: Optional[MetadataDisplayValueRead] = Field(
-        description="The value that should be shown for the observable when displaying in the GUI"
     )
 
     first_appearance: bool = Field(

--- a/api_models/submission.py
+++ b/api_models/submission.py
@@ -135,15 +135,6 @@ class SubmissionRead(NodeRead, SubmissionBase):
         orm_mode = True
 
 
-class SubmissionTreeRead(SubmissionRead):
-    children: list[ObservableSubmissionTreeRead] = Field(
-        default_factory=list, description="A list of this submission's child observables"
-    )
-
-    class Config:
-        orm_mode = True
-
-
 class SubmissionUpdate(NodeUpdate, SubmissionBase):
     disposition: Optional[type_str] = Field(description="The disposition assigned to this submission")
 
@@ -169,7 +160,9 @@ class SubmissionUpdate(NodeUpdate, SubmissionBase):
 class SubmissionTreeRead(SubmissionRead):
     root_analysis_uuid: UUID4 = Field(description="The UUID the submission's root analysis")
 
-    children: list[dict] = Field(default_factory=list, description="A list of this submission's child objects")
+    children: list[ObservableSubmissionTreeRead] = Field(
+        default_factory=list, description="A list of this submission's child observables"
+    )
 
     class Config:
         orm_mode = True

--- a/db_api/app/db/crud/analysis_metadata.py
+++ b/db_api/app/db/crud/analysis_metadata.py
@@ -48,8 +48,8 @@ def create_or_read(
         )
 
         if crud.helpers.create(obj=obj, db=db):
-            # Refreshing the analysis object ensures that its analysis_metadata relationship is updated
-            db.refresh(analysis)
+            # Refreshing the observable object ensures that its all_analysis_metadata relationship is updated
+            db.refresh(observable)
             return obj
 
         return read_existing(

--- a/db_api/app/db/schemas/analysis.py
+++ b/db_api/app/db/schemas/analysis.py
@@ -7,7 +7,6 @@ from typing import Optional
 from api_models.analysis import AnalysisSubmissionTreeRead
 from db.database import Base
 from db.schemas.analysis_child_observable_mapping import analysis_child_observable_mapping
-from db.schemas.analysis_metadata import AnalysisMetadata
 from db.schemas.helpers import utcnow
 from db.schemas.observable import Observable
 
@@ -16,10 +15,6 @@ class Analysis(Base):
     __tablename__ = "analysis"
 
     uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
-
-    analysis_metadata: list[AnalysisMetadata] = relationship(
-        "AnalysisMetadata", primaryjoin="AnalysisMetadata.analysis_uuid == Analysis.uuid", lazy="selectin"
-    )
 
     analysis_module_type = relationship("AnalysisModuleType", lazy="selectin")
 

--- a/db_api/app/db/schemas/metadata.py
+++ b/db_api/app/db/schemas/metadata.py
@@ -13,6 +13,3 @@ class Metadata(Base):
     metadata_type = Column(String)
 
     __mapper_args__ = {"polymorphic_identity": "metadata", "polymorphic_on": metadata_type, "with_polymorphic": "*"}
-
-    def convert_to_pydantic(self):  # pragma: no cover
-        raise NotImplementedError("A Metadata subclass must implement convert_to_pydantic")

--- a/db_api/app/db/schemas/metadata_display_type.py
+++ b/db_api/app/db/schemas/metadata_display_type.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 
-from api_models.metadata_display_type import MetadataDisplayTypeRead
 from db.schemas.metadata import Metadata
 
 
@@ -15,6 +14,3 @@ class MetadataDisplayType(Metadata):
     value = Column(String, nullable=False, unique=True, index=True)
 
     __mapper_args__ = {"polymorphic_identity": "display_type", "polymorphic_load": "inline"}
-
-    def convert_to_pydantic(self) -> MetadataDisplayTypeRead:
-        return MetadataDisplayTypeRead(**self.__dict__)

--- a/db_api/app/db/schemas/metadata_display_value.py
+++ b/db_api/app/db/schemas/metadata_display_value.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 
-from api_models.metadata_display_value import MetadataDisplayValueRead
 from db.schemas.metadata import Metadata
 
 
@@ -15,6 +14,3 @@ class MetadataDisplayValue(Metadata):
     value = Column(String, nullable=False, unique=True, index=True)
 
     __mapper_args__ = {"polymorphic_identity": "display_value", "polymorphic_load": "inline"}
-
-    def convert_to_pydantic(self) -> MetadataDisplayValueRead:
-        return MetadataDisplayValueRead(**self.__dict__)

--- a/db_api/app/db/schemas/metadata_tag.py
+++ b/db_api/app/db/schemas/metadata_tag.py
@@ -1,7 +1,6 @@
 from sqlalchemy import Column, ForeignKey, String
 from sqlalchemy.dialects.postgresql import UUID
 
-from api_models.metadata_tag import MetadataTagRead
 from db.schemas.metadata import Metadata
 
 
@@ -15,6 +14,3 @@ class MetadataTag(Metadata):
     value = Column(String, nullable=False, unique=True, index=True)
 
     __mapper_args__ = {"polymorphic_identity": "tag", "polymorphic_load": "inline"}
-
-    def convert_to_pydantic(self) -> MetadataTagRead:
-        return MetadataTagRead(**self.__dict__)

--- a/db_api/app/db/schemas/observable.py
+++ b/db_api/app/db/schemas/observable.py
@@ -11,14 +11,12 @@ from sqlalchemy import (
 )
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
-from typing import Optional
 
 from api_models.observable import ObservableSubmissionTreeRead, ObservableRead, ObservableRelationshipRead
 from db.database import Base
+from db.schemas.analysis_metadata import AnalysisMetadata
 from db.schemas.helpers import utcnow
 from db.schemas.history import HasHistory, HistoryMixin
-from db.schemas.metadata_display_type import MetadataDisplayType
-from db.schemas.metadata_display_value import MetadataDisplayValue
 from db.schemas.metadata_tag import MetadataTag
 from db.schemas.node import Node
 from db.schemas.node_relationship import NodeRelationship
@@ -36,16 +34,14 @@ class Observable(Node, HasHistory):
 
     uuid = Column(UUID(as_uuid=True), ForeignKey("node.uuid"), primary_key=True)
 
-    # This is an empty list that gets populated by certain submission-related queries.
-    analysis_tags: list[MetadataTag] = []
+    all_analysis_metadata: list[AnalysisMetadata] = relationship(
+        "AnalysisMetadata", primaryjoin="AnalysisMetadata.observable_uuid == Observable.uuid", lazy="selectin"
+    )
+
+    # This gets populated by certain submission-related queries.
+    analysis_metadata = None
 
     context = Column(String)
-
-    # This gets populated by certain submission-related queries.
-    display_type: Optional[MetadataDisplayType] = None
-
-    # This gets populated by certain submission-related queries.
-    display_value: Optional[MetadataDisplayValue] = None
 
     # Using timezone=True causes PostgreSQL to store the datetime as UTC. Datetimes without timezone
     # information will be assumed to be UTC, whereas datetimes with timezone data will be converted to UTC.

--- a/db_api/app/db/schemas/submission.py
+++ b/db_api/app/db/schemas/submission.py
@@ -3,6 +3,7 @@ import json
 from datetime import datetime
 from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.orm import relationship
 from typing import Optional
 
@@ -32,6 +33,8 @@ class Submission(Node, HasHistory):
 
     # Analyses are lazy loaded and are not included by default when fetching a submission from the API.
     analyses: list[Analysis] = relationship("Analysis", secondary=submission_analysis_mapping)
+
+    analysis_uuids: list[UUID] = association_proxy("analyses", "uuid")
 
     # The child_* fields use a composite join relationship to get a list of the objects that
     # are applied to any observables that exist in this submission's tree structure. For example, this is

--- a/db_api/app/tests/db_tests/crud/analysis_metadata/test_create.py
+++ b/db_api/app/tests/db_tests/crud/analysis_metadata/test_create.py
@@ -13,7 +13,7 @@ def test_create_duplicate_tag(db):
     observable = factory.observable.create_or_read(
         type="type", value="value", parent_analysis=submission.root_analysis, db=db
     )
-    assert submission.root_analysis.analysis_metadata == []
+    assert observable.all_analysis_metadata == []
 
     # Create the first tag
     analysis_metadata = crud.analysis_metadata.create_or_read(
@@ -25,7 +25,7 @@ def test_create_duplicate_tag(db):
         ),
         db=db,
     )
-    assert submission.root_analysis.analysis_metadata == [analysis_metadata]
+    assert observable.all_analysis_metadata == [analysis_metadata]
 
     # Try to create the same tag on the same observable. It should be the same object.
     analysis_metadata2 = crud.analysis_metadata.create_or_read(
@@ -38,7 +38,7 @@ def test_create_duplicate_tag(db):
         db=db,
     )
     assert analysis_metadata2 == analysis_metadata
-    assert submission.root_analysis.analysis_metadata == [analysis_metadata]
+    assert observable.all_analysis_metadata == [analysis_metadata]
 
 
 def test_create_tag_with_uuids(db):
@@ -47,7 +47,7 @@ def test_create_tag_with_uuids(db):
         type="type", value="value", parent_analysis=submission.root_analysis, db=db
     )
 
-    assert submission.root_analysis.analysis_metadata == []
+    assert observable.all_analysis_metadata == []
 
     analysis_metadata = crud.analysis_metadata.create_or_read(
         model=AnalysisMetadataCreate(
@@ -59,4 +59,4 @@ def test_create_tag_with_uuids(db):
         db=db,
     )
 
-    assert submission.root_analysis.analysis_metadata == [analysis_metadata]
+    assert observable.all_analysis_metadata == [analysis_metadata]

--- a/db_api/app/tests/db_tests/crud/event/test_read.py
+++ b/db_api/app/tests/db_tests/crud/event/test_read.py
@@ -1111,12 +1111,12 @@ def test_read_summary_observable(db):
     assert len(result) == 2
     assert result[0].value == "127.0.0.1"
     assert result[0].faqueue_hits == 10
-    assert [t.value for t in result[0].analysis_tags] == ["analysis_tag1", "analysis_tag2"]
+    assert [t.value for t in result[0].analysis_metadata.tags] == ["analysis_tag1", "analysis_tag2"]
     assert result[0].permanent_tags == []
 
     assert result[1].value == "192.168.1.1"
     assert result[1].faqueue_hits == 100
-    assert result[1].analysis_tags == []
+    assert result[1].analysis_metadata.tags == []
     assert [t.value for t in result[1].permanent_tags] == ["permanent_tag1"]
 
 

--- a/db_api/app/tests/db_tests/crud/submission/test_create.py
+++ b/db_api/app/tests/db_tests/crud/submission/test_create.py
@@ -67,7 +67,8 @@ def test_create(db):
 
     assert submission.alert is True
     assert len(submission.analyses) == 2
-    assert submission.analyses[1].analysis_module_type_uuid == analysis_module_type.uuid
+    assert any(a.analysis_module_type_uuid is None for a in submission.analyses)
+    assert any(a.analysis_module_type_uuid == analysis_module_type.uuid for a in submission.analyses)
     assert len(submission.child_detection_points) == 1
     assert submission.child_detection_points[0].value == "detection_point"
     assert len(submission.child_analysis_tags) == 1

--- a/db_api/app/tests/db_tests/crud/submission/test_read.py
+++ b/db_api/app/tests/db_tests/crud/submission/test_read.py
@@ -450,22 +450,23 @@ def test_read_observables(db):
     # ipv4: 127.0.0.1 (analysis_tag3, permanent_tag1)
     result = crud.submission.read_observables(uuids=[submission.uuid, submission2.uuid], db=db)
     assert len(result) == 3
+
     assert result[0].type.value == "email_address" and result[0].value == "badguy@bad.com"
-    assert result[0].analysis_tags == []
-    assert result[0].display_type is None
-    assert result[0].display_value is None
+    assert result[0].analysis_metadata.tags == []
+    assert result[0].analysis_metadata.display_type is None
+    assert result[0].analysis_metadata.display_value is None
     assert result[0].permanent_tags == []
 
     assert result[1].type.value == "fqdn" and result[1].value == "bad.com"
-    assert [t.value for t in result[1].analysis_tags] == ["analysis_tag1", "analysis_tag2"]
-    assert result[1].display_type.value == "display_type1"
-    assert result[1].display_value is None
+    assert [t.value for t in result[1].analysis_metadata.tags] == ["analysis_tag1", "analysis_tag2"]
+    assert result[1].analysis_metadata.display_type.value == "display_type1"
+    assert result[1].analysis_metadata.display_value is None
     assert result[1].permanent_tags == []
 
     assert result[2].type.value == "ipv4" and result[2].value == "127.0.0.1"
-    assert [t.value for t in result[2].analysis_tags] == ["analysis_tag3"]
-    assert result[2].display_type is None
-    assert result[2].display_value.value == "display_value1"
+    assert [t.value for t in result[2].analysis_metadata.tags] == ["analysis_tag3"]
+    assert result[2].analysis_metadata.display_type is None
+    assert result[2].analysis_metadata.display_value.value == "display_value1"
     assert [t.value for t in result[2].permanent_tags] == ["permanent_tag1"]
 
 
@@ -653,16 +654,18 @@ def test_read_summary_url_domain(db):
 def test_tag_functionality(db):
     """
     Submission1
-        O1 - permanent_tag1
-            A1 - adds tag z_analysis1_tag to O2
-                O2 - analysis2_tag, z_analysis1_tag (should show all analysis tags in this alert for the observable)
-        O3
-            A2 - adds tag analysis2_tag to O2
-                O2 - analysis2_tag, z_analysis1_tag (should show all analysis tags in this alert for the observable)
+        RootAnalysis1
+            O1 - permanent_tag1
+                A1 - adds tag z_analysis1_tag to O2
+                    O2 - analysis2_tag, z_analysis1_tag (should show all analysis tags in this alert for the observable)
+            O3
+                A2 - adds tag analysis2_tag to O2
+                    O2 - analysis2_tag, z_analysis1_tag (should show all analysis tags in this alert for the observable)
 
     Submission2
-        O1 - should have permanent_tag1 because it is a permanent tag
-        O2 - should not have any tags because the alert does not contain analysis A1 or A2
+        RootAnalysis2
+            O1 - should have permanent_tag1 because it is a permanent tag
+            O2 - should not have any tags because the alert does not contain analysis A1 or A2
     """
 
     # Create the submission1 tree structure
@@ -741,23 +744,27 @@ def test_tag_functionality(db):
     # Verify the tags for O2 in the first submission under A1. It should have two tags, even though
     # its parent analysis A1 only added one tag. The tags should be in alphabetical order, not the
     # order in which they were added by the analyses.
-    assert len(o1_a1.analysis_metadata) == 1
-    assert o1_a1.analysis_metadata[0].metadata_object.value == "z_analysis1_tag"
-    assert len(submission1_tree["children"][0]["children"][0]["children"][0]["analysis_tags"]) == 2
-    assert submission1_tree["children"][0]["children"][0]["children"][0]["analysis_tags"][0]["value"] == "analysis2_tag"
+    assert len(submission1_tree["children"][0]["children"][0]["children"][0]["analysis_metadata"]["tags"]) == 2
     assert (
-        submission1_tree["children"][0]["children"][0]["children"][0]["analysis_tags"][1]["value"] == "z_analysis1_tag"
+        submission1_tree["children"][0]["children"][0]["children"][0]["analysis_metadata"]["tags"][0]["value"]
+        == "analysis2_tag"
+    )
+    assert (
+        submission1_tree["children"][0]["children"][0]["children"][0]["analysis_metadata"]["tags"][1]["value"]
+        == "z_analysis1_tag"
     )
 
     # Verify the tags for O2 in the first submission under A2. It should have two tags, even though
     # its parent analysis A2 only added one tag. The tags should be in alphabetical order, not the
     # order in which they were added by the analyses.
-    assert len(o3_a2.analysis_metadata) == 1
-    assert o3_a2.analysis_metadata[0].metadata_object.value == "analysis2_tag"
-    assert len(submission1_tree["children"][1]["children"][0]["children"][0]["analysis_tags"]) == 2
-    assert submission1_tree["children"][1]["children"][0]["children"][0]["analysis_tags"][0]["value"] == "analysis2_tag"
+    assert len(submission1_tree["children"][1]["children"][0]["children"][0]["analysis_metadata"]["tags"]) == 2
     assert (
-        submission1_tree["children"][1]["children"][0]["children"][0]["analysis_tags"][1]["value"] == "z_analysis1_tag"
+        submission1_tree["children"][1]["children"][0]["children"][0]["analysis_metadata"]["tags"][0]["value"]
+        == "analysis2_tag"
+    )
+    assert (
+        submission1_tree["children"][1]["children"][0]["children"][0]["analysis_metadata"]["tags"][1]["value"]
+        == "z_analysis1_tag"
     )
 
     # The second submission should have two child observables, and they should be in the order
@@ -773,5 +780,5 @@ def test_tag_functionality(db):
     # Verify the tags for O2 in the second submission. Even though it is the exact same observable
     # object as in the first submission, it shouldn't have any tags because the submission does not
     # contain any analysis that added tags to it.
-    assert len(submission2_tree["children"][1]["analysis_tags"]) == 0
-    assert len(submission2_tree["children"][1]["permanent_tags"]) == 0
+    assert submission2_tree["children"][1]["analysis_metadata"]["tags"] == []
+    assert submission2_tree["children"][1]["permanent_tags"] == []

--- a/frontend/src/components/Alerts/AlertTableExpansion.vue
+++ b/frontend/src/components/Alerts/AlertTableExpansion.vue
@@ -26,7 +26,7 @@
         :tag="tag"
       />
       <MetadataTag
-        v-for="tag of obs.analysisTags"
+        v-for="tag of obs.analysisMetadata.tags"
         :key="tag.value"
         :tag="tag"
       />

--- a/frontend/src/components/Events/EventObservableSummary.vue
+++ b/frontend/src/components/Events/EventObservableSummary.vue
@@ -151,7 +151,7 @@
           override-node-type="alerts"
         />
         <MetadataTag
-          v-for="tag of slotProps.data.analysisTags"
+          v-for="tag of slotProps.data.analysisMetadata.tags"
           :key="tag.value"
           :tag="tag"
           override-node-type="alerts"

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -67,7 +67,8 @@
     <span
       v-if="
         showTags &&
-        (observable.permanentTags.length || observable.analysisTags.length)
+        (observable.permanentTags.length ||
+          observable.analysisMetadata.tags.length)
       "
       class="leaf-element"
     >
@@ -77,7 +78,7 @@
         :tag="tag"
       ></MetadataTag>
       <MetadataTag
-        v-for="tag in observable.analysisTags"
+        v-for="tag in observable.analysisMetadata.tags"
         :key="tag.uuid"
         :tag="tag"
       ></MetadataTag
@@ -184,12 +185,12 @@
     let type = observableType.value;
     let value = props.observable.value;
 
-    if (props.observable.displayType) {
-      type = `${props.observable.displayType.value} (${props.observable.type.value})`;
+    if (props.observable.analysisMetadata.displayType) {
+      type = `${props.observable.analysisMetadata.displayType.value} (${props.observable.type.value})`;
     }
 
-    if (props.observable.displayValue) {
-      value = props.observable.displayValue.value;
+    if (props.observable.analysisMetadata.displayValue) {
+      value = props.observable.analysisMetadata.displayValue.value;
     }
 
     const displayValue = `${type}: ${value}`;

--- a/frontend/src/models/analysisMetadata.ts
+++ b/frontend/src/models/analysisMetadata.ts
@@ -1,0 +1,9 @@
+import { metadataDisplayTypeRead } from "./metadataDisplayType";
+import { metadataDisplayValueRead } from "./metadataDisplayValue";
+import { metadataTagRead } from "./metadataTag";
+
+export interface analysisMetadataRead {
+  displayType: metadataDisplayTypeRead | null;
+  displayValue: metadataDisplayValueRead | null;
+  tags: metadataTagRead[];
+}

--- a/frontend/src/models/observable.ts
+++ b/frontend/src/models/observable.ts
@@ -1,8 +1,7 @@
 import { Component } from "vue";
 import { analysisTreeRead } from "./analysis";
+import { analysisMetadataRead } from "./analysisMetadata";
 import { historyUsername, UUID } from "./base";
-import { metadataDisplayTypeRead } from "./metadataDisplayType";
-import { metadataDisplayValueRead } from "./metadataDisplayValue";
 import { metadataTagRead } from "./metadataTag";
 import { nodeCreate, nodeRead, nodeUpdate } from "./node";
 import { nodeCommentRead } from "./nodeComment";
@@ -47,9 +46,7 @@ export interface observableRead extends nodeRead {
 }
 
 export interface observableInAlertRead extends observableRead {
-  analysisTags: metadataTagRead[];
-  displayType: metadataDisplayTypeRead | null;
-  displayValue: metadataDisplayValueRead | null;
+  analysisMetadata: analysisMetadataRead;
 }
 
 export interface observableReadPage {
@@ -59,11 +56,8 @@ export interface observableReadPage {
   total: number;
 }
 
-export interface observableTreeRead extends observableRead {
-  analysisTags: metadataTagRead[];
+export interface observableTreeRead extends observableInAlertRead {
   children: analysisTreeRead[];
-  displayType: metadataDisplayTypeRead | null;
-  displayValue: metadataDisplayValueRead | null;
   firstAppearance?: boolean;
 }
 

--- a/frontend/tests/component/src/components/Alerts/AlertTableExpansion.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AlertTableExpansion.spec.ts
@@ -8,6 +8,7 @@ import { metadataObjectReadFactory } from "@mocks/metadata";
 import { observableInAlertRead } from "@/models/observable";
 import { observableInAlertReadFactory } from "@mocks/observable";
 import router from "@/router/index";
+import { analysisMetadataReadFactory } from "@mocks/analysisMetadata";
 
 interface AlertTableExpansionProps {
   observables: observableInAlertRead[] | null;
@@ -49,9 +50,9 @@ describe("AlertTableExpansion", () => {
           observableInAlertReadFactory(),
           observableInAlertReadFactory({
             value: "TestObservable2",
-            analysisTags: [
-              metadataObjectReadFactory({ value: "analysisTag1" }),
-            ],
+            analysisMetadata: analysisMetadataReadFactory({
+              tags: [metadataObjectReadFactory({ value: "analysisTag1" })],
+            }),
             permanentTags: [metadataObjectReadFactory({ value: "testTag" })],
           }),
         ],

--- a/frontend/tests/component/src/components/Alerts/TheAlertsTable.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/TheAlertsTable.spec.ts
@@ -8,7 +8,7 @@ import { Alert } from "@/services/api/alert";
 import { createCustomCypressPinia } from "@tests/cypressHelpers";
 import { alertRead } from "@/models/alert";
 import { alertReadFactory } from "@mocks/alert";
-import { observableReadFactory } from "@mocks/observable";
+import { observableInAlertReadFactory } from "@mocks/observable";
 import { genericObjectReadFactory } from "@mocks/genericObject";
 import ToastService from "primevue/toastservice";
 import { testConfiguration } from "@/etc/configuration/test/index";
@@ -97,15 +97,15 @@ describe("TheAlertsTable", () => {
   it("attempts to fetch and show observables when alert dropdown is clicked", () => {
     // The database sorts the returned observables by their type then their value
     const testObservables = [
-      observableReadFactory({
+      observableInAlertReadFactory({
         type: genericObjectReadFactory({ value: "A-Type" }),
         value: "Z-Value",
       }),
-      observableReadFactory({
+      observableInAlertReadFactory({
         type: genericObjectReadFactory({ value: "B-Type" }),
         value: "A-Value",
       }),
-      observableReadFactory({
+      observableInAlertReadFactory({
         type: genericObjectReadFactory({ value: "B-Type" }),
         value: "Z-Value",
       }),

--- a/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableLeaf.spec.ts
@@ -15,6 +15,7 @@ import { ObservableInstance } from "@/services/api/observable";
 import ToastService from "primevue/toastservice";
 import Tooltip from "primevue/tooltip";
 import TagModalVue from "@/components/Modals/TagModal.vue";
+import { analysisMetadataReadFactory } from "@mocks/analysisMetadata";
 
 interface ObservableLeafProps {
   observable: observableTreeRead;
@@ -62,12 +63,16 @@ function factory(
 
 const observableWithDisplayType = observableTreeReadFactory({
   value: "Observable with display type",
-  displayType: metadataObjectReadFactory({ value: "displayType" }),
+  analysisMetadata: analysisMetadataReadFactory({
+    displayType: metadataObjectReadFactory({ value: "displayType" }),
+  }),
 });
 
 const observableWithDisplayValue = observableTreeReadFactory({
   value: "Observable with display value",
-  displayValue: metadataObjectReadFactory({ value: "displayValue" }),
+  analysisMetadata: analysisMetadataReadFactory({
+    displayValue: metadataObjectReadFactory({ value: "displayValue" }),
+  }),
 });
 
 const observableWithTags = observableTreeReadFactory({

--- a/frontend/tests/mocks/analysisMetadata.ts
+++ b/frontend/tests/mocks/analysisMetadata.ts
@@ -1,0 +1,11 @@
+import { analysisMetadataRead } from "@/models/analysisMetadata";
+
+export const analysisMetadataReadFactory = ({
+  displayType = null,
+  displayValue = null,
+  tags = [],
+}: Partial<analysisMetadataRead> = {}): analysisMetadataRead => ({
+  displayType: displayType,
+  displayValue: displayValue,
+  tags: tags,
+});

--- a/frontend/tests/mocks/observable.ts
+++ b/frontend/tests/mocks/observable.ts
@@ -3,6 +3,7 @@ import {
   observableRead,
   observableTreeRead,
 } from "@/models/observable";
+import { analysisMetadataReadFactory } from "./analysisMetadata";
 import { genericObjectReadFactory } from "./genericObject";
 
 export const observableReadFactory = ({
@@ -44,12 +45,10 @@ export const observableInAlertReadFactory = ({
   time = new Date("2020-01-01"),
   uuid = "observableUuid1",
   value = "TestObservable",
-  analysisTags = [],
+  analysisMetadata = analysisMetadataReadFactory(),
   comments = [],
   context = null,
   directives = [],
-  displayType = null,
-  displayValue = null,
   detectionPoints = [],
   forDetection = false,
   expiresOn = null,
@@ -63,12 +62,10 @@ export const observableInAlertReadFactory = ({
   time: time,
   uuid: uuid,
   value: value,
-  analysisTags: analysisTags,
+  analysisMetadata: analysisMetadata,
   comments: comments,
   context: context,
   directives: directives,
-  displayType: displayType,
-  displayValue: displayValue,
   detectionPoints: detectionPoints,
   forDetection: forDetection,
   expiresOn: expiresOn,
@@ -82,16 +79,14 @@ export const observableInAlertReadFactory = ({
 });
 
 export const observableTreeReadFactory = ({
-  analysisTags = [],
   children = [],
   time = new Date("2020-01-01"),
   uuid = "observableUuid1",
   value = "TestObservable",
+  analysisMetadata = analysisMetadataReadFactory(),
   comments = [],
   context = null,
   directives = [],
-  displayType = null,
-  displayValue = null,
   detectionPoints = [],
   firstAppearance = undefined,
   forDetection = false,
@@ -103,17 +98,15 @@ export const observableTreeReadFactory = ({
   version = "observableVersion1",
   observableRelationships = [],
 }: Partial<observableTreeRead> = {}): observableTreeRead => ({
-  analysisTags: analysisTags,
   children: children,
   uuid: uuid,
   version: version,
   time: time,
   value: value,
+  analysisMetadata: analysisMetadata,
   comments: comments,
   context: context,
   directives: directives,
-  displayType: displayType,
-  displayValue: displayValue,
   detectionPoints: detectionPoints,
   firstAppearance: firstAppearance,
   forDetection: forDetection,

--- a/gui_api/app/tests/api/alert/test_read.py
+++ b/gui_api/app/tests/api/alert/test_read.py
@@ -1,7 +1,5 @@
 import pytest
-import uuid
 
-from fastapi import status
 from datetime import datetime
 from urllib.parse import unquote_plus, urlencode
 from uuid import uuid4
@@ -84,7 +82,7 @@ def test_get_alerts_observables(client_valid_access_token, requests_mock):
                 "value": "value",
                 "node_type": "observable",
                 "uuid": str(uuid4()),
-                "analysis_tags": [],
+                "analysis_metadata": {"display_type": None, "display_value": None, "tags": []},
                 "directives": [],
                 "observable_relationships": [],
                 "permanent_tags": [],


### PR DESCRIPTION
This PR refactors how analysis metadata is added to observables. Now that a few types of analysis metadata exist (display type, display value, and tags), it became clear that the original way it was working was cumbersome. This streamlines the process of associating the metadata with observables.