### PR TITLE
Removes chmod 777 hack

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,15 +174,6 @@ jobs:
       - name: Run environment
         run: docker compose -f docker-compose-ci.yml up -d
 
-      - name: whoami
-        run: whoami
-
-      - name: Container whoami
-        run: docker exec ace2-ams-gui whoami
-
-      - name: Permissions?
-        run: docker exec ace2-ams-gui ls -lah /app
-
       - name: Wait for the environment to be accessible
         run: docker exec ace2-ams-gui bin/wait-for-gui.sh
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,11 +174,17 @@ jobs:
       - name: Run environment
         run: docker compose -f docker-compose.yml up -d
 
-      - name: Wait for the environment to be accessible
-        run: docker exec ace2-ams-gui bin/wait-for-gui.sh
+      - name: whoami
+        run: whoami
+
+      - name: Container whoami
+        run: docker exec ace2-ams-gui whoami
 
       - name: Permissions?
         run: docker exec ace2-ams-gui ls -lah /app
+
+      - name: Wait for the environment to be accessible
+        run: docker exec ace2-ams-gui bin/wait-for-gui.sh
 
       - name: Component Tests
         run: docker exec -e TZ=America/New_York -e CYPRESS_COVERAGE=true ace2-ams-gui xvfb-run cypress run --component --headless --browser chrome --config-file "cypress.config.ts" --config video=false,screenshotOnRunFailure=false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,6 +177,9 @@ jobs:
       - name: Wait for the environment to be accessible
         run: docker exec ace2-ams-gui bin/wait-for-gui.sh
 
+      - name: Permissions?
+        run: docker exec ace2-ams-gui ls -lah /app
+
       - name: Component Tests
         run: docker exec -e TZ=America/New_York -e CYPRESS_COVERAGE=true ace2-ams-gui xvfb-run cypress run --component --headless --browser chrome --config-file "cypress.config.ts" --config video=false,screenshotOnRunFailure=false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,6 @@ jobs:
 
     env:
       ACE_DEV: true
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
       POSTGRES_DB: ace
       POSTGRES_USER: ace
       POSTGRES_PASSWORD: supersecret
@@ -41,8 +39,6 @@ jobs:
 
     env:
       ACE_DEV: true
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
       COOKIES_SAMESITE: lax
       COOKIES_SECURE: False
       JWT_ACCESS_EXPIRE_SECONDS: 900
@@ -107,8 +103,6 @@ jobs:
 
     env:
       ACE_DEV: true
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
       COOKIES_SAMESITE: lax
       COOKIES_SECURE: False
       JWT_ACCESS_EXPIRE_SECONDS: 900
@@ -157,8 +151,6 @@ jobs:
 
     env:
       ACE_DEV: true
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
       COOKIES_SAMESITE: lax
       COOKIES_SECURE: False
       JWT_ACCESS_EXPIRE_SECONDS: 900
@@ -194,10 +186,6 @@ jobs:
   production-build:
     name: Production Build
     runs-on: ubuntu-latest
-
-    env:
-      DOCKER_BUILDKIT: 0
-      COMPOSE_DOCKER_CLI_BUILD: 0
 
     steps:
       - name: Checkout code

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,7 +122,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run environment
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose-ci.yml up -d
 
       - name: Wait for the environment to be accessible
         run: docker exec ace2-ams-gui bin/wait-for-gui.sh
@@ -172,7 +172,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run environment
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f docker-compose-ci.yml up -d
 
       - name: whoami
         run: whoami

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,96 @@
+version: "3.9"
+
+services:
+  db:
+    container_name: ace2-ams-db
+    build:
+      context: ./db_container
+      dockerfile: ./Dockerfile
+    environment:
+      - POSTGRES_DB=${POSTGRES_DB}
+      - POSTGRES_USER=${POSTGRES_USER}
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    ports:
+      - 6666:5432
+
+  db-api:
+    depends_on:
+      - db
+    container_name: ace2-ams-db-api
+    build:
+      context: ./
+      dockerfile: ./db_api/Dockerfile
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy:-}
+        https_proxy: ${https_proxy:-}
+        pip_install_options: ${pip_install_options:-}
+    environment:
+      # The DATABASE_URL environment variable needs to be in the form of:
+      # postgresql://<user>:<password>@db:5432/<database>
+      - ACE_DEV=${ACE_DEV}
+      - DATABASE_URL=${DATABASE_URL}
+      - DATABASE_TEST_URL=${DATABASE_TEST_URL}
+      - LOG_LEVEL=debug
+      - SQL_ECHO=${SQL_ECHO}
+      - TESTING=${TESTING:-no}
+    ports:
+      - 8888:80
+    command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; /start-reload.sh'
+
+  gui-api:
+    depends_on:
+      - db-api
+    container_name: ace2-ams-gui-api
+    build:
+      context: ./
+      dockerfile: ./gui_api/Dockerfile
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy:-}
+        https_proxy: ${https_proxy:-}
+        pip_install_options: ${pip_install_options:-}
+    environment:
+      # The DATABASE_URL environment variable needs to be in the form of:
+      # postgresql://<user>:<password>@db:5432/<database>
+      - COOKIES_SAMESITE=${COOKIES_SAMESITE}
+      - COOKIES_SECURE=${COOKIES_SECURE}
+      - DATABASE_API_URL=${DATABASE_API_URL}
+      - JWT_ACCESS_EXPIRE_SECONDS=${JWT_ACCESS_EXPIRE_SECONDS}
+      - JWT_ALGORITHM=${JWT_ALGORITHM}
+      - JWT_REFRESH_EXPIRE_SECONDS=${JWT_REFRESH_EXPIRE_SECONDS}
+      - JWT_SECRET=${JWT_SECRET}
+      - LOG_LEVEL=debug
+      - SQL_ECHO=${SQL_ECHO}
+    ports:
+      - 7777:80
+    command: bash -c 'while !</dev/tcp/db-api/80; do sleep 1; done; /start-reload.sh'
+
+  gui:
+    depends_on:
+      - gui-api
+    container_name: ace2-ams-gui
+    build:
+      context: ./frontend
+      dockerfile: ./Dockerfile.dev
+      args:
+        # needed if behind a proxy for pip installation
+        http_proxy: ${http_proxy:-}
+        https_proxy: ${https_proxy:-}
+        pip_install_options: ${pip_install_options:-}
+        npm_strict_ssl: ${npm_strict_ssl:-true}
+    environment:
+      - DATABASE_TEST_URL=${DATABASE_TEST_URL}
+      - VITE_BACKEND_URL=http://ace2-ams:8080/api/
+      - VITE_TESTING_MODE=${TESTING:-no}
+      - CYPRESS_COVERAGE=${CYPRESS_COVERAGE:-false}
+
+  ace2-ams:
+    depends_on:
+      - gui
+    container_name: ace2-ams
+    build:
+      context: ./nginx
+      dockerfile: ./Dockerfile
+    ports:
+      - 8080:8080

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -14,8 +14,5 @@ RUN npm config set strict-ssl ${npm_strict_ssl} && http_proxy="$http_proxy" http
 
 COPY . .
 
-# Fixes the strange permission issues GitHub Actions was having.
-RUN chmod -R 777 /app
-
 # Override the entrypoint of the cypress/included image
 ENTRYPOINT ["bash", "-c", "while !</dev/tcp/gui-api/80; do sleep 1; done; npm run dev"]

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -12,7 +12,7 @@ COPY package*.json ./
 
 RUN npm config set strict-ssl ${npm_strict_ssl} && http_proxy="$http_proxy" https_proxy="$https_proxy" npm install 
 
-COPY . .
+COPY --chown=root:root . .
 
 # Override the entrypoint of the cypress/included image
 ENTRYPOINT ["bash", "-c", "while !</dev/tcp/gui-api/80; do sleep 1; done; npm run dev"]


### PR DESCRIPTION
This PR removes the hack of running `chmod -R 777 /app` in the frontend's Dockerfile. This was used to fix an obscure error code 137 (which is normally supposed to refer to out of memory) that GitHub Actions would throw.

It actually turned out to be a file permission error. Since we use volume mounts, when the containers get built, the files would be owned by the user on your host machine. In GitHub Actions, only the `node_modules` directory would be owned by root, and everything else was owned by uid 1001.

The fix was to use the `--chown` option on the Dockerfile's COPY command as well as to create a separate docker-compose file that does not use any volumes that GitHub Actions will use.

The side effect of this is that building/resetting the containers locally should be much faster since it's not running `chmod 777`.