### PR TITLE
Removes Constrained types since ConstrainedList caused errors

### DIFF
--- a/api_models/__init__.py
+++ b/api_models/__init__.py
@@ -1,4 +1,4 @@
-from pydantic import conint, conlist, constr, ConstrainedStr, ConstrainedInt
+from pydantic import conint, conlist, constr
 
 
 type_int = conint(strict=True)
@@ -6,12 +6,3 @@ type_int = conint(strict=True)
 type_str = constr(strict=True, min_length=1)
 
 type_list_str = conlist(type_str, min_items=1)
-
-
-class TypeInt(ConstrainedInt):
-    strict = True
-
-
-class TypeStr(ConstrainedStr):
-    min_length = 1
-    strict = True

--- a/api_models/analysis_metadata.py
+++ b/api_models/analysis_metadata.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from pydantic import BaseModel, Field, UUID4
 from typing import Optional, Union
 
-from api_models import TypeInt, type_str
+from api_models import type_int, type_str
 from api_models.metadata_detection_point import MetadataDetectionPointRead
 from api_models.metadata_directive import MetadataDirectiveRead
 from api_models.metadata_display_type import MetadataDisplayTypeRead
@@ -25,7 +25,7 @@ class AnalysisMetadataCreate(BaseModel):
 
     type: type_str = Field(description="The type of the metadata")
 
-    value: Union[TypeInt, type_str, datetime] = Field(description="The value of the metadata")
+    value: Union[type_int, type_str, datetime] = Field(description="The value of the metadata")
 
 
 class AnalysisMetadataRead(BaseModel):

--- a/api_models/metadata.py
+++ b/api_models/metadata.py
@@ -1,7 +1,7 @@
 from pydantic import BaseModel, Field, UUID4
 from uuid import uuid4
 
-from api_models import TypeStr
+from api_models import type_str
 
 
 class MetadataBase(BaseModel):
@@ -16,7 +16,7 @@ class MetadataCreate(MetadataBase):
 
 class MetadataRead(MetadataBase):
 
-    metadata_type: TypeStr = Field(description="The type of the metadata")
+    metadata_type: type_str = Field(description="The type of the metadata")
 
     uuid: UUID4 = Field(description="The UUID of the metadata")
 

--- a/api_models/metadata_sort.py
+++ b/api_models/metadata_sort.py
@@ -2,24 +2,24 @@ from pydantic import BaseModel, Field, UUID4
 from typing import Optional
 from uuid import uuid4
 
-from api_models import TypeInt, TypeStr, validators
+from api_models import type_int, type_str, validators
 from api_models.metadata import MetadataRead
 
 
 class MetadataSortCreate(BaseModel):
-    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+    description: Optional[type_str] = Field(description="An optional human-readable description of the sort")
 
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the sort")
 
-    value: TypeInt = Field(description="The value of the sort")
+    value: type_int = Field(description="The value of the sort")
 
 
 class MetadataSortRead(MetadataRead):
-    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+    description: Optional[type_str] = Field(description="An optional human-readable description of the sort")
 
     uuid: UUID4 = Field(description="The UUID of the sort")
 
-    value: TypeInt = Field(description="The value of the sort")
+    value: type_int = Field(description="The value of the sort")
 
     class Config:
         orm_mode = True
@@ -29,8 +29,8 @@ class MetadataSortRead(MetadataRead):
 
 
 class MetadataSortUpdate(BaseModel):
-    description: Optional[TypeStr] = Field(description="An optional human-readable description of the sort")
+    description: Optional[type_str] = Field(description="An optional human-readable description of the sort")
 
-    value: Optional[TypeInt] = Field(description="The value of the sort")
+    value: Optional[type_int] = Field(description="The value of the sort")
 
     _prevent_none: classmethod = validators.prevent_none("value")


### PR DESCRIPTION
This PR removes some recent changes made that introduced new custom Pydantic types (in an attempt to be compatible with mypy) that inherited from `ConstrainedInt`, `ConstrainedStr`, and `ConstrainedList`... the `ConstrainedList` one caused weird issues, so this just fully reverts back to the original setup.