### PR TITLE
Updates the frontend dev container to match Cypress version

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM cypress/included:10.0.2
+FROM cypress/included:10.3.0
 
 RUN apt-get install -y curl
 


### PR DESCRIPTION
This updates the frontend dev container (which is based off the Cypress container) to match the version of Cypress used in `package.json`.