### PR TITLE
Custom sort order for observables

### DIFF
--- a/api_models/__init__.py
+++ b/api_models/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import conint, conlist, constr
+from pydantic import conint, conlist, constr, ConstrainedStr, ConstrainedInt
 
 
 type_int = conint(strict=True)
@@ -6,3 +6,12 @@ type_int = conint(strict=True)
 type_str = constr(strict=True, min_length=1)
 
 type_list_str = conlist(type_str, min_items=1)
+
+
+class TypeInt(ConstrainedInt):
+    strict = True
+
+
+class TypeStr(ConstrainedStr):
+    min_length = 1
+    strict = True

--- a/api_models/analysis_metadata.py
+++ b/api_models/analysis_metadata.py
@@ -2,11 +2,12 @@ from datetime import datetime
 from pydantic import BaseModel, Field, UUID4
 from typing import Optional, Union
 
-from api_models import type_str
+from api_models import TypeInt, type_str
 from api_models.metadata_detection_point import MetadataDetectionPointRead
 from api_models.metadata_directive import MetadataDirectiveRead
 from api_models.metadata_display_type import MetadataDisplayTypeRead
 from api_models.metadata_display_value import MetadataDisplayValueRead
+from api_models.metadata_sort import MetadataSortRead
 from api_models.metadata_tag import MetadataTagRead
 from api_models.metadata_time import MetadataTimeRead
 
@@ -24,7 +25,7 @@ class AnalysisMetadataCreate(BaseModel):
 
     type: type_str = Field(description="The type of the metadata")
 
-    value: Union[type_str, datetime] = Field(description="The value of the metadata")
+    value: Union[TypeInt, type_str, datetime] = Field(description="The value of the metadata")
 
 
 class AnalysisMetadataRead(BaseModel):
@@ -41,6 +42,8 @@ class AnalysisMetadataRead(BaseModel):
     display_type: Optional[MetadataDisplayTypeRead] = Field(description="The display type of the observable")
 
     display_value: Optional[MetadataDisplayValueRead] = Field(description="The display value of the observable")
+
+    sort: Optional[MetadataSortRead] = Field(description="The sort order for the observable")
 
     tags: list[MetadataTagRead] = Field(default_factory=list, description="A list of tags added to the observable")
 

--- a/api_models/metadata.py
+++ b/api_models/metadata.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field, UUID4
 from uuid import uuid4
 
-from api_models import type_str
+from api_models import TypeStr
 
 
 class MetadataBase(BaseModel):
@@ -16,7 +16,7 @@ class MetadataCreate(MetadataBase):
 
 class MetadataRead(MetadataBase):
 
-    metadata_type: type_str = Field(description="The type of the metadata")
+    metadata_type: TypeStr = Field(description="The type of the metadata")
 
     uuid: UUID4 = Field(description="The UUID of the metadata")
 

--- a/api_models/metadata_sort.py
+++ b/api_models/metadata_sort.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api_models import TypeInt, TypeStr, validators
+from api_models.metadata import MetadataRead
+
+
+class MetadataSortCreate(BaseModel):
+    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the sort")
+
+    value: TypeInt = Field(description="The value of the sort")
+
+
+class MetadataSortRead(MetadataRead):
+    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+
+    uuid: UUID4 = Field(description="The UUID of the sort")
+
+    value: TypeInt = Field(description="The value of the sort")
+
+    class Config:
+        orm_mode = True
+
+    def __hash__(self):
+        return hash(self.value)
+
+
+class MetadataSortUpdate(BaseModel):
+    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+
+    value: Optional[TypeInt] = Field(description="The value of the sort")
+
+    _prevent_none: classmethod = validators.prevent_none("value")

--- a/db_api/app/api/routes/__init__.py
+++ b/db_api/app/api/routes/__init__.py
@@ -17,6 +17,7 @@ from api.routes.metadata_detection_point import router as metadata_detection_poi
 from api.routes.metadata_directive import router as metadata_directive_router
 from api.routes.metadata_display_type import router as metadata_display_type_router
 from api.routes.metadata_display_value import router as metadata_display_value_router
+from api.routes.metadata_sort import router as metadata_sort_router
 from api.routes.metadata_tag import router as metadata_tag_router
 from api.routes.metadata_time import router as metadata_time_router
 from api.routes.observable import router as observable_router
@@ -41,13 +42,13 @@ from api.routes.user_role import router as user_role_router
 router = APIRouter()
 
 router.include_router(alert_disposition_router)
-router.include_router(analysis_router)
 router.include_router(analysis_module_type_router)
+router.include_router(analysis_router)
 router.include_router(auth_router)
-router.include_router(event_router)
 router.include_router(event_comment_router)
 router.include_router(event_prevention_tool_router)
 router.include_router(event_remediation_router)
+router.include_router(event_router)
 router.include_router(event_severity_router)
 router.include_router(event_source_router)
 router.include_router(event_status_router)
@@ -57,22 +58,23 @@ router.include_router(metadata_detection_point_router)
 router.include_router(metadata_directive_router)
 router.include_router(metadata_display_type_router)
 router.include_router(metadata_display_value_router)
+router.include_router(metadata_sort_router)
 router.include_router(metadata_tag_router)
 router.include_router(metadata_time_router)
-router.include_router(observable_router)
 router.include_router(observable_relationship_router)
 router.include_router(observable_relationship_type_router)
+router.include_router(observable_router)
 router.include_router(observable_type_router)
 router.include_router(ping_router)
 router.include_router(queue_router)
 router.include_router(submission_comment_router)
 router.include_router(submission_router)
-router.include_router(submission_tool_router)
 router.include_router(submission_tool_instance_router)
+router.include_router(submission_tool_router)
 router.include_router(submission_type_router)
 router.include_router(test_router)
-router.include_router(threat_router)
 router.include_router(threat_actor_router)
+router.include_router(threat_router)
 router.include_router(threat_type_router)
-router.include_router(user_router)
 router.include_router(user_role_router)
+router.include_router(user_router)

--- a/db_api/app/api/routes/metadata_sort.py
+++ b/db_api/app/api/routes/metadata_sort.py
@@ -1,0 +1,105 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi_pagination.ext.sqlalchemy_future import paginate
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from api.routes import helpers
+from api_models.metadata_sort import (
+    MetadataSortCreate,
+    MetadataSortRead,
+    MetadataSortUpdate,
+)
+from db import crud
+from db.database import get_db
+from db.schemas.metadata_sort import MetadataSort
+from exceptions.db import UuidNotFoundInDatabase
+
+
+router = APIRouter(
+    prefix="/metadata/sort",
+    tags=["Sort"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_sort(
+    create: MetadataSortCreate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    obj = crud.metadata_sort.create_or_read(model=create, db=db)
+    db.commit()
+
+    response.headers["Content-Location"] = request.url_for("get_sort", uuid=obj.uuid)
+
+
+helpers.api_route_create(router, create_sort)
+
+
+#
+# READ
+#
+
+
+def get_all_sorts(db: Session = Depends(get_db)):
+    return paginate(conn=db, query=crud.metadata_sort.build_read_all_query())
+
+
+def get_sort(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        return crud.metadata_sort.read_by_uuid(uuid=uuid, db=db)
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+helpers.api_route_read_all(router, get_all_sorts, MetadataSortRead)
+helpers.api_route_read(router, get_sort, MetadataSortRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_sort(
+    uuid: UUID,
+    sort: MetadataSortUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    try:
+        if not crud.helpers.update(uuid=uuid, update_model=sort, db_table=MetadataSort, db=db):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unable to update sort {uuid}")
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+    response.headers["Content-Location"] = request.url_for("get_sort", uuid=uuid)
+
+
+helpers.api_route_update(router, update_sort)
+
+
+#
+# DELETE
+#
+
+
+def delete_sort(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        if not crud.helpers.delete(uuid=uuid, db_table=MetadataSort, db=db):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unable to delete sort {uuid}")
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+
+helpers.api_route_delete(router, delete_sort)

--- a/db_api/app/db/crud/__init__.py
+++ b/db_api/app/db/crud/__init__.py
@@ -17,12 +17,13 @@ from db.crud import metadata_detection_point
 from db.crud import metadata_directive
 from db.crud import metadata_display_type
 from db.crud import metadata_display_value
+from db.crud import metadata_sort
 from db.crud import metadata_tag
 from db.crud import metadata_time
-from db.crud import observable_type
 from db.crud import observable
 from db.crud import observable_relationship
 from db.crud import observable_relationship_type
+from db.crud import observable_type
 from db.crud import queue
 from db.crud import submission
 from db.crud import submission_analysis_mapping
@@ -33,5 +34,5 @@ from db.crud import submission_type
 from db.crud import threat
 from db.crud import threat_actor
 from db.crud import threat_type
-from db.crud import user_role
 from db.crud import user
+from db.crud import user_role

--- a/db_api/app/db/crud/analysis_metadata.py
+++ b/db_api/app/db/crud/analysis_metadata.py
@@ -8,6 +8,7 @@ from api_models.metadata_detection_point import MetadataDetectionPointCreate
 from api_models.metadata_directive import MetadataDirectiveCreate
 from api_models.metadata_display_type import MetadataDisplayTypeCreate
 from api_models.metadata_display_value import MetadataDisplayValueCreate
+from api_models.metadata_sort import MetadataSortCreate
 from api_models.metadata_tag import MetadataTagCreate
 from api_models.metadata_time import MetadataTimeCreate
 from db import crud
@@ -50,6 +51,9 @@ def create_or_read(
         metadata_object = crud.metadata_display_value.create_or_read(
             model=MetadataDisplayValueCreate(value=model.value), db=db
         )
+
+    elif model.type == "sort":
+        metadata_object = crud.metadata_sort.create_or_read(model=MetadataSortCreate(value=model.value), db=db)
 
     elif model.type == "tag":
         metadata_object = crud.metadata_tag.create_or_read(model=MetadataTagCreate(value=model.value), db=db)

--- a/db_api/app/db/crud/event.py
+++ b/db_api/app/db/crud/event.py
@@ -1112,7 +1112,7 @@ def read_summary_url_domain(uuid: UUID, db: Session) -> URLDomainSummary:
     # NOTE: This assumes the URL values are validated as they are added to the database.
     urls = read_observable_type_from_event(observable_type="url", uuid=uuid, db=db)
 
-    return crud.helpers.read_summary_url_domain(url_observables=urls, db=db)
+    return crud.helpers.read_summary_url_domain(url_observables=urls)
 
 
 def read_summary_user(uuid: UUID, db: Session) -> list[UserSummary]:

--- a/db_api/app/db/crud/helpers.py
+++ b/db_api/app/db/crud/helpers.py
@@ -7,13 +7,12 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import Session, undefer
 from sqlalchemy.orm.decl_api import DeclarativeMeta
 from sqlalchemy.sql.selectable import Select
-from typing import Any
+from typing import Any, Union
 from urllib.parse import urlparse
 from uuid import UUID
+
 from api_models.summaries import URLDomainSummary, URLDomainSummaryIndividual
 from db.schemas.observable import Observable
-
-
 from exceptions.db import UuidNotFoundInDatabase, ValueNotFoundInDatabase
 
 
@@ -61,7 +60,7 @@ def read_by_uuid(db_table: DeclarativeMeta, uuid: UUID, db: Session, undefer_col
         raise UuidNotFoundInDatabase(f"UUID {uuid} was not found in the {db_table.__tablename__} table.") from e
 
 
-def read_by_value(db_table: DeclarativeMeta, value: str, db: Session) -> Any:
+def read_by_value(db_table: DeclarativeMeta, value: Union[int, str], db: Session) -> Any:
     """Returns the object with the specific value (if it exists) from the given database table."""
 
     try:
@@ -73,7 +72,7 @@ def read_by_value(db_table: DeclarativeMeta, value: str, db: Session) -> Any:
 
 
 def read_by_values(
-    db_table: DeclarativeMeta, values: list[str], db: Session, error_on_not_found: bool = True
+    db_table: DeclarativeMeta, values: Union[list[int], list[str]], db: Session, error_on_not_found: bool = True
 ) -> list[Any]:
     """Returns a list of objects with the specific values from the given database table. Raise an
     exception if the number of objects returned from the database does not match the number of
@@ -126,7 +125,7 @@ def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def read_summary_url_domain(url_observables: list[Observable], db: Session) -> URLDomainSummary:
+def read_summary_url_domain(url_observables: list[Observable]) -> URLDomainSummary:
     domain_count: dict[str, URLDomainSummaryIndividual] = {}
     for url in url_observables:
         parsed_url = urlparse(url.value)

--- a/db_api/app/db/crud/metadata_sort.py
+++ b/db_api/app/db/crud/metadata_sort.py
@@ -1,0 +1,41 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
+from uuid import UUID
+
+from api_models.metadata_sort import MetadataSortCreate, MetadataSortUpdate
+from db import crud
+from db.schemas.metadata_sort import MetadataSort
+
+
+def build_read_all_query() -> Select:
+    return select(MetadataSort).order_by(MetadataSort.value)
+
+
+def create_or_read(model: MetadataSortCreate, db: Session) -> MetadataSort:
+    obj = MetadataSort(**model.dict())
+
+    if crud.helpers.create(obj=obj, db=db):
+        return obj
+
+    return read_by_value(value=model.value, db=db)
+
+
+def delete(uuid: UUID, db: Session) -> bool:
+    return crud.helpers.delete(uuid=uuid, db_table=MetadataSort, db=db)
+
+
+def read_all(db: Session) -> list[MetadataSort]:
+    return db.execute(build_read_all_query()).scalars().all()
+
+
+def read_by_uuid(uuid: UUID, db: Session) -> MetadataSort:
+    return crud.helpers.read_by_uuid(db_table=MetadataSort, uuid=uuid, db=db)
+
+
+def read_by_value(value: int, db: Session) -> MetadataSort:
+    return crud.helpers.read_by_value(db_table=MetadataSort, value=value, db=db)
+
+
+def update(uuid: UUID, model: MetadataSortUpdate, db: Session) -> bool:
+    return crud.helpers.update(uuid=uuid, update_model=model, db_table=MetadataSort, db=db)

--- a/db_api/app/db/crud/submission.py
+++ b/db_api/app/db/crud/submission.py
@@ -69,6 +69,10 @@ def _associate_metadata_with_observable(analysis_uuids: list[UUID], o: Observabl
         elif m.metadata_object.metadata_type == "display_value" and not o.analysis_metadata.display_value:
             o.analysis_metadata.display_value = m.metadata_object
 
+        # Only add the sort metadata if one was not already set
+        elif m.metadata_object.metadata_type == "sort" and not o.analysis_metadata.sort:
+            o.analysis_metadata.sort = m.metadata_object
+
         # Add each tag metadata
         elif m.metadata_object.metadata_type == "tag":
             o.analysis_metadata.tags.append(m.metadata_object)
@@ -982,6 +986,12 @@ def read_tree(uuid: UUID, db: Session) -> dict:
             # Add the observable as a child to the analysis model.
             analyses_by_uuid[db_analysis.uuid].children.append(child_observables[db_child_observable.uuid])
 
+        # Sort the child observables for each analysis based on metadata sort objects. If the observable has sort
+        # metadata applied to it, that value will be used. Otherwise, "infinity" will be used.
+        analyses_by_uuid[db_analysis.uuid].children.sort(
+            key=lambda x: x.analysis_metadata.sort.value if x.analysis_metadata.sort else float("inf")
+        )
+
     # Loop over each overvable in the submission and add its analysis as children to the observable model
     for observable_uuid, observable in child_observables.items():
         if observable_uuid in analyses_by_target:
@@ -1026,7 +1036,7 @@ def read_summary_url_domain(uuid: UUID, db: Session) -> URLDomainSummary:
     observables = read_observables(uuids=[uuid], db=db)
     urls = [observable for observable in observables if observable.type.value == "url"]
 
-    return crud.helpers.read_summary_url_domain(url_observables=urls, db=db)
+    return crud.helpers.read_summary_url_domain(url_observables=urls)
 
 
 def update(model: SubmissionUpdate, db: Session):

--- a/db_api/app/db/migrations/versions/51170f8e158b_initial.py
+++ b/db_api/app/db/migrations/versions/51170f8e158b_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: bca5409c9fb6
+Revision ID: 51170f8e158b
 Revises: 
-Create Date: 2022-07-06 15:17:53.118942
+Create Date: 2022-07-07 15:34:37.907297
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = 'bca5409c9fb6'
+revision = '51170f8e158b'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -275,6 +275,14 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_metadata_display_value_value'), 'metadata_display_value', ['value'], unique=True)
+    op.create_table('metadata_sort',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('description', sa.String(), nullable=True),
+    sa.Column('value', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['uuid'], ['metadata.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_metadata_sort_value'), 'metadata_sort', ['value'], unique=True)
     op.create_table('metadata_tag',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), nullable=False),
     sa.Column('description', sa.String(), nullable=True),
@@ -798,6 +806,8 @@ def downgrade() -> None:
     op.drop_table('metadata_time')
     op.drop_index(op.f('ix_metadata_tag_value'), table_name='metadata_tag')
     op.drop_table('metadata_tag')
+    op.drop_index(op.f('ix_metadata_sort_value'), table_name='metadata_sort')
+    op.drop_table('metadata_sort')
     op.drop_index(op.f('ix_metadata_display_value_value'), table_name='metadata_display_value')
     op.drop_table('metadata_display_value')
     op.drop_index(op.f('ix_metadata_display_type_value'), table_name='metadata_display_type')

--- a/db_api/app/db/schemas/__init__.py
+++ b/db_api/app/db/schemas/__init__.py
@@ -33,6 +33,7 @@ from db.schemas.metadata_detection_point import MetadataDetectionPoint
 from db.schemas.metadata_directive import MetadataDirective
 from db.schemas.metadata_display_type import MetadataDisplayType
 from db.schemas.metadata_display_value import MetadataDisplayValue
+from db.schemas.metadata_sort import MetadataSort
 from db.schemas.metadata_tag import MetadataTag
 from db.schemas.metadata_time import MetadataTime
 from db.schemas.threat import Threat

--- a/db_api/app/db/schemas/metadata_sort.py
+++ b/db_api/app/db/schemas/metadata_sort.py
@@ -1,0 +1,16 @@
+from sqlalchemy import Column, ForeignKey, Integer, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from db.schemas.metadata import Metadata
+
+
+class MetadataSort(Metadata):
+    __tablename__ = "metadata_sort"
+
+    uuid = Column(UUID(as_uuid=True), ForeignKey("metadata.uuid"), primary_key=True)
+
+    description = Column(String)
+
+    value = Column(Integer, nullable=False, unique=True, index=True)
+
+    __mapper_args__ = {"polymorphic_identity": "sort", "polymorphic_load": "inline"}

--- a/db_api/app/tests/api_tests/metadata_sort/test_create.py
+++ b/db_api/app/tests/api_tests/metadata_sort/test_create.py
@@ -1,0 +1,71 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+        ("value", "123"),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client, key, value):
+    create_json = {"value": 1, key: value}
+    create = client.post("/api/metadata/sort/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_create_missing_required_fields(client, key):
+    create_json = {"value": 1}
+    del create_json[key]
+    create = client.post("/api/metadata/sort/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("description", None), ("description", "test"), ("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client, key, value):
+    # Create the object
+    create = client.post("/api/metadata/sort/", json={key: value, "value": 1})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client):
+    # Create the object
+    create = client.post("/api/metadata/sort/", json={"value": 1})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()["value"] == 1

--- a/db_api/app/tests/api_tests/metadata_sort/test_delete.py
+++ b/db_api/app/tests/api_tests/metadata_sort/test_delete.py
@@ -1,0 +1,49 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client):
+    delete = client.delete("/api/metadata/sort/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client):
+    delete = client.delete(f"/api/metadata/sort/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_used(client, db):
+    # Create an object
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    # Assign it to another object
+    submission = factory.submission.create(db=db)
+    factory.observable.create_or_read(
+        type="test", value="test", parent_analysis=submission.root_analysis, sort=1, db=db
+    )
+
+    # Ensure you cannot delete it now that it is in use
+    delete = client.delete(f"/api/metadata/sort/{obj.uuid}")
+    assert delete.status_code == status.HTTP_400_BAD_REQUEST
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete(client, db):
+    # Create the object
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    # Delete it
+    delete = client.delete(f"/api/metadata/sort/{obj.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT

--- a/db_api/app/tests/api_tests/metadata_sort/test_read.py
+++ b/db_api/app/tests/api_tests/metadata_sort/test_read.py
@@ -1,0 +1,42 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client):
+    get = client.get("/api/metadata/sort/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client):
+    get = client.get(f"/api/metadata/sort/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_all(client, db):
+    # Create some objects
+    factory.metadata_sort.create_or_read(value=1, db=db)
+    factory.metadata_sort.create_or_read(value=2, db=db)
+
+    # Read them back
+    get = client.get("/api/metadata/sort/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 2
+
+
+def test_get_all_empty(client):
+    get = client.get("/api/metadata/sort/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 0

--- a/db_api/app/tests/api_tests/metadata_sort/test_update.py
+++ b/db_api/app/tests/api_tests/metadata_sort/test_update.py
@@ -1,0 +1,79 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("value", "123"),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_update_invalid_fields(client, key, value):
+    update = client.patch(f"/api/metadata/sort/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_invalid_uuid(client):
+    update = client.patch("/api/metadata/sort/1", json={"value": 1})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_update_duplicate_unique_fields(client, db, key):
+    # Create some objects
+    obj1 = factory.metadata_sort.create_or_read(value=1, db=db)
+    obj2 = factory.metadata_sort.create_or_read(value=2, db=db)
+
+    # Ensure you cannot update a unique field to a value that already exists
+    update = client.patch(f"/api/metadata/sort/{obj2.uuid}", json={key: getattr(obj1, key)})
+    assert update.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_nonexistent_uuid(client):
+    update = client.patch(f"/api/metadata/sort/{uuid.uuid4()}", json={"value": 1})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,initial_value,updated_value",
+    [
+        ("description", None, "test"),
+        ("description", "test", "test"),
+        ("value", 1, 2),
+        ("value", 1, 1),
+    ],
+)
+def test_update(client, db, key, initial_value, updated_value):
+    # Create the object
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    # Set the initial value
+    setattr(obj, key, initial_value)
+
+    # Update it
+    update = client.patch(f"/api/metadata/sort/{obj.uuid}", json={key: updated_value})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert getattr(obj, key) == updated_value

--- a/db_api/app/tests/db_tests/crud/metadata_sort/test_create.py
+++ b/db_api/app/tests/db_tests/crud/metadata_sort/test_create.py
@@ -1,0 +1,20 @@
+from api_models.metadata_sort import MetadataSortCreate
+from db import crud
+
+
+def test_create(db):
+    obj = crud.metadata_sort.create_or_read(model=MetadataSortCreate(description="test description", value=1), db=db)
+
+    assert obj.description == "test description"
+    assert obj.value == 1
+
+
+def test_create_duplicate_value(db):
+    obj1 = crud.metadata_sort.create_or_read(model=MetadataSortCreate(value=1), db=db)
+    assert obj1
+
+    # Ensure that you get the same object back if you try to create a duplicate value
+    obj2 = crud.metadata_sort.create_or_read(model=MetadataSortCreate(value=obj1.value), db=db)
+    assert obj2.description == obj1.description
+    assert obj2.uuid == obj1.uuid
+    assert obj2.value == obj1.value

--- a/db_api/app/tests/db_tests/crud/metadata_sort/test_delete.py
+++ b/db_api/app/tests/db_tests/crud/metadata_sort/test_delete.py
@@ -1,0 +1,19 @@
+from db import crud
+from tests import factory
+
+
+def test_delete(db):
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+    assert crud.metadata_sort.delete(uuid=obj.uuid, db=db) is True
+
+
+def test_unable_to_delete(db):
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    submission = factory.submission.create(db=db)
+    factory.observable.create_or_read(
+        type="type", value="value", parent_analysis=submission.root_analysis, sort=1, db=db
+    )
+
+    # You should not be able to delete it now that it is in use
+    assert crud.metadata_sort.delete(uuid=obj.uuid, db=db) is False

--- a/db_api/app/tests/db_tests/crud/metadata_sort/test_read.py
+++ b/db_api/app/tests/db_tests/crud/metadata_sort/test_read.py
@@ -1,0 +1,26 @@
+from db import crud
+from tests import factory
+
+
+def test_read_all(db):
+    obj1 = factory.metadata_sort.create_or_read(value=1, db=db)
+    obj2 = factory.metadata_sort.create_or_read(value=2, db=db)
+
+    result = crud.metadata_sort.read_all(db=db)
+    assert len(result) == 2
+    assert result[0].uuid == obj1.uuid
+    assert result[1].uuid == obj2.uuid
+
+
+def test_read_by_uuid(db):
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    result = crud.metadata_sort.read_by_uuid(uuid=obj.uuid, db=db)
+    assert result.uuid == obj.uuid
+
+
+def test_read_by_value(db):
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    result = crud.metadata_sort.read_by_value(value=obj.value, db=db)
+    assert result.uuid == obj.uuid

--- a/db_api/app/tests/db_tests/crud/metadata_sort/test_update.py
+++ b/db_api/app/tests/db_tests/crud/metadata_sort/test_update.py
@@ -1,0 +1,27 @@
+from api_models.metadata_sort import MetadataSortUpdate
+from db import crud
+from tests import factory
+
+
+def test_update(db):
+    obj = factory.metadata_sort.create_or_read(value=1, db=db)
+
+    assert obj.description is None
+    assert obj.value == 1
+
+    crud.metadata_sort.update(
+        uuid=obj.uuid,
+        model=MetadataSortUpdate(description="test description", value=2),
+        db=db,
+    )
+
+    assert obj.description == "test description"
+    assert obj.value == 2
+
+
+def test_update_duplicate_value(db):
+    obj1 = factory.metadata_sort.create_or_read(value=1, db=db)
+    obj2 = factory.metadata_sort.create_or_read(value=2, db=db)
+
+    result = crud.metadata_sort.update(uuid=obj2.uuid, model=MetadataSortUpdate(value=obj1.value), db=db)
+    assert result is False

--- a/db_api/app/tests/factory/__init__.py
+++ b/db_api/app/tests/factory/__init__.py
@@ -14,11 +14,12 @@ from tests.factory import metadata_detection_point
 from tests.factory import metadata_directive
 from tests.factory import metadata_display_type
 from tests.factory import metadata_display_value
+from tests.factory import metadata_sort
 from tests.factory import metadata_tag
 from tests.factory import metadata_time
+from tests.factory import observable
 from tests.factory import observable_relationship
 from tests.factory import observable_relationship_type
-from tests.factory import observable
 from tests.factory import observable_type
 from tests.factory import queue
 from tests.factory import submission

--- a/db_api/app/tests/factory/metadata_sort.py
+++ b/db_api/app/tests/factory/metadata_sort.py
@@ -1,0 +1,8 @@
+from sqlalchemy.orm import Session
+
+from api_models.metadata_sort import MetadataSortCreate
+from db import crud
+
+
+def create_or_read(value: int, db: Session):
+    return crud.metadata_sort.create_or_read(model=MetadataSortCreate(value=value), db=db)

--- a/db_api/app/tests/factory/observable.py
+++ b/db_api/app/tests/factory/observable.py
@@ -24,6 +24,7 @@ def create_or_read(
     expires_on: Optional[datetime] = None,
     for_detection: bool = False,
     history_username: Optional[str] = None,
+    sort: Optional[int] = None,
     tags: Optional[list[str]] = None,
     time: Optional[datetime] = None,
     whitelisted: bool = False,
@@ -53,6 +54,10 @@ def create_or_read(
     if display_value is not None:
         factory.metadata_display_value.create_or_read(value=display_value, db=db)
         metadata.append(AnalysisMetadataCreate(type="display_value", value=display_value))
+
+    if sort is not None:
+        factory.metadata_sort.create_or_read(value=sort, db=db)
+        metadata.append(AnalysisMetadataCreate(type="sort", value=sort))
 
     if tags is not None:
         for tag in tags:

--- a/frontend/src/models/analysisMetadata.ts
+++ b/frontend/src/models/analysisMetadata.ts
@@ -2,6 +2,7 @@ import { metadataDetectionPointRead } from "./metadataDetectionPoint";
 import { metadataDirectiveRead } from "./metadataDirective";
 import { metadataDisplayTypeRead } from "./metadataDisplayType";
 import { metadataDisplayValueRead } from "./metadataDisplayValue";
+import { metadataSortRead } from "./metadataSort";
 import { metadataTagRead } from "./metadataTag";
 import { metadataTimeRead } from "./metadataTime";
 
@@ -11,6 +12,7 @@ export interface analysisMetadataCreate {
     | "directive"
     | "display_type"
     | "display_value"
+    | "sort"
     | "tag"
     | "time";
   value: string;
@@ -21,6 +23,7 @@ export interface analysisMetadataRead {
   directives: metadataDirectiveRead[];
   displayType: metadataDisplayTypeRead | null;
   displayValue: metadataDisplayValueRead | null;
+  sort: metadataSortRead | null;
   tags: metadataTagRead[];
   time: metadataTimeRead | null;
 }

--- a/frontend/src/models/metadataSort.ts
+++ b/frontend/src/models/metadataSort.ts
@@ -1,0 +1,25 @@
+import { page, UUID } from "./base";
+
+export interface metadataSortCreate {
+  description?: string;
+  uuid?: UUID;
+  value: number;
+  [key: string]: unknown;
+}
+
+export interface metadataSortRead {
+  description: string | null;
+  metadataType: string;
+  uuid: UUID;
+  value: number;
+}
+
+export interface metadataSortReadPage extends page {
+  items: metadataSortRead[];
+}
+
+export interface metadataSortUpdate {
+  description?: string;
+  value?: number;
+  [key: string]: unknown;
+}

--- a/frontend/tests/mocks/analysisMetadata.ts
+++ b/frontend/tests/mocks/analysisMetadata.ts
@@ -5,6 +5,7 @@ export const analysisMetadataReadFactory = ({
   directives = [],
   displayType = null,
   displayValue = null,
+  sort = null,
   tags = [],
   time = null,
 }: Partial<analysisMetadataRead> = {}): analysisMetadataRead => ({
@@ -12,6 +13,7 @@ export const analysisMetadataReadFactory = ({
   directives: directives,
   displayType: displayType,
   displayValue: displayValue,
+  sort: sort,
   tags: tags,
   time: time,
 });


### PR DESCRIPTION
ACE 1.0 has a relatively recent feature that allows an analysis module to manually specify the order in which its child observables should be displayed when viewing the alert tree.

This PR implements that functionality by using the analysis metadata system to add a "sort object" to an observable. When viewing an alert tree, each analysis' child observables are sorted according to its analysis metadata sort value (if it exists). Otherwise, the "infinity" value is used.