### PR TITLE
Fix for renaming PrimeVue CSS classes

### DIFF
--- a/db_api/app/tests/db_tests/crud/submission/test_read.py
+++ b/db_api/app/tests/db_tests/crud/submission/test_read.py
@@ -716,29 +716,46 @@ def test_read_observables(db):
 
 
 def test_read_submission_tree(db):
+    expected_structure = """
+file: email.rfc822
+    Email Analysis
+        email_address: badguy@evil.com
+            FA Queue Analysis
+            Email Address Analysis
+                fqdn: evil.com
+                    FA Queue Analysis
+                    Test Analysis
+                        test_type: test_value
+        email_address: goodguy@company.com
+            Email Address Analysis
+                fqdn: company.com
+        email_subject: Hello
+            FA Queue Analysis
+        file: email.rfc822.unknown_plain_text_000
+            URL Extraction Analysis
+                url: http://evil.com/malware.exe
+                    FA Queue Analysis
+                    URL Parse Analysis
+                        fqdn: evil.com (Duplicate)
+                            FA Queue Analysis (Duplicate)
+                            Test Analysis (Duplicate)
+                                test_type: test_value (Duplicate)
+                        uri_path: /malware.exe
+                            FA Queue Analysis
+    File Analysis
+        md5: 912ec803b2ce49e4a541068d495ab570
+            FA Queue Analysis
+ipv4: 127.0.0.1
+    FA Queue Analysis
+"""
+
     submission = factory.submission.create_from_json_file(
         db=db, json_path="/app/tests/alerts/small.json", submission_name="Test Alert"
     )
 
-    # The small.json submission has 14 observables and 16 analyses (the Root Analysis is not included in the tree).
-    result = crud.submission.read_tree(uuid=submission.uuid, db=db)
-    assert str(result["children"]).count("'observable'") == 14
-    assert str(result["children"]).count("'analysis'") == 16
-    assert len(result["children"]) == 2
-
-    # The small.json has three different analysis tags applied to observables, and they should be in alphabetical order.
-    assert len(submission.child_analysis_tags) == 3
-    assert submission.child_analysis_tags[0].value == "contacted_host"
-    assert submission.child_analysis_tags[1].value == "from_address"
-    assert submission.child_analysis_tags[2].value == "recipient"
-
-    # The small.json has one detection point
-    assert len(submission.child_detection_points) == 1
-    assert submission.child_detection_points[0].value == "Malicious email address"
-
-    # The small.json has one permanent tag applied to an observable.
-    assert len(submission.child_tags) == 1
-    assert submission.child_tags[0].value == "c2"
+    # Verify the structure of the tree
+    tree = crud.submission.read_tree(uuid=submission.uuid, db=db)
+    assert factory.submission.stringify_submission_tree(tree).strip() == expected_structure.strip()
 
 
 def test_sort_by_disposition(db):

--- a/db_api/app/tests/factory/submission.py
+++ b/db_api/app/tests/factory/submission.py
@@ -258,11 +258,11 @@ def stringify_submission_tree(submission_tree: dict):
         for child in children:
             duplicate = "" if child["first_appearance"] else " (Duplicate)"
             if child["object_type"] == "observable":
-                string += f"{' '*depth}{child['type']['value']}: {child['value']}{duplicate}\n"
+                string += f"{'  '*depth}{child['type']['value']}: {child['value']}{duplicate}\n"
                 if child["children"]:
                     string = _stringify_children(children=child["children"], depth=depth + 2, string=string)
             if child["object_type"] == "analysis":
-                string += f"{' '*depth}{child['analysis_module_type']['value']}{duplicate}\n"
+                string += f"{'  '*depth}{child['analysis_module_type']['value']}{duplicate}\n"
                 if child["children"]:
                     string = _stringify_children(children=child["children"], depth=depth + 2, string=string)
 

--- a/frontend/src/components/Alerts/AlertTree.vue
+++ b/frontend/src/components/Alerts/AlertTree.vue
@@ -8,7 +8,7 @@
         :class="containerClass(i)"
         :data-cy="treeItemName(i)"
       >
-        <span class="p-treeleaf-content">
+        <span class="p-treenode-content">
           <span v-if="!i.children.length">
             <i class="pi pi-fw pi-minus"></i>
           </span>
@@ -28,7 +28,7 @@
           ></ObservableLeafVue>
 
           <router-link v-else-if="isAnalysis(i)" :to="viewAnalysisRoute(i)"
-            ><span class="treeleaf-text">{{
+            ><span class="treenode-text">{{
               treeItemName(i)
             }}</span></router-link
           >
@@ -36,7 +36,7 @@
 
         <div
           v-if="leafExpanded(index) && i.children.length"
-          class="p-treeleaf-children"
+          class="p-treenode-children"
         >
           <AlertTree :items="i.children" :alert-id="alertId" />
         </div>
@@ -120,12 +120,12 @@
   }
 
   function containerClass(item: analysisTreeRead | observableTreeRead) {
-    return ["p-treeleaf", { "p-treeleaf-leaf": !item.children.length }];
+    return ["p-treenode", { "p-treenode-leaf": !item.children.length }];
   }
 </script>
 
 <style>
-  .p-treeleaf-children {
+  .p-treenode-children {
     margin: 0;
     padding: 0;
     list-style-type: none;
@@ -139,14 +139,14 @@
     overflow: hidden;
     position: relative;
   }
-  .p-treeleaf-leaf > .p-treeleaf-content .p-tree-toggler {
+  .p-treenode-leaf > .p-treenode-content .p-tree-toggler {
     visibility: hidden;
   }
-  .p-treeleaf-content {
+  .p-treenode-content {
     display: flex;
     align-items: center;
   }
-  .treeleaf-text:hover {
+  .treenode-text:hover {
     cursor: pointer;
     text-decoration: underline;
     font-weight: bold;


### PR DESCRIPTION
The #276 PR removed and renamed all references to "node" since it got rid of the `Node` database table. In doing so, it also renamed some CSS class names provided by PrimeVue that coincidentally used "node" in their names. This in turn caused the alert tree structure to not render correctly.