### PR TITLE
Analysis summary details

### DIFF
--- a/api_models/analysis.py
+++ b/api_models/analysis.py
@@ -5,6 +5,7 @@ from uuid import uuid4
 
 from api_models import type_str
 from api_models.analysis_module_type import AnalysisModuleTypeRead, AnalysisModuleTypeSubmissionTreeRead
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreateInAnalysis, AnalysisSummaryDetailRead
 
 
 class AnalysisBase(BaseModel):
@@ -33,6 +34,10 @@ class AnalysisCreateBase(AnalysisBase):
     )
 
     submission_uuid: UUID4 = Field(description="The UUID of the submission that will contain this analysis")
+
+    summary_details: list[AnalysisSummaryDetailCreateInAnalysis] = Field(
+        default_factory=list, description="A list of summary details to add to the analysis"
+    )
 
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the analysis")
 
@@ -65,6 +70,10 @@ class AnalysisRead(AnalysisBase):
 
     run_time: datetime = Field(description="The time at which the analysis was performed")
 
+    summary_details: list[AnalysisSummaryDetailRead] = Field(
+        default_factory=list, description="A list of summary details added to the analysis"
+    )
+
     uuid: UUID4 = Field(description="The UUID of the analysis")
 
     class Config:
@@ -88,6 +97,10 @@ class AnalysisSubmissionTreeRead(BaseModel):
 
     # Set a static string value so code displaying the tree structure knows which type of object this is.
     object_type: str = "analysis"
+
+    summary_details: list[AnalysisSummaryDetailRead] = Field(
+        default_factory=list, description="A list of summary details added to the analysis"
+    )
 
     uuid: UUID4 = Field(description="The UUID of the analysis")
 

--- a/api_models/analysis_summary_detail.py
+++ b/api_models/analysis_summary_detail.py
@@ -1,0 +1,41 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api_models import type_str, validators
+from api_models.format import FormatRead
+
+
+class AnalysisSummaryDetailCreate(BaseModel):
+    analysis_uuid: UUID4 = Field(description="The analysis UUID that should receive this summary detail")
+
+    content: type_str = Field(description="The content of the analysis summary detail")
+
+    format: type_str = Field(description="The format to use when displaying in the GUI")
+
+    header: type_str = Field(description="The header or title of the analysis summary detail")
+
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the analysis summary detail")
+
+
+class AnalysisSummaryDetailRead(BaseModel):
+    uuid: UUID4 = Field(description="The UUID of the analysis summary detail")
+
+    content: type_str = Field(description="The content of the analysis summary detail")
+
+    format: FormatRead = Field(description="The format to use when displaying in the GUI")
+
+    header: type_str = Field(description="The header or title of the analysis summary detail")
+
+    class Config:
+        orm_mode = True
+
+
+class AnalysisSummaryDetailUpdate(BaseModel):
+    content: Optional[type_str] = Field(description="The content of the analysis summary detail")
+
+    format: Optional[type_str] = Field(description="The format to use when displaying in the GUI")
+
+    header: Optional[type_str] = Field(description="The header or title of the analysis summary detail")
+
+    _prevent_none: classmethod = validators.prevent_none("content", "format", "header")

--- a/api_models/analysis_summary_detail.py
+++ b/api_models/analysis_summary_detail.py
@@ -6,9 +6,7 @@ from api_models import type_str, validators
 from api_models.format import FormatRead
 
 
-class AnalysisSummaryDetailCreate(BaseModel):
-    analysis_uuid: UUID4 = Field(description="The analysis UUID that should receive this summary detail")
-
+class AnalysisSummaryDetailCreateBase(BaseModel):
     content: type_str = Field(description="The content of the analysis summary detail")
 
     format: type_str = Field(description="The format to use when displaying in the GUI")
@@ -16,6 +14,14 @@ class AnalysisSummaryDetailCreate(BaseModel):
     header: type_str = Field(description="The header or title of the analysis summary detail")
 
     uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the analysis summary detail")
+
+
+class AnalysisSummaryDetailCreate(AnalysisSummaryDetailCreateBase):
+    analysis_uuid: UUID4 = Field(description="The analysis UUID that should receive this summary detail")
+
+
+class AnalysisSummaryDetailCreateInAnalysis(AnalysisSummaryDetailCreateBase):
+    pass
 
 
 class AnalysisSummaryDetailRead(BaseModel):

--- a/api_models/format.py
+++ b/api_models/format.py
@@ -1,0 +1,30 @@
+from pydantic import BaseModel, Field, UUID4
+from typing import Optional
+from uuid import uuid4
+
+from api_models import type_str, validators
+
+
+class FormatBase(BaseModel):
+    """Represents a format used to inform a GUI how an item is intended to be displayed."""
+
+    description: Optional[type_str] = Field(description="An optional human-readable description of the format")
+
+    value: type_str = Field(description="The value of the format")
+
+
+class FormatCreate(FormatBase):
+    uuid: UUID4 = Field(default_factory=uuid4, description="The UUID of the format")
+
+
+class FormatRead(FormatBase):
+    uuid: UUID4 = Field(description="The UUID of the format")
+
+    class Config:
+        orm_mode = True
+
+
+class FormatUpdate(FormatBase):
+    value: Optional[type_str] = Field(description="The value of the format")
+
+    _prevent_none: classmethod = validators.prevent_none("value")

--- a/db_api/app/api/routes/__init__.py
+++ b/db_api/app/api/routes/__init__.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter
 from api.routes.alert_disposition import router as alert_disposition_router
 from api.routes.analysis import router as analysis_router
 from api.routes.analysis_module_type import router as analysis_module_type_router
+from api.routes.analysis_summary_detail import router as analysis_summary_detail_router
 from api.routes.auth import router as auth_router
 from api.routes.event import router as event_router
 from api.routes.event_comment import router as event_comment_router
@@ -13,6 +14,7 @@ from api.routes.event_source import router as event_source_router
 from api.routes.event_status import router as event_status_router
 from api.routes.event_type import router as event_type_router
 from api.routes.event_vector import router as event_vector_router
+from api.routes.format import router as format_router
 from api.routes.metadata_detection_point import router as metadata_detection_point_router
 from api.routes.metadata_directive import router as metadata_directive_router
 from api.routes.metadata_display_type import router as metadata_display_type_router
@@ -44,6 +46,7 @@ router = APIRouter()
 router.include_router(alert_disposition_router)
 router.include_router(analysis_module_type_router)
 router.include_router(analysis_router)
+router.include_router(analysis_summary_detail_router)
 router.include_router(auth_router)
 router.include_router(event_comment_router)
 router.include_router(event_prevention_tool_router)
@@ -54,6 +57,7 @@ router.include_router(event_source_router)
 router.include_router(event_status_router)
 router.include_router(event_type_router)
 router.include_router(event_vector_router)
+router.include_router(format_router)
 router.include_router(metadata_detection_point_router)
 router.include_router(metadata_directive_router)
 router.include_router(metadata_display_type_router)

--- a/db_api/app/api/routes/analysis_summary_detail.py
+++ b/db_api/app/api/routes/analysis_summary_detail.py
@@ -1,0 +1,108 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from api.routes import helpers
+from api_models.analysis_summary_detail import (
+    AnalysisSummaryDetailCreate,
+    AnalysisSummaryDetailRead,
+    AnalysisSummaryDetailUpdate,
+)
+from db import crud
+from db.database import get_db
+from exceptions.db import UuidNotFoundInDatabase, ValueNotFoundInDatabase
+
+
+router = APIRouter(
+    prefix="/analysis/summary_detail",
+    tags=["Analysis Summary Detail"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_analysis_summary_details(
+    analysis_summary_details: list[AnalysisSummaryDetailCreate],
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    for analysis_summary_detail in analysis_summary_details:
+        try:
+            obj = crud.analysis_summary_detail.create_or_read(model=analysis_summary_detail, db=db)
+        except (UuidNotFoundInDatabase, ValueNotFoundInDatabase) as e:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+        response.headers["Content-Location"] = request.url_for("get_analysis_summary_detail", uuid=obj.uuid)
+
+    db.commit()
+
+
+helpers.api_route_create(router, create_analysis_summary_details)
+
+
+#
+# READ
+#
+
+
+def get_analysis_summary_detail(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        return crud.analysis_summary_detail.read_by_uuid(uuid=uuid, db=db)
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=f"Analysis summary detail {uuid} does not exist"
+        ) from e
+
+
+helpers.api_route_read(router, get_analysis_summary_detail, AnalysisSummaryDetailRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_analysis_summary_detail(
+    uuid: UUID,
+    analysis_summary_detail: AnalysisSummaryDetailUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    try:
+        if not crud.analysis_summary_detail.update(uuid=uuid, model=analysis_summary_detail, db=db):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unable to update analysis summary detail {uuid}"
+            )
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+    except ValueNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+    response.headers["Content-Location"] = request.url_for("get_analysis_summary_detail", uuid=uuid)
+
+
+helpers.api_route_update(router, update_analysis_summary_detail)
+
+
+#
+# DELETE
+#
+
+
+def delete_analysis_summary_detail(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        crud.analysis_summary_detail.delete(uuid=uuid, db=db)
+    except (UuidNotFoundInDatabase, ValueNotFoundInDatabase) as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+
+helpers.api_route_delete(router, delete_analysis_summary_detail)

--- a/db_api/app/api/routes/format.py
+++ b/db_api/app/api/routes/format.py
@@ -1,0 +1,101 @@
+from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from fastapi_pagination.ext.sqlalchemy_future import paginate
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from api.routes import helpers
+from api_models.format import FormatCreate, FormatRead, FormatUpdate
+from db import crud
+from db.database import get_db
+from db.schemas.format import Format
+from exceptions.db import UuidNotFoundInDatabase
+
+
+router = APIRouter(
+    prefix="/format",
+    tags=["Format"],
+)
+
+
+#
+# CREATE
+#
+
+
+def create_format(
+    create: FormatCreate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    obj = crud.format.create_or_read(model=create, db=db)
+    db.commit()
+
+    response.headers["Content-Location"] = request.url_for("get_format", uuid=obj.uuid)
+
+
+helpers.api_route_create(router, create_format)
+
+
+#
+# READ
+#
+
+
+def get_all_formats(db: Session = Depends(get_db)):
+    return paginate(conn=db, query=crud.format.build_read_all_query())
+
+
+def get_format(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        return crud.format.read_by_uuid(uuid=uuid, db=db)
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+
+helpers.api_route_read_all(router, get_all_formats, FormatRead)
+helpers.api_route_read(router, get_format, FormatRead)
+
+
+#
+# UPDATE
+#
+
+
+def update_format(
+    uuid: UUID,
+    observable_relationship: FormatUpdate,
+    request: Request,
+    response: Response,
+    db: Session = Depends(get_db),
+):
+    try:
+        if not crud.helpers.update(uuid=uuid, update_model=observable_relationship, db_table=Format, db=db):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unable to update format {uuid}")
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+    response.headers["Content-Location"] = request.url_for("get_format", uuid=uuid)
+
+
+helpers.api_route_update(router, update_format)
+
+
+#
+# DELETE
+#
+
+
+def delete_format(uuid: UUID, db: Session = Depends(get_db)):
+    try:
+        if not crud.helpers.delete(uuid=uuid, db_table=Format, db=db):
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=f"Unable to delete format {uuid}")
+    except UuidNotFoundInDatabase as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e)) from e
+
+    db.commit()
+
+
+helpers.api_route_delete(router, delete_format)

--- a/db_api/app/db/crud/__init__.py
+++ b/db_api/app/db/crud/__init__.py
@@ -2,6 +2,7 @@ from db.crud import alert_disposition
 from db.crud import analysis
 from db.crud import analysis_metadata
 from db.crud import analysis_module_type
+from db.crud import analysis_summary_detail
 from db.crud import event
 from db.crud import event_comment
 from db.crud import event_prevention_tool
@@ -11,6 +12,7 @@ from db.crud import event_source
 from db.crud import event_status
 from db.crud import event_type
 from db.crud import event_vector
+from db.crud import format
 from db.crud import helpers
 from db.crud import history
 from db.crud import metadata_detection_point

--- a/db_api/app/db/crud/analysis.py
+++ b/db_api/app/db/crud/analysis.py
@@ -12,6 +12,7 @@ from api_models.analysis_details import (
     SandboxAnalysisDetails,
     UserAnalysisDetails,
 )
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreate
 from db import crud
 from db.schemas.analysis import Analysis
 from db.schemas.analysis_module_type import AnalysisModuleType
@@ -56,6 +57,12 @@ def create_or_read(model: AnalysisCreate, db: Session) -> Analysis:
     obj.child_observables = [
         crud.observable.create_or_read(model=co, parent_analysis=obj, db=db) for co in model.child_observables
     ]
+
+    # Add any summary details that were given
+    for summary_detail in model.summary_details:
+        crud.analysis_summary_detail.create_or_read(
+            model=AnalysisSummaryDetailCreate(analysis_uuid=obj.uuid, **summary_detail.dict()), db=db
+        )
 
     # Associate the analysis with its submission
     crud.submission_analysis_mapping.create(analysis_uuid=obj.uuid, submission_uuid=model.submission_uuid, db=db)

--- a/db_api/app/db/crud/analysis_summary_detail.py
+++ b/db_api/app/db/crud/analysis_summary_detail.py
@@ -3,17 +3,18 @@ from sqlalchemy.exc import IntegrityError, NoResultFound
 from sqlalchemy.orm import Session
 from uuid import UUID
 
-from api_models.analysis_summary_detail import AnalysisSummaryDetailCreate, AnalysisSummaryDetailUpdate
+from api_models.analysis_summary_detail import (
+    AnalysisSummaryDetailCreate,
+    AnalysisSummaryDetailUpdate,
+)
 from db import crud
-from db.schemas.analysis import Analysis
 from db.schemas.analysis_summary_detail import AnalysisSummaryDetail
 from exceptions.db import ValueNotFoundInDatabase
 
 
-def create_or_read(model: AnalysisSummaryDetailCreate, db: Session, analysis: Analysis = None) -> AnalysisSummaryDetail:
-    # Make sure the analysis exists if one was not passed in
-    if analysis is None:
-        analysis = crud.analysis.read_by_uuid(uuid=model.analysis_uuid, db=db)
+def create_or_read(model: AnalysisSummaryDetailCreate, db: Session) -> AnalysisSummaryDetail:
+    # Make sure the analysis exists
+    analysis = crud.analysis.read_by_uuid(uuid=model.analysis_uuid, db=db)
 
     obj = AnalysisSummaryDetail(
         analysis_uuid=analysis.uuid,
@@ -24,7 +25,7 @@ def create_or_read(model: AnalysisSummaryDetailCreate, db: Session, analysis: An
     )
 
     if crud.helpers.create(obj=obj, db=db):
-        # Refresh the analysis object so that its summary_details relationship is updated
+        # Refresh the analysis object so its summary_details relationship is updated
         db.refresh(analysis)
 
         return obj

--- a/db_api/app/db/crud/analysis_summary_detail.py
+++ b/db_api/app/db/crud/analysis_summary_detail.py
@@ -1,0 +1,89 @@
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError, NoResultFound
+from sqlalchemy.orm import Session
+from uuid import UUID
+
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreate, AnalysisSummaryDetailUpdate
+from db import crud
+from db.schemas.analysis import Analysis
+from db.schemas.analysis_summary_detail import AnalysisSummaryDetail
+from exceptions.db import ValueNotFoundInDatabase
+
+
+def create_or_read(model: AnalysisSummaryDetailCreate, db: Session, analysis: Analysis = None) -> AnalysisSummaryDetail:
+    # Make sure the analysis exists if one was not passed in
+    if analysis is None:
+        analysis = crud.analysis.read_by_uuid(uuid=model.analysis_uuid, db=db)
+
+    obj = AnalysisSummaryDetail(
+        analysis_uuid=analysis.uuid,
+        content=model.content,
+        header=model.header,
+        format=crud.format.read_by_value(value=model.format, db=db),
+        uuid=model.uuid,
+    )
+
+    if crud.helpers.create(obj=obj, db=db):
+        # Refresh the analysis object so that its summary_details relationship is updated
+        db.refresh(analysis)
+
+        return obj
+
+    return read_by_analysis_header_content(
+        analysis_uuid=analysis.uuid, header=model.header, content=model.content, db=db
+    )
+
+
+def delete(uuid: UUID, db: Session) -> bool:
+    return crud.helpers.delete(uuid=uuid, db_table=AnalysisSummaryDetail, db=db)
+
+
+def read_by_uuid(uuid: UUID, db: Session) -> AnalysisSummaryDetail:
+    return crud.helpers.read_by_uuid(db_table=AnalysisSummaryDetail, uuid=uuid, db=db)
+
+
+def read_by_analysis_header_content(
+    analysis_uuid: UUID, header: str, content: str, db: Session
+) -> AnalysisSummaryDetail:
+    try:
+        return (
+            db.execute(
+                select(AnalysisSummaryDetail).where(
+                    AnalysisSummaryDetail.analysis_uuid == analysis_uuid,
+                    AnalysisSummaryDetail.header == header,
+                    AnalysisSummaryDetail.content == content,
+                )
+            )
+            .scalars()
+            .one()
+        )
+    except NoResultFound as e:
+        raise ValueNotFoundInDatabase(
+            f"The '{header}': '{content}' summary detail for analysis {analysis_uuid} was not found in the {AnalysisSummaryDetail.__tablename__} table."
+        ) from e
+
+
+def update(uuid: UUID, model: AnalysisSummaryDetailUpdate, db: Session) -> bool:
+    with db.begin_nested():
+        # Read the current object
+        obj = read_by_uuid(uuid=uuid, db=db)
+
+        # Get the data that was given in the request and use it to update the database object
+        update_data = model.dict(exclude_unset=True)
+
+        if "content" in update_data:
+            obj.content = update_data["content"]
+
+        if "format" in update_data:
+            obj.format = crud.format.read_by_value(value=update_data["format"], db=db)
+
+        if "header" in update_data:
+            obj.header = update_data["header"]
+
+        # Try to flush the changes to the database
+        try:
+            db.flush()
+            return True
+        except IntegrityError:
+            db.rollback()
+            return False

--- a/db_api/app/db/crud/format.py
+++ b/db_api/app/db/crud/format.py
@@ -1,0 +1,41 @@
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+from sqlalchemy.sql.selectable import Select
+from uuid import UUID
+
+from api_models.format import FormatCreate, FormatUpdate
+from db import crud
+from db.schemas.format import Format
+
+
+def build_read_all_query() -> Select:
+    return select(Format).order_by(Format.value)
+
+
+def create_or_read(model: FormatCreate, db: Session) -> Format:
+    obj = Format(description=model.description, uuid=model.uuid, value=model.value)
+
+    if crud.helpers.create(obj=obj, db=db):
+        return obj
+
+    return read_by_value(value=model.value, db=db)
+
+
+def delete(uuid: UUID, db: Session) -> bool:
+    return crud.helpers.delete(uuid=uuid, db_table=Format, db=db)
+
+
+def read_all(db: Session) -> list[Format]:
+    return db.execute(build_read_all_query()).scalars().all()
+
+
+def read_by_uuid(uuid: UUID, db: Session) -> Format:
+    return crud.helpers.read_by_uuid(db_table=Format, uuid=uuid, db=db)
+
+
+def read_by_value(value: str, db: Session) -> Format:
+    return crud.helpers.read_by_value(db_table=Format, value=value, db=db)
+
+
+def update(uuid: UUID, model: FormatUpdate, db: Session) -> bool:
+    return crud.helpers.update(uuid=uuid, update_model=model, db_table=Format, db=db)

--- a/db_api/app/db/migrations/versions/366f824ad8c2_initial.py
+++ b/db_api/app/db/migrations/versions/366f824ad8c2_initial.py
@@ -1,8 +1,8 @@
 """Initial
 
-Revision ID: 51170f8e158b
+Revision ID: 366f824ad8c2
 Revises: 
-Create Date: 2022-07-07 15:34:37.907297
+Create Date: 2022-07-12 11:51:34.502426
 """
 
 from alembic import op
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic
-revision = '51170f8e158b'
+revision = '366f824ad8c2'
 down_revision = None
 branch_labels = None
 depends_on = None
@@ -90,6 +90,13 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('uuid')
     )
     op.create_index(op.f('ix_event_vector_value'), 'event_vector', ['value'], unique=True)
+    op.create_table('format',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('description', sa.String(), nullable=True),
+    sa.Column('value', sa.String(), nullable=False),
+    sa.PrimaryKeyConstraint('uuid')
+    )
+    op.create_index(op.f('ix_format_value'), 'format', ['value'], unique=True)
     op.create_table('metadata',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('metadata_type', sa.String(), nullable=True),
@@ -517,6 +524,18 @@ def upgrade() -> None:
     sa.PrimaryKeyConstraint('analysis_uuid', 'observable_uuid', 'metadata_uuid')
     )
     op.create_index(op.f('ix_analysis_metadata_analysis_uuid'), 'analysis_metadata', ['analysis_uuid'], unique=False)
+    op.create_table('analysis_summary_detail',
+    sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
+    sa.Column('analysis_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('content', sa.String(), nullable=False),
+    sa.Column('format_uuid', postgresql.UUID(as_uuid=True), nullable=False),
+    sa.Column('header', sa.String(), nullable=False),
+    sa.ForeignKeyConstraint(['analysis_uuid'], ['analysis.uuid'], ),
+    sa.ForeignKeyConstraint(['format_uuid'], ['format.uuid'], ),
+    sa.PrimaryKeyConstraint('uuid'),
+    sa.UniqueConstraint('analysis_uuid', 'header', 'content', name='analysis_header_content_uc')
+    )
+    op.create_index(op.f('ix_analysis_summary_detail_analysis_uuid'), 'analysis_summary_detail', ['analysis_uuid'], unique=False)
     op.create_table('event_comment',
     sa.Column('uuid', postgresql.UUID(as_uuid=True), server_default=sa.text('gen_random_uuid()'), nullable=False),
     sa.Column('insert_time', sa.DateTime(), server_default=sa.text("TIMEZONE('utc', CURRENT_TIMESTAMP)"), nullable=True),
@@ -747,6 +766,8 @@ def downgrade() -> None:
     op.drop_index(op.f('ix_event_comment_event_uuid'), table_name='event_comment')
     op.drop_index('event_comment_value_trgm', table_name='event_comment', postgresql_ops={'value': 'gin_trgm_ops'}, postgresql_using='gin')
     op.drop_table('event_comment')
+    op.drop_index(op.f('ix_analysis_summary_detail_analysis_uuid'), table_name='analysis_summary_detail')
+    op.drop_table('analysis_summary_detail')
     op.drop_index(op.f('ix_analysis_metadata_analysis_uuid'), table_name='analysis_metadata')
     op.drop_table('analysis_metadata')
     op.drop_index(op.f('ix_analysis_child_observable_mapping_observable_uuid'), table_name='analysis_child_observable_mapping')
@@ -863,6 +884,8 @@ def downgrade() -> None:
     op.drop_index(op.f('ix_observable_relationship_type_value'), table_name='observable_relationship_type')
     op.drop_table('observable_relationship_type')
     op.drop_table('metadata')
+    op.drop_index(op.f('ix_format_value'), table_name='format')
+    op.drop_table('format')
     op.drop_index(op.f('ix_event_vector_value'), table_name='event_vector')
     op.drop_table('event_vector')
     op.drop_index(op.f('ix_event_type_value'), table_name='event_type')

--- a/db_api/app/db/schemas/__init__.py
+++ b/db_api/app/db/schemas/__init__.py
@@ -6,6 +6,7 @@ from db.schemas.analysis_module_type import AnalysisModuleType
 from db.schemas.analysis_module_type_directive_mapping import analysis_module_type_directive_mapping
 from db.schemas.analysis_module_type_observable_type_mapping import analysis_module_type_observable_type_mapping
 from db.schemas.analysis_module_type_tag_mapping import analysis_module_type_tag_mapping
+from db.schemas.analysis_summary_detail import AnalysisSummaryDetail
 from db.schemas.event import Event
 from db.schemas.event_comment import EventComment
 from db.schemas.event_prevention_tool import EventPreventionTool
@@ -28,6 +29,7 @@ from db.schemas.event_type_queue_mapping import event_type_queue_mapping
 from db.schemas.event_vector import EventVector
 from db.schemas.event_vector_queue_mapping import event_vector_queue_mapping
 from db.schemas.event_vector_mapping import event_vector_mapping
+from db.schemas.format import Format
 from db.schemas.metadata import Metadata
 from db.schemas.metadata_detection_point import MetadataDetectionPoint
 from db.schemas.metadata_directive import MetadataDirective

--- a/db_api/app/db/schemas/analysis.py
+++ b/db_api/app/db/schemas/analysis.py
@@ -40,6 +40,8 @@ class Analysis(Base):
 
     summary = Column(String)
 
+    summary_details: "list[AnalysisSummaryDetail]" = relationship("AnalysisSummaryDetail", lazy="selectin")
+
     # An analysis with NULL for analysis_module_type_uuid and target_uuid signifies it is a Root Analysis
     target_uuid = Column(UUID(as_uuid=True), ForeignKey("observable.uuid"), nullable=True)
 
@@ -71,3 +73,6 @@ class Analysis(Base):
 
     def convert_to_pydantic(self) -> AnalysisSubmissionTreeRead:
         return AnalysisSubmissionTreeRead(**self.__dict__)
+
+
+from db.schemas.analysis_summary_detail import AnalysisSummaryDetail

--- a/db_api/app/db/schemas/analysis_summary_detail.py
+++ b/db_api/app/db/schemas/analysis_summary_detail.py
@@ -1,0 +1,24 @@
+from sqlalchemy import Column, ForeignKey, func, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+
+from db.database import Base
+from db.schemas.format import Format
+
+
+class AnalysisSummaryDetail(Base):
+    __tablename__ = "analysis_summary_detail"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    analysis_uuid = Column(UUID(as_uuid=True), ForeignKey("analysis.uuid"), index=True, nullable=False)
+
+    content = Column(String, nullable=False)
+
+    format_uuid = Column(UUID(as_uuid=True), ForeignKey("format.uuid"), nullable=False)
+
+    format: Format = relationship("Format", foreign_keys=[format_uuid], lazy="selectin")
+
+    header = Column(String, nullable=False)
+
+    __table_args__ = (UniqueConstraint("analysis_uuid", "header", "content", name="analysis_header_content_uc"),)

--- a/db_api/app/db/schemas/format.py
+++ b/db_api/app/db/schemas/format.py
@@ -1,0 +1,14 @@
+from sqlalchemy import func, Column, String
+from sqlalchemy.dialects.postgresql import UUID
+
+from db.database import Base
+
+
+class Format(Base):
+    __tablename__ = "format"
+
+    uuid = Column(UUID(as_uuid=True), primary_key=True, server_default=func.gen_random_uuid())
+
+    description = Column(String)
+
+    value = Column(String, nullable=False, unique=True, index=True)

--- a/db_api/app/tests/api_tests/analysis_summary_detail/test_create.py
+++ b/db_api/app/tests/api_tests/analysis_summary_detail/test_create.py
@@ -1,0 +1,132 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("analysis_uuid", None),
+        ("analysis_uuid", 1),
+        ("analysis_uuid", "abc"),
+        ("analysis_uuid", ""),
+        ("content", 123),
+        ("content", None),
+        ("content", ""),
+        ("format", 123),
+        ("format", None),
+        ("format", ""),
+        ("header", 123),
+        ("header", None),
+        ("header", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+    ],
+)
+def test_create_invalid_fields(client, key, value):
+    create_json = [
+        {
+            "analysis_uuid": str(uuid.uuid4()),
+            "content": "test",
+            "format": "PRE",
+            "header": "test",
+            key: value,
+        }
+    ]
+    create = client.post("/api/analysis/summary_detail/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("analysis_uuid"),
+        ("content"),
+        ("format"),
+        ("header"),
+    ],
+)
+def test_create_missing_required_fields(client, key):
+    create_json = [{"analysis_uuid": str(uuid.uuid4()), "content": "test", "format": "PRE", "header": "test"}]
+    del create_json[0][key]
+    create = client.post("/api/analysis/summary_detail/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_create_nonexistent_analysis_uuid(client, db):
+    factory.format.create_or_read(value="PRE", db=db)
+
+    create_json = [{"analysis_uuid": str(uuid.uuid4()), "content": "test", "format": "PRE", "header": "test"}]
+    create = client.post("/api/analysis/summary_detail/", json=create_json)
+    assert create.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_create_nonexistent_format(client, db):
+    submission = factory.submission.create(db=db)
+
+    create_json = [
+        {"analysis_uuid": str(submission.root_analysis_uuid), "content": "test", "format": "PRE", "header": "test"}
+    ]
+    create = client.post("/api/analysis/summary_detail/", json=create_json)
+    assert create.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client, db, key, value):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+
+    # Create the object
+    create = client.post(
+        "/api/analysis/summary_detail/",
+        json=[
+            {
+                "analysis_uuid": str(submission.root_analysis_uuid),
+                "content": "test",
+                "format": "PRE",
+                "header": "test",
+                key: value,
+            }
+        ],
+    )
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client, db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+
+    # Create the object
+    create = client.post(
+        "/api/analysis/summary_detail/",
+        json=[
+            {"analysis_uuid": str(submission.root_analysis_uuid), "content": "test", "format": "PRE", "header": "test"}
+        ],
+    )
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()["content"] == "test"

--- a/db_api/app/tests/api_tests/analysis_summary_detail/test_delete.py
+++ b/db_api/app/tests/api_tests/analysis_summary_detail/test_delete.py
@@ -1,0 +1,41 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client):
+    delete = client.delete("/api/analysis/summary_detail/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client):
+    delete = client.delete(f"/api/analysis/summary_detail/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete(client, db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+
+    # Create the object
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", format="PRE", db=db
+    )
+    assert len(submission.root_analysis.summary_details) == 1
+
+    # Delete it
+    delete = client.delete(f"/api/analysis/summary_detail/{obj.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT
+    assert len(submission.root_analysis.summary_details) == 0

--- a/db_api/app/tests/api_tests/analysis_summary_detail/test_read.py
+++ b/db_api/app/tests/api_tests/analysis_summary_detail/test_read.py
@@ -1,0 +1,36 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client):
+    get = client.get("/api/analysis/summary_detail/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client):
+    get = client.get(f"/api/analysis/summary_detail/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get(client, db):
+    submission = factory.submission.create(db=db)
+    summary_detail = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+
+    get = client.get(f"/api/analysis/summary_detail/{summary_detail.uuid}")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["uuid"] == str(summary_detail.uuid)

--- a/db_api/app/tests/api_tests/analysis_summary_detail/test_update.py
+++ b/db_api/app/tests/api_tests/analysis_summary_detail/test_update.py
@@ -1,0 +1,116 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("content", 123),
+        ("content", None),
+        ("content", ""),
+        ("format", 123),
+        ("format", None),
+        ("format", ""),
+        ("header", 123),
+        ("header", None),
+        ("header", ""),
+    ],
+)
+def test_update_invalid_fields(client, key, value):
+    update = client.patch(f"/api/analysis/summary_detail/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_invalid_uuid(client):
+    update = client.patch("/api/analysis/summary_detail/1", json={"content": "test"})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_duplicate_unique_fields(client, db):
+    submission = factory.submission.create(db=db)
+
+    # Create some objects
+    obj1 = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test1", content="test1", db=db
+    )
+    obj2 = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test2", content="test2", db=db
+    )
+
+    # Ensure you cannot update a unique field to a value that already exists
+    update = client.patch(f"/api/analysis/summary_detail/{obj2.uuid}", json={"header": "test1", "content": "test1"})
+    assert update.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_nonexistent_format(client, db):
+    submission = factory.submission.create(db=db)
+
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test1", content="test1", format="PRE", db=db
+    )
+
+    update = client.patch(f"/api/analysis/summary_detail/{obj.uuid}", json={"format": "TEXT"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_nonexistent_uuid(client):
+    update = client.patch(f"/api/analysis/summary_detail/{uuid.uuid4()}", json={"content": "test"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,initial_value,updated_value",
+    [
+        ("content", "test", "test2"),
+        ("content", "test", "test"),
+        ("header", "test", "test2"),
+        ("header", "test", "test"),
+    ],
+)
+def test_update(client, db, key, initial_value, updated_value):
+    submission = factory.submission.create(db=db)
+
+    # Create the object
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+
+    # Set the initial value
+    setattr(obj, key, initial_value)
+
+    # Update it
+    update = client.patch(f"/api/analysis/summary_detail/{obj.uuid}", json={key: updated_value})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert getattr(obj, key) == updated_value
+
+
+def test_update_format(client, db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+    factory.format.create_or_read(value="TEXT", db=db)
+
+    # Create the object
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", format="PRE", db=db
+    )
+    assert obj.format.value == "PRE"
+
+    # Update it
+    update = client.patch(f"/api/analysis/summary_detail/{obj.uuid}", json={"format": "TEXT"})
+    print(update.text)
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert obj.format.value == "TEXT"

--- a/db_api/app/tests/api_tests/format/test_create.py
+++ b/db_api/app/tests/api_tests/format/test_create.py
@@ -1,0 +1,71 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("uuid", None),
+        ("uuid", 1),
+        ("uuid", "abc"),
+        ("uuid", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_create_invalid_fields(client, key, value):
+    create_json = {"value": "test", key: value}
+    create = client.post("/api/format/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_create_missing_required_fields(client, key):
+    create_json = {"value": "test"}
+    del create_json[key]
+    create = client.post("/api/format/", json=create_json)
+    assert create.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [("description", None), ("description", "test"), ("uuid", str(uuid.uuid4()))],
+)
+def test_create_valid_optional_fields(client, key, value):
+    # Create the object
+    create = client.post("/api/format/", json={key: value, "value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()[key] == value
+
+
+def test_create_valid_required_fields(client):
+    # Create the object
+    create = client.post("/api/format/", json={"value": "test"})
+    assert create.status_code == status.HTTP_201_CREATED
+
+    # Read it back
+    get = client.get(create.headers["Content-Location"])
+    assert get.json()["value"] == "test"

--- a/db_api/app/tests/api_tests/format/test_delete.py
+++ b/db_api/app/tests/api_tests/format/test_delete.py
@@ -1,0 +1,49 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_delete_invalid_uuid(client):
+    delete = client.delete("/api/format/1")
+    assert delete.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_delete_nonexistent_uuid(client):
+    delete = client.delete(f"/api/format/{uuid.uuid4()}")
+    assert delete.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_delete_used(client, db):
+    # Create an object
+    obj = factory.format.create_or_read(value="PRE", db=db)
+
+    # Assign it to another object
+    alert = factory.submission.create(db=db)
+    factory.analysis_summary_detail.create_or_read(
+        analysis=alert.root_analysis, header="test", content="test", format="PRE", db=db
+    )
+
+    # Ensure you cannot delete it now that it is in use
+    delete = client.delete(f"/api/format/{obj.uuid}")
+    assert delete.status_code == status.HTTP_400_BAD_REQUEST
+
+
+#
+# VALID TESTS
+#
+
+
+def test_delete(client, db):
+    # Create the object
+    obj = factory.format.create_or_read(value="test", db=db)
+
+    # Delete it
+    delete = client.delete(f"/api/format/{obj.uuid}")
+    assert delete.status_code == status.HTTP_204_NO_CONTENT

--- a/db_api/app/tests/api_tests/format/test_read.py
+++ b/db_api/app/tests/api_tests/format/test_read.py
@@ -1,0 +1,42 @@
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_get_invalid_uuid(client):
+    get = client.get("/api/format/1")
+    assert get.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_get_nonexistent_uuid(client):
+    get = client.get(f"/api/format/{uuid.uuid4()}")
+    assert get.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+def test_get_all(client, db):
+    # Create some objects
+    factory.format.create_or_read(value="test", db=db)
+    factory.format.create_or_read(value="test2", db=db)
+
+    # Read them back
+    get = client.get("/api/format/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 2
+
+
+def test_get_all_empty(client):
+    get = client.get("/api/format/")
+    assert get.status_code == status.HTTP_200_OK
+    assert get.json()["total"] == 0

--- a/db_api/app/tests/api_tests/format/test_update.py
+++ b/db_api/app/tests/api_tests/format/test_update.py
@@ -1,0 +1,79 @@
+import pytest
+import uuid
+
+from fastapi import status
+
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("description", 123),
+        ("description", ""),
+        ("value", 123),
+        ("value", None),
+        ("value", ""),
+    ],
+)
+def test_update_invalid_fields(client, key, value):
+    update = client.patch(f"/api/format/{uuid.uuid4()}", json={key: value})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_invalid_uuid(client):
+    update = client.patch("/api/format/1", json={"value": "test"})
+    assert update.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        ("value"),
+    ],
+)
+def test_update_duplicate_unique_fields(client, db, key):
+    # Create some objects
+    obj1 = factory.format.create_or_read(value="test", db=db)
+    obj2 = factory.format.create_or_read(value="test2", db=db)
+
+    # Ensure you cannot update a unique field to a value that already exists
+    update = client.patch(f"/api/format/{obj2.uuid}", json={key: getattr(obj1, key)})
+    assert update.status_code == status.HTTP_400_BAD_REQUEST
+
+
+def test_update_nonexistent_uuid(client):
+    update = client.patch(f"/api/format/{uuid.uuid4()}", json={"value": "test"})
+    assert update.status_code == status.HTTP_404_NOT_FOUND
+
+
+#
+# VALID TESTS
+#
+
+
+@pytest.mark.parametrize(
+    "key,initial_value,updated_value",
+    [
+        ("description", None, "test"),
+        ("description", "test", "test"),
+        ("value", "test", "test2"),
+        ("value", "test", "test"),
+    ],
+)
+def test_update(client, db, key, initial_value, updated_value):
+    # Create the object
+    obj = factory.format.create_or_read(value="test", db=db)
+
+    # Set the initial value
+    setattr(obj, key, initial_value)
+
+    # Update it
+    update = client.patch(f"/api/format/{obj.uuid}", json={key: updated_value})
+    assert update.status_code == status.HTTP_204_NO_CONTENT
+    assert getattr(obj, key) == updated_value

--- a/db_api/app/tests/db_tests/crud/analysis/test_create.py
+++ b/db_api/app/tests/db_tests/crud/analysis/test_create.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from uuid import uuid4
 
 from api_models.analysis import AnalysisCreate
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreateInAnalysis
 from db import crud
 from exceptions.db import UuidNotFoundInDatabase
 from tests import factory
@@ -74,6 +75,7 @@ def test_create(db):
         type="test", value="test", parent_analysis=submission.root_analysis, db=db
     )
     analysis_module_type = factory.analysis_module_type.create_or_read(value="test", cache_seconds=90, db=db)
+    factory.format.create_or_read(value="PRE", db=db)
     factory.observable_type.create_or_read(value="ipv4", db=db)
 
     # Create the analysis
@@ -88,6 +90,7 @@ def test_create(db):
             stack_trace="test stack trace",
             submission_uuid=submission.uuid,
             summary="test summary",
+            summary_details=[AnalysisSummaryDetailCreateInAnalysis(content="test", header="test", format="PRE")],
             target_uuid=observable.uuid,
         ),
         db=db,
@@ -101,6 +104,7 @@ def test_create(db):
     assert analysis.run_time == now
     assert analysis.stack_trace == "test stack trace"
     assert analysis.summary == "test summary"
+    assert len(analysis.summary_details) == 1
     assert analysis.target == observable
 
 

--- a/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_create.py
+++ b/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_create.py
@@ -1,0 +1,51 @@
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreate
+from db import crud
+from tests import factory
+
+
+def test_create(db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+
+    obj = crud.analysis_summary_detail.create_or_read(
+        model=AnalysisSummaryDetailCreate(
+            analysis_uuid=submission.root_analysis_uuid,
+            content="test",
+            format="PRE",
+            header="test",
+        ),
+        db=db,
+    )
+
+    assert obj.analysis_uuid == submission.root_analysis_uuid
+    assert obj.content == "test"
+    assert obj.format.value == "PRE"
+    assert obj.header == "test"
+
+
+def test_create_duplicate_value(db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+
+    obj1 = crud.analysis_summary_detail.create_or_read(
+        model=AnalysisSummaryDetailCreate(
+            analysis_uuid=submission.root_analysis_uuid,
+            content="test",
+            format="PRE",
+            header="test",
+        ),
+        db=db,
+    )
+    assert obj1
+
+    # Ensure that you get the same object back if you try to create a duplicate value
+    obj2 = crud.analysis_summary_detail.create_or_read(
+        model=AnalysisSummaryDetailCreate(
+            analysis_uuid=obj1.analysis_uuid,
+            content=obj1.content,
+            format="PRE",
+            header=obj1.header,
+        ),
+        db=db,
+    )
+    assert obj2.uuid == obj1.uuid

--- a/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_create.py
+++ b/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_create.py
@@ -41,7 +41,7 @@ def test_create_duplicate_value(db):
     # Ensure that you get the same object back if you try to create a duplicate value
     obj2 = crud.analysis_summary_detail.create_or_read(
         model=AnalysisSummaryDetailCreate(
-            analysis_uuid=obj1.analysis_uuid,
+            analysis_uuid=submission.root_analysis_uuid,
             content=obj1.content,
             format="PRE",
             header=obj1.header,

--- a/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_delete.py
+++ b/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_delete.py
@@ -1,0 +1,11 @@
+from db import crud
+from tests import factory
+
+
+def test_delete(db):
+    submission = factory.submission.create(db=db)
+
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+    assert crud.analysis_summary_detail.delete(uuid=obj.uuid, db=db) is True

--- a/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_read.py
+++ b/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_read.py
@@ -1,0 +1,52 @@
+import pytest
+
+from db import crud
+from exceptions.db import ValueNotFoundInDatabase
+from tests import factory
+
+
+#
+# INVALID TESTS
+#
+
+
+def test_read_nonexistent(db):
+    submission = factory.submission.create(db=db)
+
+    factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+
+    with pytest.raises(ValueNotFoundInDatabase):
+        crud.analysis_summary_detail.read_by_analysis_header_content(
+            analysis_uuid=submission.root_analysis_uuid, header="test2", content="test2", db=db
+        )
+
+
+#
+# VALID TESTS
+#
+
+
+def test_read_by_uuid(db):
+    submission = factory.submission.create(db=db)
+
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+
+    result = crud.analysis_summary_detail.read_by_uuid(uuid=obj.uuid, db=db)
+    assert result.uuid == obj.uuid
+
+
+def test_read_by_value(db):
+    submission = factory.submission.create(db=db)
+
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", db=db
+    )
+
+    result = crud.analysis_summary_detail.read_by_analysis_header_content(
+        analysis_uuid=submission.root_analysis_uuid, header="test", content="test", db=db
+    )
+    assert result.uuid == obj.uuid

--- a/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_update.py
+++ b/db_api/app/tests/db_tests/crud/analysis_summary_detail/test_update.py
@@ -1,0 +1,43 @@
+from api_models.analysis_summary_detail import AnalysisSummaryDetailUpdate
+from db import crud
+from tests import factory
+
+
+def test_update(db):
+    submission = factory.submission.create(db=db)
+    factory.format.create_or_read(value="PRE", db=db)
+    factory.format.create_or_read(value="TEXT", db=db)
+
+    obj = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", format="PRE", db=db
+    )
+
+    assert obj.content == "test"
+    assert obj.header == "test"
+    assert obj.format.value == "PRE"
+
+    crud.analysis_summary_detail.update(
+        uuid=obj.uuid,
+        model=AnalysisSummaryDetailUpdate(content="new content", header="new header", format="TEXT"),
+        db=db,
+    )
+
+    assert obj.content == "new content"
+    assert obj.header == "new header"
+    assert obj.format.value == "TEXT"
+
+
+def test_update_duplicate(db):
+    submission = factory.submission.create(db=db)
+
+    obj1 = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, content="test1", header="test1", db=db
+    )
+    obj2 = factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, content="test2", header="test2", db=db
+    )
+
+    result = crud.analysis_summary_detail.update(
+        uuid=obj2.uuid, model=AnalysisSummaryDetailUpdate(content="test1", header="test1"), db=db
+    )
+    assert result is False

--- a/db_api/app/tests/db_tests/crud/format/test_create.py
+++ b/db_api/app/tests/db_tests/crud/format/test_create.py
@@ -1,0 +1,20 @@
+from api_models.format import FormatCreate
+from db import crud
+
+
+def test_create(db):
+    obj = crud.format.create_or_read(model=FormatCreate(description="test description", value="test value"), db=db)
+
+    assert obj.description == "test description"
+    assert obj.value == "test value"
+
+
+def test_create_duplicate_value(db):
+    obj1 = crud.format.create_or_read(model=FormatCreate(value="test"), db=db)
+    assert obj1
+
+    # Ensure that you get the same object back if you try to create a duplicate value
+    obj2 = crud.format.create_or_read(model=FormatCreate(value=obj1.value), db=db)
+    assert obj2.description == obj1.description
+    assert obj2.uuid == obj1.uuid
+    assert obj2.value == obj1.value

--- a/db_api/app/tests/db_tests/crud/format/test_delete.py
+++ b/db_api/app/tests/db_tests/crud/format/test_delete.py
@@ -1,0 +1,19 @@
+from db import crud
+from tests import factory
+
+
+def test_delete(db):
+    obj = factory.format.create_or_read(value="test", db=db)
+    assert crud.format.delete(uuid=obj.uuid, db=db) is True
+
+
+def test_unable_to_delete(db):
+    obj = factory.format.create_or_read(value="PRE", db=db)
+
+    submission = factory.submission.create(db=db)
+    factory.analysis_summary_detail.create_or_read(
+        analysis=submission.root_analysis, header="test", content="test", format="PRE", db=db
+    )
+
+    # You should not be able to delete it now that it is in use
+    assert crud.format.delete(uuid=obj.uuid, db=db) is False

--- a/db_api/app/tests/db_tests/crud/format/test_read.py
+++ b/db_api/app/tests/db_tests/crud/format/test_read.py
@@ -1,0 +1,26 @@
+from db import crud
+from tests import factory
+
+
+def test_read_all(db):
+    obj1 = factory.format.create_or_read(value="test", db=db)
+    obj2 = factory.format.create_or_read(value="test2", db=db)
+
+    result = crud.format.read_all(db=db)
+    assert len(result) == 2
+    assert result[0].uuid == obj1.uuid
+    assert result[1].uuid == obj2.uuid
+
+
+def test_read_by_uuid(db):
+    obj = factory.format.create_or_read(value="test", db=db)
+
+    result = crud.format.read_by_uuid(uuid=obj.uuid, db=db)
+    assert result.uuid == obj.uuid
+
+
+def test_read_by_value(db):
+    obj = factory.format.create_or_read(value="test", db=db)
+
+    result = crud.format.read_by_value(value=obj.value, db=db)
+    assert result.uuid == obj.uuid

--- a/db_api/app/tests/db_tests/crud/format/test_update.py
+++ b/db_api/app/tests/db_tests/crud/format/test_update.py
@@ -1,0 +1,27 @@
+from api_models.format import FormatUpdate
+from db import crud
+from tests import factory
+
+
+def test_update(db):
+    obj = factory.format.create_or_read(value="test", db=db)
+
+    assert obj.description is None
+    assert obj.value == "test"
+
+    crud.format.update(
+        uuid=obj.uuid,
+        model=FormatUpdate(description="test description", value="new value"),
+        db=db,
+    )
+
+    assert obj.description == "test description"
+    assert obj.value == "new value"
+
+
+def test_update_duplicate_value(db):
+    obj1 = factory.format.create_or_read(value="test", db=db)
+    obj2 = factory.format.create_or_read(value="test2", db=db)
+
+    result = crud.format.update(uuid=obj2.uuid, model=FormatUpdate(value=obj1.value), db=db)
+    assert result is False

--- a/db_api/app/tests/factory/__init__.py
+++ b/db_api/app/tests/factory/__init__.py
@@ -1,6 +1,7 @@
 from tests.factory import alert_disposition
 from tests.factory import analysis
 from tests.factory import analysis_module_type
+from tests.factory import analysis_summary_detail
 from tests.factory import event
 from tests.factory import event_comment
 from tests.factory import event_prevention_tool
@@ -10,6 +11,7 @@ from tests.factory import event_source
 from tests.factory import event_status
 from tests.factory import event_type
 from tests.factory import event_vector
+from tests.factory import format
 from tests.factory import metadata_detection_point
 from tests.factory import metadata_directive
 from tests.factory import metadata_display_type

--- a/db_api/app/tests/factory/analysis_summary_detail.py
+++ b/db_api/app/tests/factory/analysis_summary_detail.py
@@ -1,0 +1,24 @@
+from sqlalchemy.orm import Session
+
+from api_models.analysis_summary_detail import AnalysisSummaryDetailCreate
+from db import crud
+from db.schemas.analysis import Analysis
+from tests import factory
+
+
+def create_or_read(
+    analysis: Analysis,
+    header: str,
+    content: str,
+    db: Session,
+    format: str = "PRE",
+):
+    factory.format.create_or_read(value=format, db=db)
+
+    obj = crud.analysis_summary_detail.create_or_read(
+        model=AnalysisSummaryDetailCreate(analysis_uuid=analysis.uuid, content=content, header=header, format=format),
+        db=db,
+    )
+
+    db.commit()
+    return obj

--- a/db_api/app/tests/factory/format.py
+++ b/db_api/app/tests/factory/format.py
@@ -1,0 +1,8 @@
+from sqlalchemy.orm import Session
+
+from api_models.format import FormatCreate
+from db import crud
+
+
+def create_or_read(value: str, db: Session):
+    return crud.format.create_or_read(model=FormatCreate(value=value), db=db)

--- a/frontend/src/models/analysis.ts
+++ b/frontend/src/models/analysis.ts
@@ -3,6 +3,7 @@ import {
   analysisModuleTypeAlertTreeRead,
   analysisModuleTypeRead,
 } from "./analysisModuleType";
+import { analysisSummaryDetailRead } from "./analysisSummaryDetail";
 import { observableRead, observableTreeRead } from "./observable";
 
 export interface analysisRead {
@@ -15,6 +16,7 @@ export interface analysisRead {
   runTime: string;
   stackTrace: string | null;
   summary: string | null;
+  summaryDetails: analysisSummaryDetailRead[];
   uuid: UUID;
 }
 
@@ -27,6 +29,7 @@ export interface analysisTreeRead {
   objectType: string;
   stackTrace: string | null;
   summary: string | null;
+  summaryDetails: analysisSummaryDetailRead[];
   uuid: UUID;
 }
 

--- a/frontend/src/models/analysisSummaryDetail.ts
+++ b/frontend/src/models/analysisSummaryDetail.ts
@@ -1,0 +1,9 @@
+import { UUID } from "./base";
+import { formatRead } from "./format";
+
+export interface analysisSummaryDetailRead {
+  content: string;
+  format: formatRead;
+  header: string;
+  uuid: UUID;
+}

--- a/frontend/src/models/format.ts
+++ b/frontend/src/models/format.ts
@@ -1,0 +1,16 @@
+import {
+  genericObjectCreate,
+  genericObjectRead,
+  genericObjectReadPage,
+  genericObjectUpdate,
+} from "./base";
+
+export type formatCreate = genericObjectCreate;
+
+export type formatRead = genericObjectRead;
+
+export interface formatReadPage extends genericObjectReadPage {
+  items: formatRead[];
+}
+
+export type formatUpdate = genericObjectUpdate;

--- a/frontend/tests/mocks/analysis.ts
+++ b/frontend/tests/mocks/analysis.ts
@@ -40,6 +40,7 @@ export const analysisReadFactory = ({
   runTime = "2020-01-01T00:00:00.000000+00:00",
   stackTrace = null,
   summary = null,
+  summaryDetails = [],
   objectType = "analysis",
   uuid = "uuid2",
 }: Partial<analysisRead> = {}): analysisRead => ({
@@ -51,6 +52,7 @@ export const analysisReadFactory = ({
   runTime: runTime,
   stackTrace: stackTrace,
   summary: summary,
+  summaryDetails: summaryDetails,
   objectType: objectType,
   uuid: uuid,
 });
@@ -70,6 +72,7 @@ export const analysisTreeReadFactory = ({
   firstAppearance = undefined,
   stackTrace = null,
   summary = null,
+  summaryDetails = [],
   uuid = "testUuid",
 }: Partial<analysisTreeRead> = {}): analysisTreeRead => ({
   analysisModuleType: analysisModuleType,
@@ -79,12 +82,14 @@ export const analysisTreeReadFactory = ({
   objectType: "analysis",
   stackTrace: stackTrace,
   summary: summary,
+  summaryDetails: summaryDetails,
   uuid: uuid,
 });
 
 export const rootAnalysisTreeReadFactory = ({
   children = [],
   details = null,
+  summaryDetails = [],
   uuid = "testUuid",
 }: Partial<rootAnalysisTreeRead> = {}): rootAnalysisTreeRead => ({
   analysisModuleType: null,
@@ -94,5 +99,6 @@ export const rootAnalysisTreeReadFactory = ({
   objectType: "analysis",
   stackTrace: null,
   summary: null,
+  summaryDetails: summaryDetails,
   uuid: uuid,
 });


### PR DESCRIPTION
This PR adds the analysis summary details functionality to the backend that exists in 1.0. Certain types of alerts and analysis modules in 1.0 add summary details, which are then displayed in the GUI inside of the alert tree to add short, contextual information for analysts without them needing to open up the full analysis details.

An upcoming PR will update the 2.0 GUI to actually display the summary details.