### PR TITLE
Feature/matching open events panel

### DIFF
--- a/frontend/src/components/Alerts/AlertMatchingOpenEventsPanel.vue
+++ b/frontend/src/components/Alerts/AlertMatchingOpenEventsPanel.vue
@@ -1,0 +1,96 @@
+<template>
+  <Panel
+    v-if="openEvents.length"
+    data-cy="matching-open-events-panel"
+    :header="panelHeader"
+    :toggleable="true"
+    :collapsed="true"
+  >
+    <DataTable
+      data-cy="matching-open-events-table"
+      :value="openEvents"
+      responsive-layout="scroll"
+    >
+      <Column field="event.name" header="Event">
+        <template #body="slotProps">
+          <router-link :to="getEventLink(slotProps.data.event.uuid)">
+            <span class="link-text">{{
+              slotProps.data.event.name
+            }}</span></router-link
+          >
+        </template>
+      </Column>
+      <Column field="percent" header="Match">
+        <template #body="slotProps">
+          {{ slotProps.data.percent }}% ({{ slotProps.data.count }})
+        </template>
+      </Column>
+      <Column field="event.threats" header="Threat Names">
+        <template #body="slotProps">
+          <span v-if="!slotProps.data.event.threats.length">No threats</span>
+          <span
+            v-for="threat in slotProps.data.event.threats"
+            :key="threat.uuid"
+          >
+            <Tag rounded>{{ threat.value }}</Tag>
+          </span>
+        </template>
+      </Column>
+      <Column field="event.allTags" header="Tags">
+        <template #body="slotProps">
+          <span v-if="!slotProps.data.event.allTags.length">No tags</span>
+          <span v-for="tag in slotProps.data.event.allTags" :key="tag.uuid">
+            <Tag rounded>{{ tag.value }}</Tag>
+          </span>
+        </template></Column
+      >
+    </DataTable>
+  </Panel>
+</template>
+
+<script setup lang="ts">
+  import { computed } from "vue";
+
+  import Panel from "primevue/panel";
+  import DataTable from "primevue/datatable";
+  import Column from "primevue/column";
+  import Tag from "primevue/tag";
+
+  import { useAlertStore } from "@/stores/alert";
+
+  const alertStore = useAlertStore();
+
+  const openEvents = computed(() => {
+    if (!alertStore.open) {
+      return [];
+    }
+
+    const openEvents = alertStore.open.matchingEvents.find(
+      (x) => x.status == "OPEN",
+    );
+    if (openEvents) {
+      return openEvents.events;
+    }
+    return [];
+  });
+
+  const panelHeader = computed(() => {
+    if (!openEvents.value.length) {
+      return "";
+    }
+
+    return `Matching Open Events: ${openEvents.value.length} Event(s) | ${openEvents.value[0].count}/${alertStore.openObservables.length} matching observables | ${openEvents.value[0].event.name}`;
+  });
+
+  const getEventLink = (uuid: string) => {
+    return "/event/" + uuid;
+  };
+</script>
+
+<style scoped>
+  .link-text:hover {
+    cursor: pointer;
+    text-decoration: underline;
+    font-weight: bold;
+  }
+</style>

--- a/frontend/src/pages/Alerts/ViewAlert.vue
+++ b/frontend/src/pages/Alerts/ViewAlert.vue
@@ -18,6 +18,8 @@
   <div v-if="alertStore.open">
     <TheAlertDetails />
     <br />
+    <AlertMatchingOpenEventsPanel />
+    <br />
     <AlertUrlDomainSummary :alert-uuid="alertID" />
     <br />
     <Card style="overflow-x: scroll">
@@ -45,6 +47,7 @@
 
   import TheAlertActionToolbar from "@/components/Alerts/TheAlertActionToolbar.vue";
   import AlertUrlDomainSummary from "@/components/Alerts/AlertUrlDomainSummary.vue";
+  import AlertMatchingOpenEventsPanel from "@/components/Alerts/AlertMatchingOpenEventsPanel.vue";
   import AlertTree from "@/components/Alerts/AlertTree.vue";
   import TheAlertDetails from "@/components/Alerts/TheAlertDetails.vue";
   import { useAlertStore } from "@/stores/alert";

--- a/frontend/src/stores/alert.ts
+++ b/frontend/src/stores/alert.ts
@@ -6,6 +6,7 @@ import {
   alertTreeRead,
   alertUpdate,
 } from "@/models/alert";
+import { observableInAlertRead } from "@/models/observable";
 import { UUID } from "@/models/base";
 import { Alert } from "@/services/api/alert";
 import { parseAlertSummary } from "@/etc/helpers";
@@ -15,6 +16,8 @@ export const useAlertStore = defineStore({
 
   state: () => ({
     open: null as unknown as alertTreeRead,
+
+    openObservables: [] as observableInAlertRead[],
 
     // whether the alert should be reloaded
     requestReload: false,
@@ -44,6 +47,13 @@ export const useAlertStore = defineStore({
       await Alert.read(uuid)
         .then((alert) => {
           this.open = alert;
+        })
+        .catch((error) => {
+          throw error;
+        });
+      await Alert.readObservables([uuid])
+        .then((observables) => {
+          this.openObservables = observables;
         })
         .catch((error) => {
           throw error;

--- a/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
@@ -9,6 +9,7 @@ import { testConfiguration } from "@/etc/configuration/test/index";
 
 import AlertMatchingOpenEventsPanel from "@/components/Alerts/AlertMatchingOpenEventsPanel.vue";
 import { alertTreeRead, submissionMatchingEventByStatus } from "@/models/alert";
+import { observableReadFactory } from "@mocks/observable";
 
 function factory(openAlert?: alertTreeRead) {
   mount(AlertMatchingOpenEventsPanel, {
@@ -16,7 +17,15 @@ function factory(openAlert?: alertTreeRead) {
       plugins: [
         PrimeVue,
         createCustomCypressPinia({
-          initialState: { alertStore: { open: openAlert } },
+          initialState: {
+            alertStore: {
+              open: openAlert,
+              openObservables: [
+                observableReadFactory(),
+                observableReadFactory(),
+              ],
+            },
+          },
         }),
       ],
       provide: {
@@ -92,7 +101,7 @@ describe("AlertMatchingOpenEventsPanel", () => {
     cy.get("[data-cy=matching-open-events-panel]").should("be.visible");
     cy.get("[data-cy=matching-open-events-table]").should("not.be.visible");
     cy.contains(
-      "Matching Open Events: 2 Event(s) | 1/0 matching observables | Test Event",
+      "Matching Open Events: 2 Event(s) | 1/2 matching observables | Test Event",
     ).should("be.visible");
     cy.get(".pi").click(); // expand the panel
     cy.get("[data-cy=matching-open-events-table]").should("be.visible");

--- a/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
@@ -1,0 +1,151 @@
+import { mount } from "@cypress/vue";
+import { createCustomCypressPinia } from "@tests/cypressHelpers";
+import { alertTreeReadFactory } from "@mocks/alert";
+import { eventReadFactory } from "@mocks/events";
+import { genericObjectReadFactory } from "@mocks/genericObject";
+
+import PrimeVue from "primevue/config";
+import { testConfiguration } from "@/etc/configuration/test/index";
+
+import AlertMatchingOpenEventsPanel from "@/components/Alerts/AlertMatchingOpenEventsPanel.vue";
+
+function factory(openAlert: alertTreeRead | undefined) {
+  mount(AlertMatchingOpenEventsPanel, {
+    global: {
+      plugins: [
+        PrimeVue,
+        createCustomCypressPinia({
+          initialState: { alertStore: { open: openAlert } },
+        }),
+      ],
+      provide: {
+        config: testConfiguration,
+      },
+    },
+  });
+}
+
+describe("AlertMatchingOpenEventsPanel", () => {
+  it("doesn't render and doesn't error when there is no open alert", () => {
+    factory();
+    cy.get("[data-cy=matching-open-events-panel]").should("not.exist");
+    cy.get("[data-cy=matching-open-events-table]").should("not.exist");
+  });
+  it("doesn't render and doesn't error when the open alert doesn't have any matchingEvents", () => {
+    factory(alertTreeReadFactory());
+    cy.get("[data-cy=matching-open-events-panel]").should("not.exist");
+    cy.get("[data-cy=matching-open-events-table]").should("not.exist");
+  });
+  it("doesn't render and doesn't error when the open alert doesn't have any OPEN matchingEvents", () => {
+    const matchingEvents: submissionMatchingEventByStatus[] = [
+      {
+        status: "CLOSED",
+        events: [{ count: 1, percent: 100, event: eventReadFactory() }],
+      },
+    ];
+    const openAlert = alertTreeReadFactory({ matchingEvents: matchingEvents });
+    factory(openAlert);
+    cy.get("[data-cy=matching-open-events-panel]").should("not.exist");
+    cy.get("[data-cy=matching-open-events-table]").should("not.exist");
+  });
+  it("renders correctly when there are OPEN matchingEvents", () => {
+    const matchingEvents: submissionMatchingEventByStatus[] = [
+      {
+        status: "CLOSED",
+        events: [{ count: 1, percent: 100, event: eventReadFactory() }],
+      },
+      {
+        status: "OPEN",
+        events: [
+          { count: 1, percent: 50, event: eventReadFactory({ uuid: "uuidA" }) },
+          {
+            count: 1,
+            percent: 50,
+            event: eventReadFactory({
+              name: "Test Event B",
+              uuid: "uuidB",
+              allTags: [
+                genericObjectReadFactory({ value: "Test Tag A" }),
+                genericObjectReadFactory({ value: "Test Tag B" }),
+              ],
+              threats: [genericObjectReadFactory({ value: "Threat A" })],
+            }),
+          },
+        ],
+      },
+    ];
+    const openAlert = alertTreeReadFactory({ matchingEvents: matchingEvents });
+    factory(openAlert);
+    cy.get("[data-cy=matching-open-events-panel]").should("be.visible");
+    cy.get("[data-cy=matching-open-events-table]").should("not.be.visible");
+    cy.contains(
+      "Matching Open Events: 2 Event(s) | 1/0 matching observables | Test Event",
+    ).should("be.visible");
+    cy.get(".pi").click(); // expand the panel
+    cy.get("[data-cy=matching-open-events-table]").should("be.visible");
+
+    // Check header row
+    cy.get("tr")
+      .eq(0)
+      .children()
+      .should("have.length", 4)
+      .each(($td, index) => {
+        if (index === 0) {
+          cy.wrap($td).contains("Event");
+        } else if (index === 1) {
+          cy.wrap($td).contains("Match");
+        } else if (index === 2) {
+          cy.wrap($td).contains("Threat Names");
+        } else if (index === 3) {
+          cy.wrap($td).contains("Tags");
+        }
+      });
+
+    // Check first event row
+    cy.get("tr")
+      .eq(1)
+      .children()
+      .should("have.length", 4)
+      .each(($td, index) => {
+        if (index === 0) {
+          cy.wrap($td).contains("Test Event");
+          cy.wrap($td)
+            .find("router-link")
+            .invoke("attr", "to")
+            .should("equal", "/event/uuidA");
+        } else if (index === 1) {
+          cy.wrap($td).contains("50% (1)");
+        } else if (index === 2) {
+          cy.wrap($td).contains("No threats");
+        } else if (index === 3) {
+          cy.wrap($td).contains("No tags");
+        }
+      });
+
+    // Check second event row
+    cy.get("tr")
+      .eq(2)
+      .children()
+      .should("have.length", 4)
+      .each(($td, index) => {
+        if (index === 0) {
+          cy.wrap($td).contains("Test Event B");
+          cy.wrap($td)
+            .find("router-link")
+            .invoke("attr", "to")
+            .should("equal", "/event/uuidB");
+        } else if (index === 1) {
+          cy.wrap($td).contains("50% (1)");
+        } else if (index === 2) {
+          cy.wrap($td)
+            .find(".p-tag")
+            .should("have.length", 1)
+            .should("contain", "Threat A");
+        } else if (index === 3) {
+          cy.wrap($td).find(".p-tag").should("have.length", 2);
+          cy.wrap($td).find(".p-tag").eq(0).should("contain", "Test Tag A");
+          cy.wrap($td).find(".p-tag").eq(1).should("contain", "Test Tag B");
+        }
+      });
+  });
+});

--- a/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
+++ b/frontend/tests/component/src/components/Alerts/AlertMatchingOpenEventsPanel.spec.ts
@@ -8,8 +8,9 @@ import PrimeVue from "primevue/config";
 import { testConfiguration } from "@/etc/configuration/test/index";
 
 import AlertMatchingOpenEventsPanel from "@/components/Alerts/AlertMatchingOpenEventsPanel.vue";
+import { alertTreeRead, submissionMatchingEventByStatus } from "@/models/alert";
 
-function factory(openAlert: alertTreeRead | undefined) {
+function factory(openAlert?: alertTreeRead) {
   mount(AlertMatchingOpenEventsPanel, {
     global: {
       plugins: [
@@ -65,10 +66,22 @@ describe("AlertMatchingOpenEventsPanel", () => {
               name: "Test Event B",
               uuid: "uuidB",
               allTags: [
-                genericObjectReadFactory({ value: "Test Tag A" }),
-                genericObjectReadFactory({ value: "Test Tag B" }),
+                {
+                  ...genericObjectReadFactory({ value: "Test Tag A" }),
+                  metadataType: "tag",
+                },
+                {
+                  ...genericObjectReadFactory({ value: "Test Tag B" }),
+                  metadataType: "tag",
+                },
               ],
-              threats: [genericObjectReadFactory({ value: "Threat A" })],
+              threats: [
+                {
+                  ...genericObjectReadFactory({ value: "Threat A" }),
+                  types: [],
+                  queues: [],
+                },
+              ],
             }),
           },
         ],

--- a/frontend/tests/component/src/pages/Alerts/ViewAlert.spec.ts
+++ b/frontend/tests/component/src/pages/Alerts/ViewAlert.spec.ts
@@ -39,6 +39,7 @@ function factory(stubActions = true) {
 describe("ViewAlert", () => {
   it("renders correctly when alert can be fetched", () => {
     cy.stub(Alert, "read").resolves(alertTreeReadFactory());
+    cy.stub(Alert, "readObservables").resolves([]);
     factory(false).then((wrapper) => {
       cy.get("@spy-9").should("have.been.calledOnce"); // unselectAll
       cy.get("@spy-6").should("have.been.calledOnce"); // select alert
@@ -51,6 +52,7 @@ describe("ViewAlert", () => {
   });
   it("attempts to disposition alert as 'false positive' on ignoreClicked event", () => {
     cy.stub(Alert, "read").resolves(alertTreeReadFactory());
+    cy.stub(Alert, "readObservables").resolves([]);
     cy.stub(Alert, "update")
       .withArgs([
         {
@@ -72,6 +74,7 @@ describe("ViewAlert", () => {
   });
   it("attempts to disposition alert as 'ignore' on ignoreClicked event", () => {
     cy.stub(Alert, "read").resolves(alertTreeReadFactory());
+    cy.stub(Alert, "readObservables").resolves([]);
     cy.stub(Alert, "update")
       .withArgs([
         {
@@ -93,6 +96,7 @@ describe("ViewAlert", () => {
   });
   it("will display error message if attempt to use FP disposition shortcut fails", () => {
     cy.stub(Alert, "read").resolves(alertTreeReadFactory());
+    cy.stub(Alert, "readObservables").resolves([]);
     cy.stub(Alert, "update")
       .withArgs([
         {
@@ -117,6 +121,7 @@ describe("ViewAlert", () => {
   });
   it("will display error message if attempt to use ignore disposition shortcut fails", () => {
     cy.stub(Alert, "read").resolves(alertTreeReadFactory());
+    cy.stub(Alert, "readObservables").resolves([]);
     cy.stub(Alert, "update")
       .withArgs([
         {

--- a/frontend/tests/unit/src/store/alert.spec.ts
+++ b/frontend/tests/unit/src/store/alert.spec.ts
@@ -3,6 +3,7 @@ import myNock from "@unit/services/api/nock";
 import snakecaseKeys from "snakecase-keys";
 import { useAlertStore } from "@/stores/alert";
 import { createCustomPinia } from "@tests/unitHelpers";
+import { observableReadFactory } from "@mocks/observable";
 
 import {
   alertCreateFactory,
@@ -17,6 +18,7 @@ const mockAlertTree = alertTreeReadFactory();
 const mockAlert = alertReadFactory();
 const mockAlertCreate = alertCreateFactory();
 const mockAlertSummary = alertSummaryFactory();
+const mockObservable = observableReadFactory();
 
 const store = useAlertStore();
 
@@ -42,13 +44,20 @@ describe("alert Actions", () => {
     expect(store.open).toEqual(JSON.parse(JSON.stringify(mockAlert)));
   });
 
-  it("will fetch alert data given an alert ID", async () => {
+  it("will fetch alert and observable data given an alert ID", async () => {
     const mockRequest = myNock.get("/alert/uuid1").reply(200, mockAlert);
+    const mockRequest2 = myNock
+      .post("/alert/observables", ["uuid1"])
+      .reply(200, [mockObservable]);
     await store.read("uuid1");
 
     expect(mockRequest.isDone()).toEqual(true);
+    expect(mockRequest2.isDone()).toEqual(true);
 
     expect(store.open).toEqual(JSON.parse(JSON.stringify(mockAlert)));
+    expect(store.openObservables).toEqual(
+      JSON.parse(JSON.stringify([mockObservable])),
+    );
   });
 
   it("will make a request to update an alert given the UUID and update data upon the updateAlert action", async () => {


### PR DESCRIPTION
This PR adds the GUI component for the Matching Open Events panel on the View Alert page.

RIght now, it is identical to it's 1.0 counterpart, but can easily be expanded upon in the future.

In order to display the total number of observables in an alert, a second call is now made when calling 'read' on the alertStore to fetch all observables for the given alert. This will likely be used for other features in the future as well.

![image](https://user-images.githubusercontent.com/31867815/176742974-9b85316e-0de1-4fec-85db-62f918bf8869.png)
