### PR TITLE
support proxy access during image builds

### DIFF
--- a/db_api/Dockerfile
+++ b/db_api/Dockerfile
@@ -1,7 +1,14 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
 COPY db_api/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
 
 COPY db_api/app/ /app
 COPY api_models/ /app/api_models

--- a/db_api/Dockerfile
+++ b/db_api/Dockerfile
@@ -3,12 +3,14 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG pip_install_options
+
 ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 ENV no_proxy=$no_proxy
 
 COPY db_api/requirements.txt .
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
+RUN pip install -r requirements.txt ${pip_install_options}
 
 COPY db_api/app/ /app
 COPY api_models/ /app/api_models

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,11 @@ services:
     build:
       context: ./
       dockerfile: ./db_api/Dockerfile
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        pip_install_options: ${pip_install_options}
     environment:
       # The DATABASE_URL environment variable needs to be in the form of:
       # postgresql://<user>:<password>@db:5432/<database>
@@ -45,6 +50,11 @@ services:
     build:
       context: ./
       dockerfile: ./gui_api/Dockerfile
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        pip_install_options: ${pip_install_options}
     environment:
       # The DATABASE_URL environment variable needs to be in the form of:
       # postgresql://<user>:<password>@db:5432/<database>
@@ -71,6 +81,12 @@ services:
     build:
       context: ./frontend
       dockerfile: ./Dockerfile.dev
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy}
+        https_proxy: ${https_proxy}
+        pip_install_options: ${pip_install_options}
+        npm_strict_ssl: ${npm_strict_ssl:-true}
     environment:
       - DATABASE_TEST_URL=${DATABASE_TEST_URL}
       - VITE_BACKEND_URL=http://ace2-ams:8080/api/

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -36,6 +36,24 @@ Add the following entry to the file:
 127.0.0.1 ace2-ams
 ```
 
+## Building behind a proxy
+
+If you are in an environment where a proxy is enforced then you will need to create a file in the root project directory called `.env` with the following contents.
+
+```
+http_proxy=http://your.proxy:port
+https_proxy=http://your.proxy:port
+```
+
+If your proxy breaks SSL (if you are getting some kind of an SSL error) then you will also need to ignore SSL warnings.
+
+```
+http_proxy=http://your.proxy:port
+https_proxy=http://your.proxy:port
+pip_install_options=--trusted-host pypi.org --trusted-host files.pythonhosted.org
+npm_strict_ssl=false
+```
+
 ## Starting the application
 
 You can start the application using Docker containers so that it uses hot-reloading anytime you change a file:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,23 @@
 # BUILD STAGE
 FROM node:16-alpine as builder
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
 WORKDIR /app
 
 COPY package*.json .
 
 RUN apk --no-cache add --virtual native-deps \
   g++ gcc libgcc libstdc++ linux-headers make python && \
-  npm install --quiet node-gyp -g && \
-  npm install --quiet && \
+  npm config set strict-ssl false && \
+  npm config set registry "http://registry.npmjs.org/"
+  npm install --proxy "$http_proxy" node-gyp -g && \
+  npm install --proxy "$http_proxy" && \
   apk del native-deps
 
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,6 +4,8 @@ FROM node:16-alpine as builder
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG npm_strict_ssl=true
+
 ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 ENV no_proxy=$no_proxy
@@ -13,11 +15,11 @@ WORKDIR /app
 COPY package*.json .
 
 RUN apk --no-cache add --virtual native-deps \
-  g++ gcc libgcc libstdc++ linux-headers make python && \
-  npm config set strict-ssl false && \
-  npm config set registry "http://registry.npmjs.org/"
-  npm install --proxy "$http_proxy" node-gyp -g && \
-  npm install --proxy "$http_proxy" && \
+  g++ gcc libgcc libstdc++ linux-headers make python 
+
+RUN npm config set strict-ssl ${npm_strict_ssl} && \
+  npm install node-gyp -g && \
+  npm install && \
   apk del native-deps
 
 COPY . .

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -1,12 +1,22 @@
 FROM cypress/included:10.3.0
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
 RUN apt-get install -y curl
 
 WORKDIR /app
 
 COPY package*.json ./
 
-RUN npm install
+RUN \
+  npm config set strict-ssl && \
+  npm config set registry "http://registry.npmjs.org/" && \
+  npm install --proxy "$http_proxy"
 
 COPY . .
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -3,6 +3,8 @@ FROM cypress/included:10.3.0
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG npm_strict_ssl=true
+
 ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 ENV no_proxy=$no_proxy
@@ -13,10 +15,7 @@ WORKDIR /app
 
 COPY package*.json ./
 
-RUN \
-  npm config set strict-ssl && \
-  npm config set registry "http://registry.npmjs.org/" && \
-  npm install --proxy "$http_proxy"
+RUN npm config set strict-ssl ${npm_strict_ssl} && npm install 
 
 COPY . .
 

--- a/gui_api/Dockerfile
+++ b/gui_api/Dockerfile
@@ -3,12 +3,14 @@ FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
+ARG pip_install_options
+
 ENV http_proxy=$http_proxy
 ENV https_proxy=$https_proxy
 ENV no_proxy=$no_proxy
 
 COPY gui_api/requirements.txt .
-RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
+RUN pip install -r requirements.txt ${pip_install_options}
 
 COPY gui_api/app/ /app
 COPY api_models/ /app/api_models

--- a/gui_api/Dockerfile
+++ b/gui_api/Dockerfile
@@ -1,7 +1,14 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
 
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
 COPY gui_api/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install --trusted-host pypi.org --trusted-host files.pythonhosted.org -r requirements.txt
 
 COPY gui_api/app/ /app
 COPY api_models/ /app/api_models


### PR DESCRIPTION
For those of us behind corporate firewalls. Allows the use of .env files to control these optional settings.