### PR TITLE
clear the proxy settings after build is complete

### DIFF
--- a/db_api/Dockerfile
+++ b/db_api/Dockerfile
@@ -6,11 +6,22 @@ ARG no_proxy
 ARG pip_install_options
 
 ENV http_proxy=$http_proxy
+ENV HTTP_PROXY=$http_proxy
 ENV https_proxy=$https_proxy
+ENV HTTPS_PROXY=$https_proxy
 ENV no_proxy=$no_proxy
+ENV NO_PROXY=$no_proxy
 
 COPY db_api/requirements.txt .
 RUN pip install -r requirements.txt ${pip_install_options}
+
+# clear proxy settings after we're done using them
+ENV http_proxy=
+ENV HTTP_PROXY=
+ENV https_proxy=
+ENV HTTPS_PROXY=
+ENV no_proxy=
+ENV NO_PROXY=
 
 COPY db_api/app/ /app
 COPY api_models/ /app/api_models

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,8 +7,11 @@ ARG no_proxy
 ARG npm_strict_ssl=true
 
 ENV http_proxy=$http_proxy
+ENV HTTP_PROXY=$http_proxy
 ENV https_proxy=$https_proxy
+ENV HTTPS_PROXY=$https_proxy
 ENV no_proxy=$no_proxy
+ENV NO_PROXY=$no_proxy
 
 WORKDIR /app
 
@@ -21,6 +24,14 @@ RUN npm config set strict-ssl ${npm_strict_ssl} && \
   npm install node-gyp -g && \
   npm install && \
   apk del native-deps
+
+# clear proxy settings after we're done using them
+ENV http_proxy=
+ENV HTTP_PROXY=
+ENV https_proxy=
+ENV HTTPS_PROXY=
+ENV no_proxy=
+ENV NO_PROXY=
 
 COPY . .
 

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -6,8 +6,11 @@ ARG no_proxy
 ARG npm_strict_ssl=true
 
 ENV http_proxy=$http_proxy
+ENV HTTP_PROXY=$http_proxy
 ENV https_proxy=$https_proxy
+ENV HTTPS_PROXY=$https_proxy
 ENV no_proxy=$no_proxy
+ENV NO_PROXY=$no_proxy
 
 RUN apt-get install -y curl
 
@@ -16,6 +19,14 @@ WORKDIR /app
 COPY package*.json ./
 
 RUN npm config set strict-ssl ${npm_strict_ssl} && npm install 
+
+# clear proxy settings after we're done using them
+ENV http_proxy=
+ENV HTTP_PROXY=
+ENV https_proxy=
+ENV HTTPS_PROXY=
+ENV no_proxy=
+ENV NO_PROXY=
 
 COPY . .
 

--- a/gui_api/Dockerfile
+++ b/gui_api/Dockerfile
@@ -6,11 +6,22 @@ ARG no_proxy
 ARG pip_install_options
 
 ENV http_proxy=$http_proxy
+ENV HTTP_PROXY=$http_proxy
 ENV https_proxy=$https_proxy
+ENV HTTPS_PROXY=$https_proxy
 ENV no_proxy=$no_proxy
+ENV NO_PROXY=$no_proxy
 
 COPY gui_api/requirements.txt .
 RUN pip install -r requirements.txt ${pip_install_options}
+
+# clear proxy settings after we're done using them
+ENV http_proxy=
+ENV HTTP_PROXY=
+ENV https_proxy=
+ENV HTTPS_PROXY=
+ENV no_proxy=
+ENV NO_PROXY=
 
 COPY gui_api/app/ /app
 COPY api_models/ /app/api_models


### PR DESCRIPTION
I forgot that those ENV variables persist in the image. This messed up access between containers since it was still trying to use the proxy. So the solution is to clear those ENV variables after we're done with them.

Couple of notes:

- I don't see a way to actually delete an ENV variable, but just setting to blank seems to work.
- Looks like ENV is the only way to have the apk command use a proxy.