### PR TITLE
Adds a fastapi_base build arg

### DIFF
--- a/db_api/test.sh
+++ b/db_api/test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Set up the variables
+FASTAPI_BASE=${FASTAPI_BASE:-tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim}
 DB=${POSTGRES_DB:-ace}
 USER=${POSTGRES_USER:-ace}
 PASS=${POSTGRES_PASSWORD:-password}
@@ -32,7 +33,7 @@ docker run -d --net ace2-db-net --name ace2-db -e POSTGRES_DB=$DB -e POSTGRES_US
 # Build and run a temporary Python container to run the tests in
 echo "Creating temporary Python container"
 cd ..
-docker build -t ace2-db-api -f db_api/Dockerfile .
+docker build --build-arg fastapi_base=$FASTAPI_BASE -t ace2-db-api -f db_api/Dockerfile .
 docker run -d --net ace2-db-net --name ace2-db-api -e DATABASE_URL=$DATABASE_URL ace2-db-api > /dev/null
 
 # Run the tests inside the Python container and capture its return code

--- a/frontend/test-components.sh
+++ b/frontend/test-components.sh
@@ -3,9 +3,12 @@
 # Exit if any command fails
 set -e
 
+# Set up the variables
 COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.yml}
+FASTAPI_BASE=${FASTAPI_BASE:-tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim}
 
-# Bring up the containers (if they aren't already)
+# Bring up the containers
+docker compose -f $COMPOSE_FILE build --build-arg fastapi_base=$FASTAPI_BASE
 docker compose -f $COMPOSE_FILE up -d
 
 # Run Cypress

--- a/frontend/test-e2e.sh
+++ b/frontend/test-e2e.sh
@@ -3,9 +3,12 @@
 # Exit if any command fails
 set -e
 
+# Set up the variables
 COMPOSE_FILE=${COMPOSE_FILE:-docker-compose.yml}
+FASTAPI_BASE=${FASTAPI_BASE:-tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim}
 
-# Bring up the containers in TESTING mode so Vite loads the testing config
+# Bring up the containers
+docker compose -f $COMPOSE_FILE build --build-arg fastapi_base=$FASTAPI_BASE
 docker compose -f $COMPOSE_FILE up -d
 
 # Wait for things to be ready

--- a/gui_api/test.sh
+++ b/gui_api/test.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+# Set up the variables
+FASTAPI_BASE=${FASTAPI_BASE:-tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim}
+
 # Remove the leading gui_api/ and app/ from the command line argument (if they are there) so the path works inside the container.
 NEW_PATH=${1#gui_api/}
 NEW_PATH=${NEW_PATH#app/}
@@ -14,7 +17,7 @@ set -e
 # Build and run a temporary Python container to run the tests in
 echo "Creating temporary Python container"
 cd ..
-docker build -t ace2-gui-api -f gui_api/Dockerfile .
+docker build --build-arg fastapi_base=$FASTAPI_BASE -t ace2-gui-api -f gui_api/Dockerfile .
 docker run -d --name ace2-gui-api -e DATABASE_API_URL=http://db-api/api -e COOKIES_SECURE=no ace2-gui-api > /dev/null
 
 # Run the tests inside the Python container and capture its return code


### PR DESCRIPTION
Allows you to specify a different location (such as AWS ECR) for the FastAPI Docker base image.