### PR TITLE
Matching event tags

### DIFF
--- a/frontend/src/components/Events/EventStatusTag.vue
+++ b/frontend/src/components/Events/EventStatusTag.vue
@@ -1,0 +1,44 @@
+<template>
+  <span class="tag" data-cy="event-status-tag">
+    <Tag rounded :style="tagStyle"
+      ><span class="tag"> Event {{ status }} </span>
+      <span v-if="statusCount">({{ statusCount }})</span>
+    </Tag>
+  </span>
+</template>
+
+<script setup lang="ts">
+  import { computed, defineProps, inject } from "vue";
+  import Tag from "primevue/tag";
+  import type CSS from "csstype";
+
+  const config = inject("config") as Record<string, any>;
+
+  const props = defineProps({
+    status: {
+      type: String,
+      required: true,
+    },
+    statusCount: {
+      type: Number,
+      default: undefined,
+      required: false,
+    },
+  });
+
+  const tagStyle = computed(() => {
+    const style: CSS.Properties = {};
+
+    const statusLowerCase = props.status.toLowerCase();
+    if (statusLowerCase in config.events.eventStatusMetadata) {
+      style["backgroundColor"] =
+        config.events.eventStatusMetadata[statusLowerCase];
+    } else {
+      style["backgroundColor"] = "white";
+      style["color"] = "black";
+      style["borderStyle"] = "solid";
+      style["borderWidth"] = "thin";
+    }
+    return style;
+  });
+</script>

--- a/frontend/src/components/Observables/ObservableEventStatusGroup.vue
+++ b/frontend/src/components/Observables/ObservableEventStatusGroup.vue
@@ -1,0 +1,75 @@
+<template>
+  <EventStatusTag
+    v-for="entry in observable.matchingEvents"
+    :key="entry.status"
+    style="cursor: pointer"
+    :status="entry.status"
+    :status-count="entry.count"
+    @click="filterByObservableAndStatus(entry.status)"
+  ></EventStatusTag>
+</template>
+
+<script setup lang="ts">
+  import { defineProps, PropType } from "vue";
+  import { useRouter } from "vue-router";
+
+  import EventStatusTag from "@/components/Events/EventStatusTag.vue";
+  import { useEventStatusStore } from "@/stores/eventStatus";
+  import { useFilterStore } from "@/stores/filter";
+  import { eventStatusRead } from "@/models/eventStatus";
+  import {
+    observableTreeRead,
+    observableInAlertRead,
+  } from "@/models/observable";
+
+  const router = useRouter();
+
+  const eventStatusStore = useEventStatusStore();
+  const filterStore = useFilterStore();
+
+  const props = defineProps({
+    observable: {
+      type: Object as PropType<observableTreeRead | observableInAlertRead>,
+      required: true,
+    },
+    rerouteToManageEvents: {
+      type: Boolean,
+      required: true,
+    },
+  });
+
+  const filterByObservableAndStatus = (status: string) => {
+    const statusObject = getStatusObject(status);
+
+    filterStore.clearAll({ objectType: "events" });
+
+    if (statusObject) {
+      filterStore.setFilter({
+        objectType: "events",
+        filterName: "status",
+        filterValue: statusObject,
+        isIncluded: true,
+      });
+    }
+
+    filterStore.setFilter({
+      objectType: "events",
+      filterName: "observable",
+      filterValue: {
+        category: props.observable.type,
+        value: props.observable.value,
+      },
+      isIncluded: true,
+    });
+
+    if (props.rerouteToManageEvents) {
+      router.replace({
+        path: "/manage_events",
+      });
+    }
+  };
+
+  const getStatusObject = (status: string): eventStatusRead | undefined => {
+    return eventStatusStore.items.find((item) => item.value == status);
+  };
+</script>

--- a/frontend/src/components/Observables/ObservableLeaf.vue
+++ b/frontend/src/components/Observables/ObservableLeaf.vue
@@ -83,6 +83,15 @@
       ></MetadataTag
     ></span>
     <span
+      v-if="showEventStatusTags && observable.matchingEvents.length"
+      class="leaf-element"
+    >
+      <ObservableEventStatusGroup
+        :observable="observable"
+        :reroute-to-manage-events="true"
+      ></ObservableEventStatusGroup>
+    </span>
+    <span
       v-if="showDispositionTags && observable.dispositionHistory.length"
       class="leaf-element"
     >
@@ -114,6 +123,7 @@
 
   import type CSS from "csstype";
 
+  import ObservableEventStatusGroup from "@/components/Observables/ObservableEventStatusGroup.vue";
   import ObservableDispositionHistoryGroup from "@/components/Observables/ObservableDispositionHistoryGroup.vue";
   import MetadataTag from "@/components/Metadata/MetadataTag.vue";
 
@@ -143,6 +153,7 @@
     showActionsMenu: { type: Boolean, required: false, default: true },
     showTags: { type: Boolean, required: false, default: true },
     showDispositionTags: { type: Boolean, required: false, default: true },
+    showEventStatusTags: { type: Boolean, required: false, default: true },
   });
 
   const alertStore = useAlertStore();

--- a/frontend/src/etc/configuration/events.ts
+++ b/frontend/src/etc/configuration/events.ts
@@ -10,6 +10,8 @@ import {
   threatsProperty,
   commentProperty,
   queueProperty,
+  GREEN,
+  RED,
 } from "@/etc/constants/common";
 import {
   eventPropertyTypes,
@@ -295,3 +297,8 @@ export const defaultEventDetailsSections = {
 };
 
 export const closedEventStatus = "CLOSED";
+
+export const eventStatusMetadata: Record<string, string> = {
+  open: RED,
+  closed: GREEN,
+};

--- a/frontend/src/etc/configuration/test/events.ts
+++ b/frontend/src/etc/configuration/test/events.ts
@@ -8,6 +8,7 @@ import {
   threatsProperty,
   commentProperty,
   queueProperty,
+  BLUE,
 } from "@/etc/constants/common";
 import {
   eventPropertyTypes,
@@ -226,3 +227,7 @@ export const defaultEventDetailsSections = {
 };
 
 export const closedEventStatus = "CLOSED";
+
+export const eventStatusMetadata: Record<string, string> = {
+  test: BLUE,
+};

--- a/frontend/tests/component/src/components/Events/EventStatusTag.spec.ts
+++ b/frontend/tests/component/src/components/Events/EventStatusTag.spec.ts
@@ -1,0 +1,58 @@
+import { mount } from "@cypress/vue";
+import { createPinia } from "pinia";
+import PrimeVue from "primevue/config";
+import { testConfiguration } from "@/etc/configuration/test/index";
+
+import EventStatusTag from "@/components/Events/EventStatusTag.vue";
+
+interface EventStatusTagProps {
+  status: string;
+  statusCount?: number;
+}
+
+const blue = "rgb(0, 191, 255)";
+const white = "rgb(255, 255, 255)";
+const black = "rgb(0, 0, 0)";
+const solid = "solid";
+
+function factory(props: EventStatusTagProps) {
+  mount(EventStatusTag, {
+    global: {
+      plugins: [PrimeVue, createPinia()],
+      provide: {
+        config: testConfiguration,
+      },
+    },
+    propsData: props,
+  });
+}
+
+describe("EventStatusTag", () => {
+  it("renders correctly when metadata config exists", () => {
+    factory({ status: "TEST" });
+    cy.contains("TEST")
+      .should("be.visible")
+      .parent()
+      .should("have.css", "background-color", blue)
+      .should("have.css", "color", white);
+  });
+  it("renders correctly when metadata config does not exist", () => {
+    factory({ status: "unknown" });
+    cy.contains("unknown")
+      .should("be.visible")
+      .parent()
+      .should("have.css", "background-color", white)
+      .should("have.css", "color", black)
+      .should("have.css", "border-style", solid);
+  });
+  it("renders correctly if statusCount prop is provided", () => {
+    factory({ status: "TEST", statusCount: 5 });
+    cy.contains("TEST")
+      .should("be.visible")
+      .parent()
+      .should("have.css", "background-color", blue)
+      .should("have.css", "color", white);
+
+    cy.contains("(5)").should("be.visible");
+  });
+});

--- a/frontend/tests/component/src/components/Observables/ObservableEventStatusGroup.spec.ts
+++ b/frontend/tests/component/src/components/Observables/ObservableEventStatusGroup.spec.ts
@@ -1,0 +1,111 @@
+import { mount } from "@cypress/vue";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import PrimeVue from "primevue/config";
+import { testConfiguration } from "@/etc/configuration/test/index";
+import { genericObjectReadFactory } from "@mocks/genericObject";
+import { observableTreeRead, observableInAlertRead } from "@/models/observable";
+import ObservableEventStatusGroup from "@/components/Observables/ObservableEventStatusGroup.vue";
+import { observableInAlertReadFactory } from "../../../../mocks/observable";
+import router from "@/router/index";
+
+interface ObservableEventStatusGroupProps {
+  observable: observableTreeRead | observableInAlertRead;
+  rerouteToManageEvents: boolean;
+}
+
+function factory(props: ObservableEventStatusGroupProps) {
+  mount(ObservableEventStatusGroup, {
+    global: {
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          initialState: {
+            eventStatusStore: {
+              items: [
+                genericObjectReadFactory({ value: "OPEN" }),
+                genericObjectReadFactory({ value: "CLOSED" }),
+                genericObjectReadFactory({ value: "OTHER" }),
+              ],
+            },
+          },
+        }),
+        router,
+      ],
+      provide: {
+        config: testConfiguration,
+      },
+    },
+    propsData: props,
+  });
+}
+
+describe("ObservableEventStatusGroup", () => {
+  it("renders no tags when there are no matching event entries", () => {
+    const observable = observableInAlertReadFactory({
+      matchingEvents: [],
+    });
+    factory({ observable: observable, rerouteToManageEvents: false });
+    cy.get("[data-cy='event-status-tag']").should("not.exist");
+  });
+
+  it("renders one tag when there is only one matching event entry", () => {
+    const observable = observableInAlertReadFactory({
+      matchingEvents: [{ count: 1, status: "OPEN" }],
+    });
+    factory({ observable: observable, rerouteToManageEvents: false });
+    cy.get("[data-cy='event-status-tag']").should("have.length", 1);
+    cy.contains("OPEN").should("be.visible");
+    cy.contains("(1)").should("be.visible");
+  });
+
+  it("renders all respective tags when there are multiple matching event entries", () => {
+    const observable = observableInAlertReadFactory({
+      matchingEvents: [
+        { count: 2, status: "OPEN" },
+        { count: 3, status: "CLOSED" },
+        { count: 4, status: "OTHER" },
+      ],
+    });
+    factory({ observable: observable, rerouteToManageEvents: false });
+    cy.get("[data-cy='event-status-tag']").should("have.length", 3);
+    cy.contains("OPEN").should("be.visible");
+    cy.contains("(2)").should("be.visible");
+
+    cy.contains("CLOSED").should("be.visible");
+    cy.contains("(3)").should("be.visible");
+
+    cy.contains("OTHER").should("be.visible");
+    cy.contains("(4)").should("be.visible");
+  });
+
+  it("sets filters as expected when click on a status", () => {
+    const observable = observableInAlertReadFactory({
+      matchingEvents: [
+        { count: 2, status: "OPEN" },
+        { count: 2, status: "CLOSED" },
+        { count: 4, status: "OTHER" },
+      ],
+    });
+
+    factory({ observable: observable, rerouteToManageEvents: false });
+    cy.contains("OPEN").click();
+    cy.get("@stub-7").should("have.been.calledWith", {
+      objectType: "events",
+    });
+    cy.get("@stub-4").should("have.been.calledWith", {
+      objectType: "events",
+      filterName: "status",
+      filterValue: genericObjectReadFactory({ value: "OPEN" }),
+      isIncluded: true,
+    });
+    cy.get("@stub-4").should("have.been.calledWith", {
+      objectType: "events",
+      filterName: "observable",
+      filterValue: {
+        category: observable.type,
+        value: observable.value,
+      },
+      isIncluded: true,
+    });
+  });
+});


### PR DESCRIPTION
This PR builds off of #280 and adds tags next to observables similar to the disposition history tags from PR #270, except these tags show the event status (and the number of events with that status) for events that contain the given observable.

![image](https://user-images.githubusercontent.com/22526682/176194228-b2896ce5-0c46-4538-bd1d-c2c4d4055fed.png)

Similar to #270, when you click on one of these tags, it will take you to the Manage Events page with the filters set for the status you clicked on as well as the observable:

![image](https://user-images.githubusercontent.com/22526682/176194668-4bb135a9-db73-43c4-bd5f-5e41e67eafc8.png)


