### PR TITLE
Update default filters

### DIFF
--- a/frontend/src/components/Filters/TheFilterToolbar.vue
+++ b/frontend/src/components/Filters/TheFilterToolbar.vue
@@ -119,7 +119,7 @@
       const filters: {
         queue?: { included: queueRead[]; notIncluded: [] };
         owner?: { included: userRead[]; notIncluded: [] };
-        dipsosition?: { included: alertDispositionRead[]; notIncluded: [] };
+        disposition?: { included: alertDispositionRead[]; notIncluded: [] };
       } = {};
 
       // look for alerts in current user's preferred queue

--- a/frontend/src/stores/helpers.ts
+++ b/frontend/src/stores/helpers.ts
@@ -21,6 +21,8 @@ import { useObservableTypeStore } from "./observableType";
 import { useQueueStore } from "./queue";
 import { useUserStore } from "./user";
 import { dateParser } from "@/etc/helpers";
+import { userRead } from "@/models/user";
+import { alertDispositionRead } from "@/models/alertDisposition";
 
 export async function populateCommonStores(): Promise<void> {
   const alertDispositionStore = useAlertDispositionStore();
@@ -137,13 +139,13 @@ export function setUserDefaults(objectType = "all"): void {
     filterStore.setFilter({
       objectType: "alerts",
       filterName: "owner",
-      filterValue: "none",
+      filterValue: { displayName: "None", username: "none" } as userRead,
       isIncluded: true,
     });
     filterStore.setFilter({
       objectType: "alerts",
       filterName: "disposition",
-      filterValue: "None",
+      filterValue: { value: "None" } as alertDispositionRead,
       isIncluded: true,
     });
   }

--- a/frontend/src/stores/helpers.ts
+++ b/frontend/src/stores/helpers.ts
@@ -128,6 +128,24 @@ export function setUserDefaults(objectType = "all"): void {
       filterValue: currentUserSettingsStore.queues.alerts,
       isIncluded: true,
     });
+    filterStore.setFilter({
+      objectType: "alerts",
+      filterName: "owner",
+      filterValue: authStore.user,
+      isIncluded: true,
+    });
+    filterStore.setFilter({
+      objectType: "alerts",
+      filterName: "owner",
+      filterValue: "none",
+      isIncluded: true,
+    });
+    filterStore.setFilter({
+      objectType: "alerts",
+      filterName: "disposition",
+      filterValue: "None",
+      isIncluded: true,
+    });
   }
 }
 

--- a/frontend/tests/component/src/components/Filters/TheFilterToolbar.spec.ts
+++ b/frontend/tests/component/src/components/Filters/TheFilterToolbar.spec.ts
@@ -12,6 +12,10 @@ import { eventFilterParams } from "@/models/event";
 import FilterChipContainerVue from "@/components/Filters/FilterChipContainer.vue";
 import DateRangePickerVue from "@/components/UserInterface/DateRangePicker.vue";
 import { genericObjectReadFactory } from "@mocks/genericObject";
+import { userReadFactory } from "@mocks/user";
+
+const user = userReadFactory();
+const externalQueue = genericObjectReadFactory({ value: "external" });
 
 function factory(
   filters: { alerts: alertFilterParams; events: eventFilterParams } = {
@@ -26,10 +30,11 @@ function factory(
         PrimeVue,
         createCustomCypressPinia({
           initialState: {
+            authStore: { user: user },
             currentUserSettingsStore: {
               queues: {
-                alerts: { value: "external" },
-                events: { value: "external" },
+                alerts: externalQueue,
+                events: externalQueue,
               },
             },
             filterStore: filters,
@@ -129,12 +134,26 @@ describe("TheFilterToolbar", () => {
     cy.get("@stub-1").should("have.been.calledOnceWith", {
       objectType: "alerts",
       filters: {
-        queue: {
+        disposition: {
           included: [
             {
-              value: "external",
+              value: "None",
             },
           ],
+          notIncluded: [],
+        },
+        owner: {
+          included: [
+            user,
+            {
+              username: "none",
+              displayName: "None",
+            },
+          ],
+          notIncluded: [],
+        },
+        queue: {
+          included: [externalQueue],
           notIncluded: [],
         },
       },

--- a/frontend/tests/unit/src/store/helpers.spec.ts
+++ b/frontend/tests/unit/src/store/helpers.spec.ts
@@ -56,6 +56,11 @@ describe("setUserDefaults", () => {
     });
     expect(filterStore.alerts).toEqual({
       queue: { included: [alertQueue], notIncluded: [] },
+      owner: {
+        included: [authStore.user, { displayName: "None", username: "none" }],
+        notIncluded: [],
+      },
+      disposition: { included: [{ value: "None" }], notIncluded: [] },
     });
   });
   it("will correctly set all user defaults when objectType == 'all' and 'OPEN' event status is not available", () => {
@@ -72,6 +77,11 @@ describe("setUserDefaults", () => {
     });
     expect(filterStore.alerts).toEqual({
       queue: { included: [alertQueue], notIncluded: [] },
+      owner: {
+        included: [authStore.user, { displayName: "None", username: "none" }],
+        notIncluded: [],
+      },
+      disposition: { included: [{ value: "None" }], notIncluded: [] },
     });
   });
   it("will correctly set event user defaults when objectType == 'events' and 'OPEN' event status is available", () => {
@@ -114,6 +124,11 @@ describe("setUserDefaults", () => {
     expect(filterStore.events).toEqual({});
     expect(filterStore.alerts).toEqual({
       queue: { included: [alertQueue], notIncluded: [] },
+      owner: {
+        included: [authStore.user, { displayName: "None", username: "none" }],
+        notIncluded: [],
+      },
+      disposition: { included: [{ value: "None" }], notIncluded: [] },
     });
   });
 


### PR DESCRIPTION
This PR adds the remaining default 'alerts' filters, (owner == none or current user) and (disposition == none)